### PR TITLE
Credentials refresh on bootstrap and when expired

### DIFF
--- a/examples/web-wagmi/package.json
+++ b/examples/web-wagmi/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@lens-protocol/react": "workspace:*",
-    "@lens-protocol/wagmi": "workspace:^0.0.1",
+    "@lens-protocol/wagmi": "workspace:*",
     "ethers": "^5.7.2",
     "react": "^18.2.0",
     "react-cool-inview": "^3.0.1",

--- a/examples/web-wagmi/src/components/app/App.tsx
+++ b/examples/web-wagmi/src/components/app/App.tsx
@@ -24,10 +24,10 @@ const client = createClient({
 });
 
 const lensConfig: LensConfig = {
-  environment: staging,
-  storage: localStorage(),
-  sources: [sources.lenster, sources.orb, 'any-other-app-id'],
   bindings: wagmiBindings(),
+  environment: staging,
+  sources: [sources.lenster, sources.orb, 'any-other-app-id'],
+  storage: localStorage(),
 };
 
 export function App() {

--- a/examples/web-wagmi/src/components/header/Header.tsx
+++ b/examples/web-wagmi/src/components/header/Header.tsx
@@ -1,11 +1,7 @@
-import { useWalletLogin } from '@lens-protocol/react';
+import { useWalletLogin, useActiveProfile } from '@lens-protocol/react';
 import { Link } from 'react-router-dom';
-import { useAccount, useConnect, useDisconnect } from 'wagmi';
+import { useConnect, useDisconnect } from 'wagmi';
 import { InjectedConnector } from 'wagmi/connectors/injected';
-
-function truncateAddress(address: string, chars = 4) {
-  return `${address.substring(0, chars + 2)}...${address.substring(42 - chars)}`;
-}
 
 export function Header() {
   const login = useWalletLogin();
@@ -22,7 +18,7 @@ export function Header() {
   });
 
   const { disconnect } = useDisconnect();
-  const { address } = useAccount();
+  const { loading, profile } = useActiveProfile();
 
   return (
     <div
@@ -48,8 +44,14 @@ export function Header() {
         <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
           <span style={{ fontWeight: 'bold' }}>@lens-protocol/react - wagmi</span>
         </Link>
-        {!address && <button onClick={() => connect()}>Connect Wallet</button>}
-        {address && <button onClick={() => disconnect()}>{truncateAddress(address)}</button>}
+        {!loading &&
+          (profile ? (
+            <button onClick={() => disconnect()}>
+              <strong>{profile.handle}</strong>
+            </button>
+          ) : (
+            <button onClick={() => connect()}>Log in</button>
+          ))}
       </div>
     </div>
   );

--- a/packages/api/src/apollo/IAccessTokenStorage.ts
+++ b/packages/api/src/apollo/IAccessTokenStorage.ts
@@ -1,3 +1,4 @@
 export interface IAccessTokenStorage {
   getAccessToken(): string | null;
+  refreshToken(): Promise<void>;
 }

--- a/packages/api/src/apollo/createAuthLink.ts
+++ b/packages/api/src/apollo/createAuthLink.ts
@@ -1,0 +1,38 @@
+import { from, fromPromise } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { onError } from '@apollo/client/link/error';
+
+import { IAccessTokenStorage } from './IAccessTokenStorage';
+
+/**
+ * An error code that's coming from `apollo-server-errors` `AuthenticationError`
+ */
+const AUTHENTICATION_ERROR_CODE = 'UNAUTHENTICATED';
+
+export const createAuthLink = (accessTokenStorage: IAccessTokenStorage) => {
+  const errorLink = onError(({ graphQLErrors, operation, forward }) => {
+    if (
+      graphQLErrors &&
+      graphQLErrors.some((error) => error.extensions?.code === AUTHENTICATION_ERROR_CODE)
+    ) {
+      return fromPromise(accessTokenStorage.refreshToken()).flatMap(() => forward(operation));
+    }
+    return;
+  });
+
+  const authHeaderLink = setContext(() => {
+    const token = accessTokenStorage.getAccessToken();
+
+    if (token) {
+      return {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      };
+    }
+
+    return;
+  });
+
+  return from([errorLink, authHeaderLink]);
+};

--- a/packages/domain/src/use-cases/wallets/ILoginPresenter.ts
+++ b/packages/domain/src/use-cases/wallets/ILoginPresenter.ts
@@ -1,5 +1,0 @@
-import { Wallet } from '../../entities';
-
-export interface ILoginPresenter {
-  presentLoginOptions(previousWallet: Wallet | null): void;
-}

--- a/packages/domain/src/use-cases/wallets/ILogoutPresenter.ts
+++ b/packages/domain/src/use-cases/wallets/ILogoutPresenter.ts
@@ -1,0 +1,15 @@
+import { WalletData } from './IActiveWalletPresenter';
+
+export enum LogoutReason {
+  CREDENTIALS_EXPIRED = 'credentials-expired',
+  USER_INITIATED = 'user-initiated',
+}
+
+export type LogoutData = {
+  lastLoggedInWallet: WalletData | null;
+  logoutReason: LogoutReason;
+};
+
+export interface ILogoutPresenter {
+  presentLogout(data: LogoutData): void;
+}

--- a/packages/domain/src/use-cases/wallets/WalletLogout.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogout.ts
@@ -1,9 +1,7 @@
-import { assertNever } from '@lens-protocol/shared-kernel';
-
 import { IActiveProfilePresenter } from '../profile';
 import { ActiveWallet } from './ActiveWallet';
 import { IActiveWalletPresenter } from './IActiveWalletPresenter';
-import { ILoginPresenter } from './ILoginPresenter';
+import { ILogoutPresenter, LogoutReason } from './ILogoutPresenter';
 
 export interface IResettableCredentialsGateway {
   invalidate(): Promise<void>;
@@ -11,11 +9,6 @@ export interface IResettableCredentialsGateway {
 
 export interface IResettableWalletGateway {
   reset(): Promise<void>;
-}
-
-export enum LogoutReason {
-  TOKEN_EXPIRED = 'token_expired',
-  USER_INITIATED = 'user_initiated',
 }
 
 export interface IActiveProfileGateway {
@@ -30,7 +23,7 @@ export class WalletLogout {
     private activeProfileGateway: IActiveProfileGateway,
     private activeProfilePresenter: IActiveProfilePresenter,
     private activeWalletPresenter: IActiveWalletPresenter,
-    private loginPresenter: ILoginPresenter,
+    private logoutPresenter: ILogoutPresenter,
   ) {}
 
   async logout(reason: LogoutReason): Promise<void> {
@@ -44,17 +37,6 @@ export class WalletLogout {
 
     await this.credentialsGateway.invalidate();
 
-    switch (reason) {
-      case LogoutReason.TOKEN_EXPIRED:
-        // TODO pass a DTO to the presenter, not the entity
-        this.loginPresenter.presentLoginOptions(activeWallet);
-        break;
-      case LogoutReason.USER_INITIATED:
-        // Stay on the same page and remove all parts that require connected wallet
-        // which is done by just removing active wallet from presenter
-        break;
-      default:
-        assertNever(reason, `Logout reason not handled. Reason "${String(reason)}".`);
-    }
+    this.logoutPresenter.presentLogout({ lastLoggedInWallet: activeWallet, logoutReason: reason });
   }
 }

--- a/packages/domain/src/use-cases/wallets/__tests__/WalletLogout.spec.ts
+++ b/packages/domain/src/use-cases/wallets/__tests__/WalletLogout.spec.ts
@@ -5,117 +5,80 @@ import { mockWallet } from '../../../entities/__helpers__/mocks';
 import { IActiveProfilePresenter } from '../../profile';
 import { ActiveWallet } from '../ActiveWallet';
 import { IActiveWalletPresenter } from '../IActiveWalletPresenter';
-import { ILoginPresenter } from '../ILoginPresenter';
+import { ILogoutPresenter, LogoutReason } from '../ILogoutPresenter';
 import {
   IActiveProfileGateway,
   IResettableCredentialsGateway,
   IResettableWalletGateway,
-  LogoutReason,
   WalletLogout,
 } from '../WalletLogout';
 
 const wallet = mockWallet();
 
-const setupWalletLogout = ({
-  activeProfileGateway = mock<IActiveProfileGateway>(),
-  activeProfilePresenter = mock<IActiveProfilePresenter>(),
-  activeWallet = mock<ActiveWallet>(),
-  credentialsGateway = mock<IResettableCredentialsGateway>(),
-  walletGateway = mock<IResettableWalletGateway>(),
-  activeWalletPresenter = mock<IActiveWalletPresenter>(),
-  loginPresenter = mock<ILoginPresenter>(),
-}: {
-  activeProfileGateway?: IActiveProfileGateway;
-  activeProfilePresenter?: IActiveProfilePresenter;
-  activeWallet?: ActiveWallet;
-  credentialsGateway?: IResettableCredentialsGateway;
-  walletGateway?: IResettableWalletGateway;
-  activeWalletPresenter?: IActiveWalletPresenter;
-  loginPresenter?: ILoginPresenter;
-}) => {
-  return new WalletLogout(
+const setupWalletLogout = ({ activeWallet }: { activeWallet: ActiveWallet }) => {
+  const walletGateway = mock<IResettableWalletGateway>();
+  const credentialsGateway = mock<IResettableCredentialsGateway>();
+  const activeWalletPresenter = mock<IActiveWalletPresenter>();
+  const activeProfilePresenter = mock<IActiveProfilePresenter>();
+  const activeProfileGateway = mock<IActiveProfileGateway>();
+  const logoutPresenter = mock<ILogoutPresenter>();
+
+  const walletLogout = new WalletLogout(
     walletGateway,
     credentialsGateway,
     activeWallet,
     activeProfileGateway,
     activeProfilePresenter,
     activeWalletPresenter,
-    loginPresenter,
+    logoutPresenter,
   );
+
+  return {
+    walletGateway,
+    credentialsGateway,
+    activeWalletPresenter,
+    activeProfilePresenter,
+    activeProfileGateway,
+    logoutPresenter,
+    walletLogout,
+  };
 };
 
 describe(`Given the ${WalletLogout.name} interactor`, () => {
   describe(`when "${WalletLogout.prototype.logout.name}" is invoked`, () => {
-    describe('with USER_INITIATED logout reason', () => {
-      it(`should:
+    it(`should:
           - clear wallets from storage
           - clear credentials from storage
           - clear active profile from storage
           - present an empty profile
-          - present an empty wallet`, async () => {
-        const walletGateway = mock<IResettableWalletGateway>();
-        const credentialsGateway = mock<IResettableCredentialsGateway>();
-        const activeWallet = mock<ActiveWallet>();
-        const activeWalletPresenter = mock<IActiveWalletPresenter>();
-        const activeProfilePresenter = mock<IActiveProfilePresenter>();
-        const activeProfileGateway = mock<IActiveProfileGateway>();
-
-        when(activeWallet.requireActiveWallet).calledWith().mockResolvedValue(wallet);
-
-        const walletLogout = setupWalletLogout({
-          activeProfileGateway,
-          activeProfilePresenter,
-          activeWallet,
-          activeWalletPresenter,
-          credentialsGateway,
-          walletGateway,
-        });
-
-        await walletLogout.logout(LogoutReason.USER_INITIATED);
-
-        expect(credentialsGateway.invalidate).toHaveBeenCalled();
-        expect(walletGateway.reset).toHaveBeenCalled();
-        expect(activeProfileGateway.reset).toHaveBeenCalled();
-        expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(null);
-        expect(activeWalletPresenter.presentActiveWallet).toHaveBeenCalledWith(null);
-      });
-    });
-
-    describe('with TOKEN_EXPIRED logout reason', () => {
-      it(`should:
-          - clear wallets from storage
-          - clear credentials from storage
-          - clear active profile from storage
           - present an empty wallet
-          - present login options with previously connected wallet`, async () => {
-        const walletGateway = mock<IResettableWalletGateway>();
-        const credentialsGateway = mock<IResettableCredentialsGateway>();
-        const activeWallet = mock<ActiveWallet>();
-        const activeWalletPresenter = mock<IActiveWalletPresenter>();
-        const activeProfileGateway = mock<IActiveProfileGateway>();
-        const activeProfilePresenter = mock<IActiveProfilePresenter>();
+          - present logout details`, async () => {
+      const activeWallet = mock<ActiveWallet>();
 
-        const loginPresenter = mock<ILoginPresenter>();
+      when(activeWallet.requireActiveWallet).calledWith().mockResolvedValue(wallet);
 
-        when(activeWallet.requireActiveWallet).calledWith().mockResolvedValue(wallet);
+      const {
+        walletLogout,
+        credentialsGateway,
+        walletGateway,
+        activeProfileGateway,
+        activeProfilePresenter,
+        logoutPresenter,
+        activeWalletPresenter,
+      } = setupWalletLogout({
+        activeWallet,
+      });
 
-        const walletLogout = setupWalletLogout({
-          activeProfileGateway,
-          activeProfilePresenter,
-          activeWallet,
-          activeWalletPresenter,
-          credentialsGateway,
-          loginPresenter,
-          walletGateway,
-        });
+      await walletLogout.logout(LogoutReason.USER_INITIATED);
 
-        await walletLogout.logout(LogoutReason.TOKEN_EXPIRED);
-
-        expect(credentialsGateway.invalidate).toHaveBeenCalled();
-        expect(walletGateway.reset).toHaveBeenCalled();
-        expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(null);
-        expect(activeWalletPresenter.presentActiveWallet).toHaveBeenCalledWith(null);
-        expect(loginPresenter.presentLoginOptions).toHaveBeenCalledWith(wallet);
+      expect(credentialsGateway.invalidate).toHaveBeenCalled();
+      expect(walletGateway.reset).toHaveBeenCalled();
+      expect(activeProfileGateway.reset).toHaveBeenCalled();
+      expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(null);
+      expect(activeWalletPresenter.presentActiveWallet).toHaveBeenCalledWith(null);
+      expect(logoutPresenter.presentLogout).toHaveBeenCalledWith({
+        lastLoggedInWallet: wallet,
+        logoutReason: LogoutReason.USER_INITIATED,
       });
     });
   });

--- a/packages/domain/src/use-cases/wallets/index.ts
+++ b/packages/domain/src/use-cases/wallets/index.ts
@@ -1,5 +1,5 @@
 export * from './IActiveWalletPresenter';
-export * from './ILoginPresenter';
+export * from './ILogoutPresenter';
 export * from './TokenAllowance';
 export * from './WalletLogin';
 export * from './WalletLogout';

--- a/packages/react/src/LensProvider.tsx
+++ b/packages/react/src/LensProvider.tsx
@@ -1,15 +1,27 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 import { LensConfig } from './config';
+import { useBootstrapController } from './lifecycle/adapters/useBootstrapController';
 import { createSharedDependencies, SharedDependenciesProvider } from './shared';
+import { LogoutHandler } from './wallet';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop() {}
 
 export type LensProviderProps = {
   children: ReactNode;
   config: LensConfig;
+  onLogout?: LogoutHandler;
 };
 
-export function LensProvider({ children, config }: LensProviderProps) {
-  const [sharedDependencies] = useState(() => createSharedDependencies(config));
+export function LensProvider({ children, config, onLogout = noop }: LensProviderProps) {
+  const [sharedDependencies] = useState(() => createSharedDependencies(config, { onLogout }));
+
+  const start = useBootstrapController(sharedDependencies);
+
+  useEffect(() => {
+    start();
+  }, []);
 
   return (
     <SharedDependenciesProvider dependencies={sharedDependencies}>

--- a/packages/react/src/lifecycle/adapters/ApplicationPresenter.ts
+++ b/packages/react/src/lifecycle/adapters/ApplicationPresenter.ts
@@ -1,0 +1,19 @@
+import { makeVar, useReactiveVar } from '@apollo/client';
+import { IApplicationPresenter } from '@lens-protocol/domain/use-cases/lifecycle';
+
+export enum ApplicationsState {
+  LOADING,
+  READY,
+}
+
+const applicationState = makeVar<ApplicationsState>(ApplicationsState.LOADING);
+
+export class ApplicationPresenter implements IApplicationPresenter {
+  signalReady(): void {
+    applicationState(ApplicationsState.READY);
+  }
+}
+
+export const useAppState = () => {
+  return useReactiveVar(applicationState);
+};

--- a/packages/react/src/lifecycle/adapters/useBootstrapController.ts
+++ b/packages/react/src/lifecycle/adapters/useBootstrapController.ts
@@ -1,0 +1,29 @@
+import { Bootstrap } from '@lens-protocol/domain/use-cases/lifecycle';
+
+import { SharedDependencies } from '../../shared';
+import { ActiveWalletPresenter } from '../../wallet/adapters/ActiveWalletPresenter';
+import { ApplicationPresenter } from './ApplicationPresenter';
+
+export function useBootstrapController({
+  activeWallet,
+  activeProfile,
+  credentialsFactory,
+  credentialsGateway,
+  logoutPresenter,
+}: SharedDependencies) {
+  return () => {
+    const activeWalletPresenter = new ActiveWalletPresenter();
+    const applicationPresenter = new ApplicationPresenter();
+    const bootstrap = new Bootstrap(
+      activeWallet,
+      credentialsGateway,
+      credentialsFactory,
+      activeWalletPresenter,
+      applicationPresenter,
+      logoutPresenter,
+      activeProfile,
+    );
+
+    void bootstrap.start();
+  };
+}

--- a/packages/react/src/profile/adapters/ActiveProfilePresenter.ts
+++ b/packages/react/src/profile/adapters/ActiveProfilePresenter.ts
@@ -47,6 +47,6 @@ export class ActiveProfilePresenter implements IActiveProfilePresenter {
   }
 }
 
-export function useActiveProfile() {
+export function useActiveProfileVar() {
   return useReactiveVar(activeProfileVar);
 }

--- a/packages/react/src/profile/index.ts
+++ b/packages/react/src/profile/index.ts
@@ -1,5 +1,6 @@
 import { ProfileFieldsFragment } from '@lens-protocol/api';
 
+export * from './useActiveProfile';
 export * from './useProfilesToFollow';
 export * from './useProfile';
 export * from './useExploreProfiles';

--- a/packages/react/src/profile/useActiveProfile.ts
+++ b/packages/react/src/profile/useActiveProfile.ts
@@ -1,0 +1,20 @@
+import { ApplicationsState, useAppState } from '../lifecycle/adapters/ApplicationPresenter';
+import { useActiveProfileVar } from './adapters/ActiveProfilePresenter';
+
+export function useActiveProfile() {
+  const state = useAppState();
+
+  const profile = useActiveProfileVar();
+
+  if (state === ApplicationsState.LOADING) {
+    return {
+      loading: true,
+      profile: null,
+    };
+  }
+
+  return {
+    loading: false,
+    profile,
+  };
+}

--- a/packages/react/src/wallet/adapters/CredentialsExpiryController.ts
+++ b/packages/react/src/wallet/adapters/CredentialsExpiryController.ts
@@ -1,0 +1,21 @@
+import { LogoutReason, WalletLogout } from '@lens-protocol/domain/use-cases/wallets';
+
+export type Callback = () => void;
+
+export interface ICredentialsExpiryEmitter {
+  onExpiry(callback: Callback): void;
+}
+
+export class CredentialsExpiryController {
+  constructor(readonly walletLogout: WalletLogout) {}
+
+  subscribe(tokenExpiryEmitter: ICredentialsExpiryEmitter) {
+    tokenExpiryEmitter.onExpiry(() => {
+      void this.onTokenExpired();
+    });
+  }
+
+  private async onTokenExpired(): Promise<void> {
+    await this.walletLogout.logout(LogoutReason.CREDENTIALS_EXPIRED);
+  }
+}

--- a/packages/react/src/wallet/adapters/LogoutPresenter.ts
+++ b/packages/react/src/wallet/adapters/LogoutPresenter.ts
@@ -1,0 +1,11 @@
+import { ILogoutPresenter, LogoutData } from '@lens-protocol/domain/use-cases/wallets';
+
+export type LogoutHandler = (data: LogoutData) => void;
+
+export class LogoutPresenter implements ILogoutPresenter {
+  constructor(private readonly logoutHandler: LogoutHandler) {}
+
+  presentLogout(data: LogoutData): void {
+    this.logoutHandler(data);
+  }
+}

--- a/packages/react/src/wallet/adapters/useWalletLoginController.ts
+++ b/packages/react/src/wallet/adapters/useWalletLoginController.ts
@@ -1,18 +1,14 @@
 import { WalletLogin, WalletLoginRequest } from '@lens-protocol/domain/use-cases/wallets';
 
 import { useSharedDependencies } from '../../shared';
-import { AuthApi } from '../infrastructure/AuthApi';
 import { ActiveWalletPresenter } from './ActiveWalletPresenter';
 import { ConnectionErrorPresenter } from './ConnectionErrorPresenter';
-import { CredentialsFactory } from './CredentialsFactory';
 
 export function useWalletLoginController() {
-  const { activeProfile, apolloClient, credentialsGateway, walletFactory, walletGateway } =
+  const { activeProfile, credentialsFactory, credentialsGateway, walletFactory, walletGateway } =
     useSharedDependencies();
 
   return (request: WalletLoginRequest) => {
-    const authApi = new AuthApi(apolloClient);
-    const credentialsFactory = new CredentialsFactory(authApi);
     const activeWalletPresenter = new ActiveWalletPresenter();
     const connectionErrorPresenter = new ConnectionErrorPresenter();
     const walletLogin = new WalletLogin(

--- a/packages/react/src/wallet/index.ts
+++ b/packages/react/src/wallet/index.ts
@@ -1,1 +1,3 @@
 export * from './useWalletLogin';
+export { useActiveWallet } from './adapters/ActiveWalletPresenter';
+export type { LogoutHandler } from './adapters/LogoutPresenter';

--- a/packages/react/src/wallet/infrastructure/AccessTokenStorage.ts
+++ b/packages/react/src/wallet/infrastructure/AccessTokenStorage.ts
@@ -1,0 +1,67 @@
+import { IAccessTokenStorage } from '@lens-protocol/api';
+import { CredentialsExpiredError } from '@lens-protocol/domain/use-cases/lifecycle';
+import { Deferred } from '@lens-protocol/shared-kernel';
+
+import { Credentials } from '../adapters/Credentials';
+import { Callback, ICredentialsExpiryEmitter } from '../adapters/CredentialsExpiryController';
+import { AuthApi } from './AuthApi';
+import { CredentialsStorage } from './CredentialsStorage';
+
+export class AccessTokenStorage implements IAccessTokenStorage, ICredentialsExpiryEmitter {
+  private isRefreshing = false;
+  private pendingRequests: Deferred<void>[] = [];
+
+  private listeners: Set<Callback> = new Set();
+
+  constructor(
+    private readonly authApi: AuthApi,
+    private readonly credentialsStorage: CredentialsStorage,
+  ) {}
+
+  onExpiry(callback: Callback) {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  getAccessToken(): string | null {
+    return this.credentialsStorage.getAccessToken();
+  }
+
+  async refreshToken(): Promise<void> {
+    if (this.isRefreshing) {
+      const deferredPromise = new Deferred<void>();
+      this.pendingRequests.push(deferredPromise);
+      return deferredPromise.promise;
+    }
+
+    this.isRefreshing = true;
+    const credentials = await this.credentialsStorage.get();
+
+    if (credentials && credentials.canRefresh()) {
+      await this.refreshCredentials(credentials);
+      this.isRefreshing = false;
+      return;
+    }
+
+    this.rejectPendingRequests();
+    this.isRefreshing = false;
+    this.emitExpiryEvent();
+    throw new CredentialsExpiredError();
+  }
+
+  private async refreshCredentials(credentials: Credentials) {
+    const newCredentials = await this.authApi.refreshCredentials(credentials.refreshToken);
+    await this.credentialsStorage.set(newCredentials);
+    this.pendingRequests.map((request) => request.resolve());
+    this.pendingRequests = [];
+  }
+
+  private rejectPendingRequests() {
+    this.pendingRequests.map((request) => request.reject(new CredentialsExpiredError()));
+    this.pendingRequests = [];
+  }
+
+  private emitExpiryEvent() {
+    this.listeners.forEach((callback) => callback());
+  }
+}

--- a/packages/react/src/wallet/infrastructure/CredentialsStorage.ts
+++ b/packages/react/src/wallet/infrastructure/CredentialsStorage.ts
@@ -1,4 +1,3 @@
-import { IAccessTokenStorage } from '@lens-protocol/api';
 import {
   BaseStorageSchema,
   IStorage,
@@ -24,7 +23,7 @@ const authStorageSchema = new BaseStorageSchema('lens.credentials', AuthData);
  * Access token is kept in memory.
  * Refresh token is persisted permanently.
  */
-export class CredentialsStorage implements IStorage<Credentials>, IAccessTokenStorage {
+export class CredentialsStorage implements IStorage<Credentials> {
   refreshTokenStorage: IStorage<AuthData>;
   accessToken: string | null = null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       '@lens-protocol/eslint-config': workspace:*
       '@lens-protocol/prettier-config': workspace:*
       '@lens-protocol/react': workspace:*
-      '@lens-protocol/wagmi': workspace:^0.0.1
+      '@lens-protocol/wagmi': workspace:*
       '@types/react': ^18.0.24
       '@types/react-dom': ^18.0.8
       '@vitejs/plugin-react': ^2.2.0
@@ -530,6 +530,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -707,6 +710,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.20.5
@@ -720,6 +726,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/compat-data': 7.20.5
       '@babel/core': 7.20.5
@@ -733,6 +742,9 @@ packages:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -742,6 +754,9 @@ packages:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -751,6 +766,9 @@ packages:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -761,6 +779,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -770,6 +791,9 @@ packages:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -779,6 +803,9 @@ packages:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -801,6 +828,9 @@ packages:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -810,6 +840,9 @@ packages:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -819,6 +852,9 @@ packages:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -828,6 +864,9 @@ packages:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -837,6 +876,9 @@ packages:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -846,6 +888,9 @@ packages:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -856,6 +901,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -866,6 +914,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -876,6 +927,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -886,6 +940,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -896,6 +953,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -906,6 +966,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -926,6 +989,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -936,6 +1002,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -946,6 +1015,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -957,6 +1029,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -967,6 +1042,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
@@ -979,6 +1057,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -989,6 +1070,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -999,6 +1083,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-module-transforms': 7.20.2
@@ -1013,6 +1100,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -1026,6 +1116,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -1036,6 +1129,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -1046,6 +1142,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -1130,6 +1229,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -1140,6 +1242,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -1151,6 +1256,9 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -4080,6 +4188,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@jest/transform': 29.3.1
@@ -4097,6 +4208,9 @@ packages:
     resolution: {integrity: sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==}
     peerDependencies:
       '@babel/core': ^7.1.2
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/parser': 7.20.5
@@ -4123,6 +4237,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       graphql-tag: ^2.10.1
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
@@ -4437,6 +4554,9 @@ packages:
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.5
@@ -4494,6 +4614,9 @@ packages:
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.5
@@ -4532,6 +4655,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dependencies:
       '@babel/core': 7.20.5
       babel-plugin-jest-hoist: 29.2.0


### PR DESCRIPTION
- Starts `Bootstrap` on `LensProvider` mount
- Exposes `useActiveProfile` hook
- Ports refresh expired tokens with the following changes
  - Auth Link now accepts a single `IAccessTokenStorage` interface which is the merge of `IAccessTokenStorage` and `IAuthRefresher` interfaces.
   - `AuthRefresher` is now called `AccessTokenStorage`. It implements directly the `ICredentialsExpiryEmitter` while previously it was accepting an object implementing such interface. It also implements the `IAccessTokenStorage` mentioned above.
   
See inline comment for more differences.