### PR TITLE
feat: improvements on `useCreatePost` optimistic update logic

### DIFF
--- a/examples/web-wagmi/src/components/header/Header.tsx
+++ b/examples/web-wagmi/src/components/header/Header.tsx
@@ -14,7 +14,6 @@ export function Header() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          width: '100%',
           maxWidth: '1600px',
           margin: 'auto',
           padding: '1rem',

--- a/examples/web-wagmi/src/publications/components/PostComposer.tsx
+++ b/examples/web-wagmi/src/publications/components/PostComposer.tsx
@@ -38,8 +38,6 @@ export function PostComposer({ profile }: PostComposerProps) {
 
   return (
     <form onSubmit={submit}>
-      {error && <p>{error.message}</p>}
-
       <fieldset>
         <textarea
           rows={3}
@@ -53,6 +51,8 @@ export function PostComposer({ profile }: PostComposerProps) {
         <button type="submit" disabled={isPending}>
           Post
         </button>
+
+        {error && <p>{error.message}</p>}
       </fieldset>
     </form>
   );

--- a/packages/domain/src/entities/Transactions.ts
+++ b/packages/domain/src/entities/Transactions.ts
@@ -119,7 +119,7 @@ export enum TransactionErrorReason {
 export class TransactionError extends Error {
   name = 'TransactionError' as const;
 
-  constructor(readonly reason: TransactionErrorReason, readonly txHash?: string) {
-    super(`Transaction "${txHash as string}" failed due to: ${reason}`);
+  constructor(readonly reason: TransactionErrorReason) {
+    super(`Transaction failed due to: ${reason}`);
   }
 }

--- a/packages/domain/src/entities/__helpers__/mocks.ts
+++ b/packages/domain/src/entities/__helpers__/mocks.ts
@@ -253,8 +253,8 @@ export function mockProfile() {
   });
 }
 
-export function mockTransactionError(txHash: string = mockTransactionHash()) {
-  return new TransactionError(TransactionErrorReason.MINING_TIMEOUT, txHash);
+export function mockTransactionError() {
+  return new TransactionError(TransactionErrorReason.MINING_TIMEOUT);
 }
 
 export function mockNftOwnershipChallenge(): NftOwnershipChallenge {

--- a/packages/react/src/ErrorHandler.tsx
+++ b/packages/react/src/ErrorHandler.tsx
@@ -1,0 +1,1 @@
+export type ErrorHandler<T extends Error> = (error: T) => void;

--- a/packages/react/src/feed/useFeed.ts
+++ b/packages/react/src/feed/useFeed.ts
@@ -15,30 +15,15 @@ export function useFeed({
 }: UseFeedArgs): PaginatedReadResult<FeedItemFragment[]> {
   const { apolloClient, sources } = useSharedDependencies();
 
-  const { data, loading, ...rest }: PaginatedReadResult<FeedItemFragment[]> =
-    usePaginatedReadResult(
-      useFeedQuery({
-        variables: {
-          profileId,
-          observerId,
-          sources,
-          limit: limit ?? 10,
-        },
-        client: apolloClient,
-      }),
-    );
-
-  if (loading) {
-    return {
-      loading: true,
-      data: undefined,
-      ...rest,
-    };
-  }
-
-  return {
-    loading: false,
-    data,
-    ...rest,
-  };
+  return usePaginatedReadResult(
+    useFeedQuery({
+      variables: {
+        profileId,
+        observerId,
+        sources,
+        limit: limit ?? 10,
+      },
+      client: apolloClient,
+    }),
+  );
 }

--- a/packages/react/src/helpers.ts
+++ b/packages/react/src/helpers.ts
@@ -62,11 +62,12 @@ type PaginatedQueryResult<K> = {
   result: { pageInfo: CommonPaginatedResultInfoFragment; items: K };
 };
 
-export function usePaginatedReadResult<
-  K,
-  V,
-  T extends PaginatedQueryResult<K> = PaginatedQueryResult<K>,
->({ error, data, loading, fetchMore }: QueryResult<T, V>): PaginatedReadResult<K> {
+export function usePaginatedReadResult<K, V>({
+  error,
+  data,
+  loading,
+  fetchMore,
+}: QueryResult<PaginatedQueryResult<K>, V>): PaginatedReadResult<K> {
   return {
     ...buildReadResult<K>(data?.result.items, loading, error),
     totalCount: data?.result.pageInfo.totalCount ?? null,

--- a/packages/react/src/transactions/adapters/ProtocolCallRelayer.ts
+++ b/packages/react/src/transactions/adapters/ProtocolCallRelayer.ts
@@ -64,7 +64,7 @@ export class ProtocolCallRelayer implements IProtocolCallRelayer<SupportedTransa
         txHash: data.result.txHash,
       });
     } catch (err) {
-      this.logger.error(err, 'It was not possible to relay the transaction');
+      this.logger.error(err, `It was not possible to relay the transaction for ${signedCall.id}`);
       return failure(new TransactionError(TransactionErrorReason.CANNOT_EXECUTE));
     }
   }

--- a/packages/react/src/transactions/adapters/TransactionQueuePresenter.tsx
+++ b/packages/react/src/transactions/adapters/TransactionQueuePresenter.tsx
@@ -9,6 +9,8 @@ import {
 } from '@lens-protocol/domain/use-cases/transactions';
 import { CausedError } from '@lens-protocol/shared-kernel';
 
+import { ErrorHandler } from '../../ErrorHandler';
+
 export enum TxStatus {
   BROADCASTING = 'broadcasting',
   MINING = 'mining',
@@ -47,7 +49,7 @@ export class FailedTransactionError extends CausedError {
 export class TransactionQueuePresenter<T extends SupportedTransactionRequest>
   implements ITransactionQueuePresenter<T>
 {
-  constructor(private readonly errorHandler: (error: FailedTransactionError) => void) {}
+  constructor(private readonly errorHandler: ErrorHandler<FailedTransactionError>) {}
 
   clearRecent(): void {
     const transactions = recentTransactions();

--- a/packages/react/src/transactions/adapters/__tests__/PublicationCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/PublicationCallGateway.spec.ts
@@ -43,7 +43,7 @@ import {
 import { ChainType } from '@lens-protocol/shared-kernel';
 
 import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
-import { PublicationCallGateway } from '../PublicationCallGateway';
+import { FailedUploadError, PublicationCallGateway } from '../PublicationCallGateway';
 import { mockITransactionFactory } from '../__helpers__/mocks';
 
 function mockCreatePostTypedDataMutationMockedResponse({
@@ -87,10 +87,17 @@ function setupTestScenario({
   contentURI,
 }: {
   apolloClient: ApolloClient<NormalizedCacheObject>;
-  contentURI: string;
+  contentURI?: string;
 }) {
   const transactionFactory = mockITransactionFactory();
-  const uploadSpy = jest.fn().mockResolvedValue(contentURI);
+  const uploadSpy = jest.fn();
+
+  if (contentURI) {
+    uploadSpy.mockResolvedValue(contentURI);
+  } else {
+    uploadSpy.mockRejectedValue(new Error('Unknown error'));
+  }
+
   const gateway = new PublicationCallGateway(apolloClient, transactionFactory, uploadSpy);
 
   return { gateway, uploadSpy };
@@ -581,99 +588,114 @@ describe(`Given an instance of ${PublicationCallGateway.name}`, () => {
       },
     },
   ])(`and $description`, ({ createExerciseData }) => {
-    describe(`when creating a post`, () => {
-      const { requestVars, expectedMutationRequestDetails, expectedMetadata } =
-        createExerciseData();
-      const request = mockCreatePostRequest(requestVars);
-      const contentURI = faker.internet.url();
+    const { requestVars, expectedMutationRequestDetails, expectedMetadata } = createExerciseData();
+    const request = mockCreatePostRequest(requestVars);
+    const contentURI = faker.internet.url();
 
-      describe(`via the "${PublicationCallGateway.prototype.createUnsignedProtocolCall.name}" method`, () => {
-        it(`should:
+    describe(`when creating an ${UnsignedLensProtocolCall.name}<CreatePostRequest>`, () => {
+      it(`should:
             - upload the expected publication metadata
             - create an instance of the ${UnsignedLensProtocolCall.name} with the expected typed data`, async () => {
-          const createPostTypedDataMutation = mockCreatePostTypedDataMutation();
-          const apolloClient = createMockApolloClientWithMultipleResponses([
-            mockCreatePostTypedDataMutationMockedResponse({
-              variables: {
-                request: {
-                  profileId: request.profileId,
-                  contentURI,
-                  ...expectedMutationRequestDetails,
-                },
+        const createPostTypedDataMutation = mockCreatePostTypedDataMutation();
+        const apolloClient = createMockApolloClientWithMultipleResponses([
+          mockCreatePostTypedDataMutationMockedResponse({
+            variables: {
+              request: {
+                profileId: request.profileId,
+                contentURI,
+                ...expectedMutationRequestDetails,
               },
-              data: createPostTypedDataMutation,
-            }),
-          ]);
-          const { gateway, uploadSpy } = setupTestScenario({ apolloClient, contentURI });
+            },
+            data: createPostTypedDataMutation,
+          }),
+        ]);
+        const { gateway, uploadSpy } = setupTestScenario({ apolloClient, contentURI });
 
-          const unsignedCall = await gateway.createUnsignedProtocolCall(request);
+        const unsignedCall = await gateway.createUnsignedProtocolCall(request);
 
-          expect(uploadSpy).toHaveBeenCalledWith({
-            ...mandatoryFallbackMetadata(request),
-            ...expectedMetadata,
-          });
-          expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
-          expect(unsignedCall.typedData).toEqual(
-            omitTypename(createPostTypedDataMutation.result.typedData),
-          );
+        expect(uploadSpy).toHaveBeenCalledWith({
+          ...mandatoryFallbackMetadata(request),
+          ...expectedMetadata,
         });
-
-        it(`should be possible to override the signature nonce`, async () => {
-          const nonce = mockNonce();
-          const apolloClient = createMockApolloClientWithMultipleResponses([
-            mockCreatePostTypedDataMutationMockedResponse({
-              variables: {
-                request: {
-                  profileId: request.profileId,
-                  contentURI,
-                  ...expectedMutationRequestDetails,
-                },
-                options: {
-                  overrideSigNonce: nonce,
-                },
-              },
-              data: mockCreatePostTypedDataMutation({ nonce }),
-            }),
-          ]);
-          const { gateway } = setupTestScenario({ apolloClient, contentURI });
-
-          const unsignedCall = await gateway.createUnsignedProtocolCall(request, nonce);
-
-          expect(unsignedCall.nonce).toEqual(nonce);
-        });
+        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall.typedData).toEqual(
+          omitTypename(createPostTypedDataMutation.result.typedData),
+        );
       });
 
-      describe(`via the "${PublicationCallGateway.prototype.createDelegatedTransaction.name}" method`, () => {
-        it(`should create an instance of the ${NativeTransaction.name}`, async () => {
-          const apolloClient = createMockApolloClientWithMultipleResponses([
-            mockCreatePostViaDispatcherMutationMockedResponse({
-              variables: {
-                request: {
-                  profileId: request.profileId,
-                  contentURI,
-                  ...expectedMutationRequestDetails,
-                },
+      it(`should be possible to override the signature nonce`, async () => {
+        const nonce = mockNonce();
+        const apolloClient = createMockApolloClientWithMultipleResponses([
+          mockCreatePostTypedDataMutationMockedResponse({
+            variables: {
+              request: {
+                profileId: request.profileId,
+                contentURI,
+                ...expectedMutationRequestDetails,
               },
-              data: {
-                result: mockRelayerResultFragment(),
+              options: {
+                overrideSigNonce: nonce,
               },
-            }),
-          ]);
-          const { gateway } = setupTestScenario({ apolloClient, contentURI });
+            },
+            data: mockCreatePostTypedDataMutation({ nonce }),
+          }),
+        ]);
+        const { gateway } = setupTestScenario({ apolloClient, contentURI });
 
-          const transaction = await gateway.createDelegatedTransaction(request);
+        const unsignedCall = await gateway.createUnsignedProtocolCall(request, nonce);
 
-          await transaction.waitNextEvent();
-          expect(transaction).toBeInstanceOf(NativeTransaction);
-          expect(transaction).toEqual(
-            expect.objectContaining({
-              chainType: ChainType.POLYGON,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              id: expect.any(String),
-              request,
-            }),
-          );
-        });
+        expect(unsignedCall.nonce).toEqual(nonce);
+      });
+
+      it(`should throw a ${FailedUploadError.name} if the Publication Metadata upload fails`, async () => {
+        const apolloClient = createMockApolloClientWithMultipleResponses([]);
+        const { gateway } = setupTestScenario({ apolloClient });
+
+        await expect(() => gateway.createUnsignedProtocolCall(request)).rejects.toThrow(
+          FailedUploadError,
+        );
+      });
+    });
+
+    describe(`when creating a ${NativeTransaction.name}<CreatePostRequest>}" method`, () => {
+      it(`should create an instance of the ${NativeTransaction.name}`, async () => {
+        const apolloClient = createMockApolloClientWithMultipleResponses([
+          mockCreatePostViaDispatcherMutationMockedResponse({
+            variables: {
+              request: {
+                profileId: request.profileId,
+                contentURI,
+                ...expectedMutationRequestDetails,
+              },
+            },
+            data: {
+              result: mockRelayerResultFragment(),
+            },
+          }),
+        ]);
+        const { gateway } = setupTestScenario({ apolloClient, contentURI });
+
+        const transaction = await gateway.createDelegatedTransaction(request);
+
+        await transaction.waitNextEvent();
+        expect(transaction).toBeInstanceOf(NativeTransaction);
+        expect(transaction).toEqual(
+          expect.objectContaining({
+            chainType: ChainType.POLYGON,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            id: expect.any(String),
+            request,
+          }),
+        );
+      });
+
+      it(`should throw a ${FailedUploadError.name} if the Publication Metadata upload fails`, async () => {
+        const apolloClient = createMockApolloClientWithMultipleResponses([]);
+        const { gateway } = setupTestScenario({ apolloClient });
+
+        await expect(() => gateway.createDelegatedTransaction(request)).rejects.toThrow(
+          FailedUploadError,
+        );
       });
     });
   });

--- a/packages/react/src/transactions/adapters/responders/CreatePostResponder.ts
+++ b/packages/react/src/transactions/adapters/responders/CreatePostResponder.ts
@@ -26,12 +26,12 @@ import { invariant, never } from '@lens-protocol/shared-kernel';
 type FeedItemFragmentEntry = {
   __typename: 'FeedItem';
   root: Reference;
-  comments: Maybe<Array<Reference>>;
+  comments: Maybe<Reference[]>;
 };
 
 type PaginatedFeedResultEntry = {
   __typename: 'PaginatedFeedResult';
-  items: Array<FeedItemFragmentEntry>;
+  items: FeedItemFragmentEntry[];
   pageInfo: PaginatedResultInfo;
 };
 

--- a/packages/react/src/transactions/adapters/responders/__tests__/CreatePostResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/CreatePostResponder.spec.ts
@@ -99,6 +99,7 @@ describe(`Given an instance of the ${CreatePostResponder.name}`, () => {
       );
     });
   });
+
   describe(`when "${CreatePostResponder.prototype.commit.name}" method is invoked`, () => {
     const post = mockPostFragment();
     const transactionData = mockBroadcastedTransactionData({
@@ -127,6 +128,29 @@ describe(`Given an instance of the ${CreatePostResponder.name}`, () => {
           id: post.id,
         },
       });
+    });
+  });
+
+  describe(`when "${CreatePostResponder.prototype.rollback.name}" method is invoked`, () => {
+    const post = mockPostFragment();
+    const transactionData = mockBroadcastedTransactionData({
+      request: mockCreatePostRequest({
+        profileId: author.id,
+      }),
+    });
+
+    it(`should remove the FeedItem with the PendingPostFragment added during the "${CreatePostResponder.prototype.prepare.name}" method call`, async () => {
+      const scenario = setupTestScenario({
+        cachedFeedData,
+        author,
+        post,
+        transactionData,
+      });
+      await scenario.responder.prepare(transactionData);
+
+      await scenario.responder.rollback(transactionData);
+
+      expect(scenario.updatedFeedQuery).toMatchObject(cachedFeedData);
     });
   });
 });

--- a/packages/react/src/transactions/adapters/useCreatePostController.ts
+++ b/packages/react/src/transactions/adapters/useCreatePostController.ts
@@ -44,7 +44,7 @@ export function useCreatePostController({ upload }: UseCreatePostControllerArgs)
 
     const createPost = new CreatePost(signedCreatePost, gateway, transactionQueue, presenter);
 
-    void createPost.execute(request);
+    await createPost.execute(request);
 
     return presenter.asResult();
   };

--- a/packages/react/src/transactions/infrastructure/TransactionObserver.ts
+++ b/packages/react/src/transactions/infrastructure/TransactionObserver.ts
@@ -79,7 +79,7 @@ export class TransactionObserver implements ITransactionObserver {
           txResponse.wait(1),
 
           delay(this.timings.maxMiningWaitTime).then(() => {
-            throw new TransactionError(TransactionErrorReason.MINING_TIMEOUT, txHash);
+            throw new TransactionError(TransactionErrorReason.MINING_TIMEOUT);
           }),
         ]);
         return success();
@@ -90,7 +90,7 @@ export class TransactionObserver implements ITransactionObserver {
         throw e;
       }
     }
-    return failure(new TransactionError(TransactionErrorReason.MINING_TIMEOUT, txHash));
+    return failure(new TransactionError(TransactionErrorReason.MINING_TIMEOUT));
   }
 
   async waitForNextIndexingEvent(
@@ -148,7 +148,6 @@ export class TransactionObserver implements ITransactionObserver {
                 failure(
                   new TransactionError(
                     resolveTransactionErrorReason(nextResponse.data.result.reason),
-                    initialTxHash,
                   ),
                 ),
               );
@@ -157,9 +156,7 @@ export class TransactionObserver implements ITransactionObserver {
           if (Date.now() - startedAt > this.timings.maxIndexingWaitTime) {
             subscription.unsubscribe();
 
-            resolve(
-              failure(new TransactionError(TransactionErrorReason.INDEXING_TIMEOUT, initialTxHash)),
-            );
+            resolve(failure(new TransactionError(TransactionErrorReason.INDEXING_TIMEOUT)));
           }
         },
         error: reject,

--- a/packages/react/src/wallet/adapters/ConnectionErrorPresenter.tsx
+++ b/packages/react/src/wallet/adapters/ConnectionErrorPresenter.tsx
@@ -6,6 +6,7 @@ import {
 } from '@lens-protocol/domain/entities';
 import { IConnectionErrorPresenter } from '@lens-protocol/domain/use-cases/wallets';
 
+import { ErrorHandler } from '../../ErrorHandler';
 function isConnectionRequestCancelled(
   error: PendingSigningRequestError | UserRejectedError | WalletConnectionError,
 ) {
@@ -23,9 +24,9 @@ function isSigningRequestCancelled(
 
 export class ConnectionErrorPresenter implements IConnectionErrorPresenter {
   constructor(
-    private readonly errorHandler: (
-      error: PendingSigningRequestError | UserRejectedError | WalletConnectionError,
-    ) => void,
+    private readonly errorHandler: ErrorHandler<
+      PendingSigningRequestError | UserRejectedError | WalletConnectionError
+    >,
   ) {}
 
   presentConnectionError(


### PR DESCRIPTION
Changes
- Removes `txHash` from `TransactionError`. This was unused, occasionally `undefined` and source of confusion. The failure is anyway presented with the original Request Model object and if broadcasted the `txHash` so we have plenty of data to report to the user if need to.
- Adds rollback logic in case the tx fails
- Manages scenarios in which the Publication Metadata upload fails. This returns (wrapped in a `FailedUploadError`) back to the `useCreatePost` as `error` the developer can use to diagnose the issue and/or inform the user.