### PR TITLE
Port ProfileGateway and ActiveProfileGateway

### DIFF
--- a/packages/api/src/graphql/__mocks__/queries.ts
+++ b/packages/api/src/graphql/__mocks__/queries.ts
@@ -1,4 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing';
+import { EthereumAddress } from '@lens-protocol/shared-kernel';
 
 import {
   ProfileFieldsFragment,
@@ -8,6 +9,8 @@ import {
   GetProfileQuery,
   GetProfileDocument,
   SingleProfileQueryRequest,
+  GetAllProfilesByOwnerAddressQuery,
+  GetAllProfilesByOwnerAddressDocument,
 } from '../generated';
 import { mockProfileFieldsFragment } from './fragments';
 
@@ -26,7 +29,7 @@ export function mockProfilesToFollowQueryMockedResponse(args: {
   };
 }
 
-function mockGetProfileQuery(profile: Maybe<ProfileFieldsFragment>): GetProfileQuery {
+export function mockGetProfileQuery(profile: Maybe<ProfileFieldsFragment>): GetProfileQuery {
   return {
     result: profile,
   };
@@ -51,6 +54,37 @@ export function mockGetProfileQueryMockedResponse({
     },
     result: {
       data: mockGetProfileQuery(profile),
+    },
+  };
+}
+
+function mockGetAllProfilesByOwnerAddressQuery(
+  profiles: ProfileFieldsFragment[],
+): GetAllProfilesByOwnerAddressQuery {
+  return {
+    profilesByOwner: {
+      __typename: 'PaginatedProfileResult',
+      items: profiles,
+    },
+  };
+}
+
+export function mockGetAllProfilesByOwnerAddressQueryMockedResponse({
+  address,
+  profiles = [mockProfileFieldsFragment()],
+}: {
+  address: EthereumAddress;
+  profiles?: ProfileFieldsFragment[];
+}): MockedResponse<GetAllProfilesByOwnerAddressQuery> {
+  return {
+    request: {
+      query: GetAllProfilesByOwnerAddressDocument,
+      variables: {
+        address,
+      },
+    },
+    result: {
+      data: mockGetAllProfilesByOwnerAddressQuery(profiles),
     },
   };
 }

--- a/packages/api/src/graphql/generated.tsx
+++ b/packages/api/src/graphql/generated.tsx
@@ -4192,6 +4192,17 @@ export type GetProfileQueryVariables = Exact<{
 
 export type GetProfileQuery = { result: Maybe<{ __typename: 'Profile' } & ProfileFieldsFragment> };
 
+export type GetAllProfilesByOwnerAddressQueryVariables = Exact<{
+  address: Scalars['EthereumAddress'];
+  observerId?: Maybe<Scalars['ProfileId']>;
+}>;
+
+export type GetAllProfilesByOwnerAddressQuery = {
+  profilesByOwner: { __typename: 'PaginatedProfileResult' } & {
+    items: Array<{ __typename: 'Profile' } & ProfileFieldsFragment>;
+  };
+};
+
 export const PublicationStatsFragmentDoc = gql`
   fragment PublicationStats on PublicationStats {
     totalAmountOfMirrors
@@ -4802,6 +4813,68 @@ export function useGetProfileLazyQuery(
 export type GetProfileQueryHookResult = ReturnType<typeof useGetProfileQuery>;
 export type GetProfileLazyQueryHookResult = ReturnType<typeof useGetProfileLazyQuery>;
 export type GetProfileQueryResult = Apollo.QueryResult<GetProfileQuery, GetProfileQueryVariables>;
+export const GetAllProfilesByOwnerAddressDocument = gql`
+  query GetAllProfilesByOwnerAddress($address: EthereumAddress!, $observerId: ProfileId) {
+    profilesByOwner: profiles(request: { ownedBy: [$address] }) {
+      items {
+        ...ProfileFields
+      }
+    }
+  }
+  ${ProfileFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAllProfilesByOwnerAddressQuery__
+ *
+ * To run a query within a React component, call `useGetAllProfilesByOwnerAddressQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAllProfilesByOwnerAddressQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAllProfilesByOwnerAddressQuery({
+ *   variables: {
+ *      address: // value for 'address'
+ *      observerId: // value for 'observerId'
+ *   },
+ * });
+ */
+export function useGetAllProfilesByOwnerAddressQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetAllProfilesByOwnerAddressQuery,
+    GetAllProfilesByOwnerAddressQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetAllProfilesByOwnerAddressQuery,
+    GetAllProfilesByOwnerAddressQueryVariables
+  >(GetAllProfilesByOwnerAddressDocument, options);
+}
+export function useGetAllProfilesByOwnerAddressLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetAllProfilesByOwnerAddressQuery,
+    GetAllProfilesByOwnerAddressQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetAllProfilesByOwnerAddressQuery,
+    GetAllProfilesByOwnerAddressQueryVariables
+  >(GetAllProfilesByOwnerAddressDocument, options);
+}
+export type GetAllProfilesByOwnerAddressQueryHookResult = ReturnType<
+  typeof useGetAllProfilesByOwnerAddressQuery
+>;
+export type GetAllProfilesByOwnerAddressLazyQueryHookResult = ReturnType<
+  typeof useGetAllProfilesByOwnerAddressLazyQuery
+>;
+export type GetAllProfilesByOwnerAddressQueryResult = Apollo.QueryResult<
+  GetAllProfilesByOwnerAddressQuery,
+  GetAllProfilesByOwnerAddressQueryVariables
+>;
 export type AccessConditionOutputKeySpecifier = (
   | 'nft'
   | 'token'

--- a/packages/api/src/graphql/profile.graphql
+++ b/packages/api/src/graphql/profile.graphql
@@ -106,3 +106,11 @@ query GetProfile($request: SingleProfileQueryRequest!, $observerId: ProfileId) {
     ...ProfileFields
   }
 }
+
+query GetAllProfilesByOwnerAddress($address: EthereumAddress!, $observerId: ProfileId) {
+  profilesByOwner: profiles(request: { ownedBy: [$address] }) {
+    items {
+      ...ProfileFields
+    }
+  }
+}

--- a/packages/domain/src/use-cases/profile/ActiveProfile.ts
+++ b/packages/domain/src/use-cases/profile/ActiveProfile.ts
@@ -12,7 +12,6 @@ export interface IProfileGateway {
 export interface IActiveProfileGateway {
   setActiveProfile(profile: Profile): Promise<void>;
   getActiveProfile(): Promise<Profile | null>;
-  reset(): Promise<void>;
 }
 
 export class ActiveProfile {

--- a/packages/domain/src/use-cases/wallets/WalletLogout.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogout.ts
@@ -1,6 +1,6 @@
 import { assertNever } from '@lens-protocol/shared-kernel';
 
-import { IActiveProfilePresenter, IActiveProfileGateway } from '../profile';
+import { IActiveProfilePresenter } from '../profile';
 import { ActiveWallet } from './ActiveWallet';
 import { IActiveWalletPresenter } from './IActiveWalletPresenter';
 import { ILoginPresenter } from './ILoginPresenter';
@@ -16,6 +16,10 @@ export interface IResettableWalletGateway {
 export enum LogoutReason {
   TOKEN_EXPIRED = 'token_expired',
   USER_INITIATED = 'user_initiated',
+}
+
+export interface IActiveProfileGateway {
+  reset(): Promise<void>;
 }
 
 export class WalletLogout {

--- a/packages/domain/src/use-cases/wallets/__tests__/WalletLogout.spec.ts
+++ b/packages/domain/src/use-cases/wallets/__tests__/WalletLogout.spec.ts
@@ -2,11 +2,12 @@ import { mock } from 'jest-mock-extended';
 import { when } from 'jest-when';
 
 import { mockWallet } from '../../../entities/__helpers__/mocks';
-import { IActiveProfileGateway, IActiveProfilePresenter } from '../../profile';
+import { IActiveProfilePresenter } from '../../profile';
 import { ActiveWallet } from '../ActiveWallet';
 import { IActiveWalletPresenter } from '../IActiveWalletPresenter';
 import { ILoginPresenter } from '../ILoginPresenter';
 import {
+  IActiveProfileGateway,
   IResettableCredentialsGateway,
   IResettableWalletGateway,
   LogoutReason,

--- a/packages/react/src/profile/adapters/ActiveProfileGateway.ts
+++ b/packages/react/src/profile/adapters/ActiveProfileGateway.ts
@@ -1,0 +1,35 @@
+import { Profile } from '@lens-protocol/domain/entities';
+import * as profileUseCases from '@lens-protocol/domain/use-cases/profile';
+import * as walletsUseCases from '@lens-protocol/domain/use-cases/wallets';
+import { IStorage } from '@lens-protocol/storage';
+import { z } from 'zod';
+
+export const StoredActiveProfileData = z.object({
+  id: z.string(),
+  handle: z.string(),
+});
+
+export type StoredActiveProfileData = z.infer<typeof StoredActiveProfileData>;
+
+export class ActiveProfileGateway
+  implements profileUseCases.IActiveProfileGateway, walletsUseCases.IActiveProfileGateway
+{
+  constructor(private readonly activeProfileStorage: IStorage<StoredActiveProfileData>) {}
+
+  async setActiveProfile(profile: Profile): Promise<void> {
+    await this.activeProfileStorage.set(profile);
+  }
+
+  async getActiveProfile(): Promise<Profile | null> {
+    const data = await this.activeProfileStorage.get();
+
+    if (!data) {
+      return null;
+    }
+    return data;
+  }
+
+  async reset() {
+    await this.activeProfileStorage.reset();
+  }
+}

--- a/packages/react/src/profile/adapters/ProfileGateway.ts
+++ b/packages/react/src/profile/adapters/ProfileGateway.ts
@@ -1,0 +1,47 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import {
+  GetProfileQuery,
+  GetProfileQueryVariables,
+  GetProfileDocument,
+  GetAllProfilesByOwnerAddressDocument,
+  GetAllProfilesByOwnerAddressQuery,
+  GetAllProfilesByOwnerAddressQueryVariables,
+} from '@lens-protocol/api';
+import { Profile } from '@lens-protocol/domain/entities';
+import { IProfileGateway } from '@lens-protocol/domain/use-cases/profile';
+import { invariant } from '@lens-protocol/shared-kernel';
+
+export class ProfileGateway implements IProfileGateway {
+  constructor(private readonly apolloClient: ApolloClient<NormalizedCacheObject>) {}
+
+  async getAllProfilesByOwnerAddress(address: string): Promise<Profile[]> {
+    const { data } = await this.apolloClient.query<
+      GetAllProfilesByOwnerAddressQuery,
+      GetAllProfilesByOwnerAddressQueryVariables
+    >({
+      query: GetAllProfilesByOwnerAddressDocument,
+      variables: { address },
+    });
+
+    invariant(data, `Could not query profiles by owner address: ${address}`);
+
+    return data.profilesByOwner.items.map(({ id, handle }) => Profile.create({ id, handle }));
+  }
+
+  async getProfileByHandle(handle: string): Promise<Profile | null> {
+    const { data } = await this.apolloClient.query<GetProfileQuery, GetProfileQueryVariables>({
+      query: GetProfileDocument,
+      variables: { request: { handle } },
+    });
+
+    invariant(data, `Could not query profiles by handle: ${handle}`);
+
+    if (data.result === null) {
+      return null;
+    }
+    return Profile.create({
+      id: data.result.id,
+      handle: data.result.handle,
+    });
+  }
+}

--- a/packages/react/src/profile/adapters/__tests__/ActiveProfileGateway.spec.ts
+++ b/packages/react/src/profile/adapters/__tests__/ActiveProfileGateway.spec.ts
@@ -1,0 +1,20 @@
+import { mockProfile } from '@lens-protocol/domain/mocks';
+import { mockStorage } from '@lens-protocol/storage/mocks';
+
+import { ActiveProfileGateway, StoredActiveProfileData } from '../ActiveProfileGateway';
+
+describe(`Given an instance of the ${ActiveProfileGateway.name}`, () => {
+  describe(`when the "${ActiveProfileGateway.prototype.setActiveProfile.name}" method is invoked`, () => {
+    it(`should persist the given profile handle so that it can be retrieved later on via ""${ActiveProfileGateway.prototype.getActiveProfile.name}"" method`, async () => {
+      const profile = mockProfile();
+      const activeProfileStorage = mockStorage<StoredActiveProfileData>(null);
+      const gateway = new ActiveProfileGateway(activeProfileStorage);
+
+      await gateway.setActiveProfile(profile);
+
+      const stored = await gateway.getActiveProfile();
+
+      expect(stored).toEqual(profile);
+    });
+  });
+});

--- a/packages/react/src/profile/adapters/__tests__/ProfileGateway.spec.ts
+++ b/packages/react/src/profile/adapters/__tests__/ProfileGateway.spec.ts
@@ -1,0 +1,77 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { faker } from '@faker-js/faker';
+import {
+  createMockApolloClientWithMultipleResponses,
+  mockGetAllProfilesByOwnerAddressQueryMockedResponse,
+  mockGetProfileQueryMockedResponse,
+  mockProfileFieldsFragment,
+} from '@lens-protocol/api/mocks';
+import { Profile } from '@lens-protocol/domain/entities';
+import { mockEthereumAddress } from '@lens-protocol/shared-kernel/mocks';
+
+import { ProfileGateway } from '../ProfileGateway';
+
+function setupProfileGateway({
+  apolloClient,
+}: {
+  apolloClient: ApolloClient<NormalizedCacheObject>;
+}) {
+  return new ProfileGateway(apolloClient);
+}
+
+describe(`Given an instance of the ${ProfileGateway.name}`, () => {
+  describe(`when "${ProfileGateway.prototype.getAllProfilesByOwnerAddress.name}" method is invoked`, () => {
+    it('should return all Profile entities owned by the given address', async () => {
+      const address = mockEthereumAddress();
+      const profileDataFragment = mockProfileFieldsFragment();
+      const apolloClient = createMockApolloClientWithMultipleResponses([
+        mockGetAllProfilesByOwnerAddressQueryMockedResponse({
+          address,
+          profiles: [profileDataFragment],
+        }),
+      ]);
+      const gateway = setupProfileGateway({ apolloClient });
+
+      const [profile] = await gateway.getAllProfilesByOwnerAddress(address);
+
+      expect(profile).toBeInstanceOf(Profile);
+      expect(profile).toEqual({
+        id: profileDataFragment.id,
+        handle: profileDataFragment.handle,
+      });
+    });
+  });
+
+  describe(`when "${ProfileGateway.prototype.getProfileByHandle.name}" method is invoked`, () => {
+    it('should return the Profile entity associated with the given handle', async () => {
+      const profileDataFragment = mockProfileFieldsFragment();
+      const apolloClient = createMockApolloClientWithMultipleResponses([
+        mockGetProfileQueryMockedResponse({
+          request: { handle: profileDataFragment.handle },
+          profile: profileDataFragment,
+        }),
+      ]);
+      const gateway = setupProfileGateway({ apolloClient });
+
+      const profile = await gateway.getProfileByHandle(profileDataFragment.handle);
+
+      expect(profile).toBeInstanceOf(Profile);
+      expect(profile).toEqual({
+        id: profileDataFragment.id,
+        handle: profileDataFragment.handle,
+      });
+    });
+
+    it('should return null if the Profile does not exist', async () => {
+      const handle = faker.internet.userName();
+      const apolloClient = createMockApolloClientWithMultipleResponses([
+        mockGetProfileQueryMockedResponse({ request: { handle }, profile: null }),
+      ]);
+      const gateway = setupProfileGateway({ apolloClient });
+
+      const profile = await gateway.getProfileByHandle(handle);
+
+      expect(profile).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Continuing on the effort of moving over dependencies required by `WalletLogin` use case. In this PR:
- `ProfileGateway` + tests and helpers
- `ActiveProfileGateway` + tests and helpers