### PR TITLE
Improve SDK packages peer dependencies setup

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -49,7 +49,8 @@
   "license": "MIT",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@lens-protocol/domain": "workspace:*"
+    "@lens-protocol/domain": "workspace:*",
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -66,15 +67,13 @@
     "@lens-protocol/shared-kernel": "workspace:*",
     "@types/jest": "^29.2.3",
     "babel-plugin-graphql-tag": "^3.3.0",
+    "eslint": "^8.28.0",
     "graphql": "15.5.1",
     "graphql-tag": "^2.12.6",
     "jest": "^29.3.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",
     "typescript": "^4.9.3"
-  },
-  "peerDependencies": {
-    "eslint": "^8.28.0"
   },
   "prettier": "@lens-protocol/prettier-config"
 }

--- a/packages/api/tsconfig.base.json
+++ b/packages/api/tsconfig.base.json
@@ -6,8 +6,11 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
     "isolatedModules": false,
     "jsx": "react-jsx",
+    "lib": ["dom", "esnext"],
+    "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
@@ -16,9 +19,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "lib": ["dom", "esnext"],
-    "target": "esnext",
-    "moduleResolution": "node"
+    "target": "esnext"
   },
   "exclude": ["node_modules", "dist"],
   "include": ["src"]

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -70,7 +70,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@lens-protocol/shared-kernel": "workspace:*"
+    "@lens-protocol/shared-kernel": "workspace:*",
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
@@ -86,12 +87,8 @@
     "prettier": "^2.8.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",
-    "tslib": "^2.4.1",
     "typescript": "^4.9.3",
     "wait-for-expect": "^3.0.2"
-  },
-  "peerDependencies": {
-    "tslib": "^2.4.1"
   },
   "prettier": "@lens-protocol/prettier-config"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,8 @@
     "@lens-protocol/storage": "workspace:*",
     "graphql": "15.5.1",
     "jwt-decode": "^3.1.2",
-    "react": "^18.2.0",
+    "lodash": "^4.17.21",
+    "tslib": "^2.4.1",
     "uuid": "^9.0.0",
     "zod": "^3.19.1"
   },
@@ -81,8 +82,8 @@
     "jest-environment-jsdom": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "jest-when": "^3.5.2",
-    "lodash": "^4.17.21",
     "prettier": "^2.8.0",
+    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",
@@ -90,7 +91,6 @@
   },
   "peerDependencies": {
     "ethers": "^5.7.2",
-    "lodash": "^4.17.21",
     "react": "^18.2.0"
   },
   "prettier": "@lens-protocol/prettier-config"

--- a/packages/react/tsconfig.base.json
+++ b/packages/react/tsconfig.base.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "ESNext"],

--- a/packages/shared-kernel/package.json
+++ b/packages/shared-kernel/package.json
@@ -50,8 +50,8 @@
   "license": "MIT",
   "dependencies": {
     "decimal.js": "^10.4.3",
-    "ethers": "^5.7.2",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@lens-protocol/eslint-config": "workspace:*",
@@ -59,15 +59,15 @@
     "@types/jest": "^29.2.3",
     "@types/lodash": "^4.14.191",
     "eslint": "^8.28.0",
+    "ethers": "^5.7.2",
     "jest": "^29.3.1",
     "prettier": "^2.8.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",
-    "tslib": "^2.4.1",
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "tslib": "^2.4.1"
+    "ethers": "^5.7.2"
   },
   "prettier": "@lens-protocol/prettier-config"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -49,6 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "@lens-protocol/shared-kernel": "workspace:*",
+    "tslib": "^2.4.1",
     "zod": "^3.19.1"
   },
   "devDependencies": {
@@ -61,11 +62,7 @@
     "prettier": "^2.8.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",
-    "tslib": "^2.4.1",
     "typescript": "^4.9.3"
   },
-  "prettier": "@lens-protocol/prettier-config",
-  "peerDependencies": {
-    "tslib": "^2.4.1"
-  }
+  "prettier": "@lens-protocol/prettier-config"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,15 +70,18 @@ importers:
       '@lens-protocol/shared-kernel': workspace:*
       '@types/jest': ^29.2.3
       babel-plugin-graphql-tag: ^3.3.0
+      eslint: ^8.28.0
       graphql: 15.5.1
       graphql-tag: ^2.12.6
       jest: ^29.3.1
       rimraf: ^3.0.2
       ts-jest: ^29.0.3
+      tslib: ^2.4.1
       typescript: ^4.9.3
     dependencies:
       '@apollo/client': 3.7.1_graphql@15.5.1
       '@lens-protocol/domain': link:../domain
+      tslib: 2.4.1
     devDependencies:
       '@babel/core': 7.20.5
       '@faker-js/faker': 7.6.0
@@ -94,6 +97,7 @@ importers:
       '@lens-protocol/shared-kernel': link:../shared-kernel
       '@types/jest': 29.2.3
       babel-plugin-graphql-tag: 3.3.0_dfknw6xjzvbhkris5p74ndxuwy
+      eslint: 8.28.0
       graphql: 15.5.1
       graphql-tag: 2.12.6_graphql@15.5.1
       jest: 29.3.1
@@ -122,6 +126,7 @@ importers:
       wait-for-expect: ^3.0.2
     dependencies:
       '@lens-protocol/shared-kernel': link:../shared-kernel
+      tslib: 2.4.1
     devDependencies:
       '@faker-js/faker': 7.6.0
       '@jest/globals': 29.3.1
@@ -136,7 +141,6 @@ importers:
       prettier: 2.8.1
       rimraf: 3.0.2
       ts-jest: 29.0.3_4f6uxrzmuwipl5rr3bcogf6k74
-      tslib: 2.4.1
       typescript: 4.9.3
       wait-for-expect: 3.0.2
 
@@ -204,6 +208,7 @@ importers:
       react-dom: ^18.2.0
       rimraf: ^3.0.2
       ts-jest: ^29.0.3
+      tslib: ^2.4.1
       typescript: ^4.9.3
       uuid: ^9.0.0
       zod: ^3.19.1
@@ -217,7 +222,8 @@ importers:
       '@lens-protocol/storage': link:../storage
       graphql: 15.5.1
       jwt-decode: 3.1.2
-      react: 18.2.0
+      lodash: 4.17.21
+      tslib: 2.4.1
       uuid: 9.0.0
       zod: 3.19.1
     devDependencies:
@@ -239,8 +245,8 @@ importers:
       jest-environment-jsdom: 29.3.1
       jest-mock-extended: 3.0.1_4f6uxrzmuwipl5rr3bcogf6k74
       jest-when: 3.5.2_jest@29.3.1
-      lodash: 4.17.21
       prettier: 2.8.0
+      react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       rimraf: 3.0.2
       ts-jest: 29.0.3_4f6uxrzmuwipl5rr3bcogf6k74
@@ -264,19 +270,19 @@ importers:
       typescript: ^4.9.3
     dependencies:
       decimal.js: 10.4.3
-      ethers: 5.7.2
       lodash: 4.17.21
+      tslib: 2.4.1
     devDependencies:
       '@lens-protocol/eslint-config': link:../eslint-config
       '@lens-protocol/prettier-config': link:../prettier-config
       '@types/jest': 29.2.3
       '@types/lodash': 4.14.191
       eslint: 8.28.0
+      ethers: 5.7.2
       jest: 29.3.1
       prettier: 2.8.0
       rimraf: 3.0.2
       ts-jest: 29.0.3_4f6uxrzmuwipl5rr3bcogf6k74
-      tslib: 2.4.1
       typescript: 4.9.3
 
   packages/storage:
@@ -296,6 +302,7 @@ importers:
       zod: ^3.19.1
     dependencies:
       '@lens-protocol/shared-kernel': link:../shared-kernel
+      tslib: 2.4.1
       zod: 3.19.1
     devDependencies:
       '@lens-protocol/eslint-config': link:../eslint-config
@@ -307,7 +314,6 @@ importers:
       prettier: 2.8.0
       rimraf: 3.0.2
       ts-jest: 29.0.3_4f6uxrzmuwipl5rr3bcogf6k74
-      tslib: 2.4.1
       typescript: 4.9.3
 
   packages/wagmi:
@@ -7908,6 +7914,9 @@ packages:
     resolution: {integrity: sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==}
     peerDependencies:
       csstype: ^3.0.10
+    peerDependenciesMeta:
+      csstype:
+        optional: true
     dev: false
 
   /gopd/1.0.1:


### PR DESCRIPTION
- Tslib/lodash - moved to `dependencies` as it’s an internal package dependency that should not be exposed to public as peer dependencies
- Missing importHelpers added where necessary 
- In `@lens-sdk/react` `react` moved to `devDependencies` as it’s a `peerDependency` 
