### PR TITLE
fix: fixes flash of logged-out content from example app

### DIFF
--- a/.changeset/modern-timers-suffer.md
+++ b/.changeset/modern-timers-suffer.md
@@ -1,0 +1,7 @@
+---
+"@lens-protocol/react": patch
+---
+
+Fixed flash of logged-out content in web-wagmi example app.
+
+Changed return type of `useActiveWallet` hook.

--- a/examples/web-wagmi/src/components/auth/LoginButton.tsx
+++ b/examples/web-wagmi/src/components/auth/LoginButton.tsx
@@ -2,12 +2,11 @@ import { useWalletLogin, useWalletLogout, WalletType } from '@lens-protocol/reac
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 
-import { useIsLoggedIn } from './auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from './auth';
 
 export function LoginButton() {
   const login = useWalletLogin();
   const logout = useWalletLogout();
-  const isLoggedIn = useIsLoggedIn();
 
   const { isDisconnected } = useAccount();
   const { connectAsync } = useConnect({
@@ -32,17 +31,19 @@ export function LoginButton() {
 
   return (
     <>
-      {!isLoggedIn && (
+      <WhenLoggedInWithProfile>
+        {() => (
+          <button onClick={onLogoutClick}>
+            <strong>Log out</strong>
+          </button>
+        )}
+      </WhenLoggedInWithProfile>
+
+      <WhenLoggedOut>
         <button onClick={onLoginClick}>
           <strong>Log in</strong>
         </button>
-      )}
-
-      {isLoggedIn && (
-        <button onClick={onLogoutClick}>
-          <strong>Log out</strong>
-        </button>
-      )}
+      </WhenLoggedOut>
     </>
   );
 }

--- a/examples/web-wagmi/src/components/auth/auth.tsx
+++ b/examples/web-wagmi/src/components/auth/auth.tsx
@@ -1,32 +1,38 @@
-import { ProfileFieldsFragment, useActiveProfile } from '@lens-protocol/react';
+import {
+  ProfileFieldsFragment,
+  useActiveProfile,
+  useActiveWallet,
+  WalletData,
+} from '@lens-protocol/react';
 import { ReactNode } from 'react';
-import { useAccount } from 'wagmi';
-
-export function useIsLoggedIn() {
-  const { address } = useAccount();
-  const { data: profile } = useActiveProfile();
-
-  return Boolean(address && profile);
-}
 
 type LoggedInConfig = {
-  walletAddress: `0x${string}`;
+  wallet: WalletData;
   profile: ProfileFieldsFragment;
 };
 
-export type WhenLoggedInProps = {
+export type WhenLoggedInWithProfileProps = {
   children: (config: LoggedInConfig) => ReactNode;
 };
 
-export function WhenLoggedIn({ children }: WhenLoggedInProps) {
-  const { address: walletAddress } = useAccount();
-  const { data: profile } = useActiveProfile();
+export function WhenLoggedInWithProfile({ children }: WhenLoggedInWithProfileProps) {
+  const { data: wallet, loading: walletLoading } = useActiveWallet();
+  const { data: profile, loading: profileLoading } = useActiveProfile();
 
-  if (!walletAddress || !profile) {
+  if (walletLoading || profileLoading) {
     return null;
   }
 
-  return <>{children({ walletAddress, profile })}</>;
+  if (wallet === null) {
+    return null;
+  }
+
+  if (profile === null) {
+    // TODO guide user to create profile
+    return null;
+  }
+
+  return <>{children({ wallet, profile })}</>;
 }
 
 export type WhenLoggedOutProps = {
@@ -34,9 +40,9 @@ export type WhenLoggedOutProps = {
 };
 
 export function WhenLoggedOut({ children }: WhenLoggedOutProps) {
-  const isLoggedIn = useIsLoggedIn();
+  const { data: wallet, loading } = useActiveWallet();
 
-  if (isLoggedIn) {
+  if (loading || wallet !== null) {
     return null;
   }
 

--- a/examples/web-wagmi/src/misc/UseNotifications.tsx
+++ b/examples/web-wagmi/src/misc/UseNotifications.tsx
@@ -1,7 +1,7 @@
 import { ProfileFieldsFragment, useNotifications } from '@lens-protocol/react';
 
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { NotificationItem } from './components/NotificationItem';
 
@@ -38,7 +38,9 @@ export function UseNotifications() {
   return (
     <>
       <h2>Notifications</h2>
-      <WhenLoggedIn>{({ profile }) => <NotificationsInner profile={profile} />}</WhenLoggedIn>
+      <WhenLoggedInWithProfile>
+        {({ profile }) => <NotificationsInner profile={profile} />}
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>You must be logged in to use this example.</p>

--- a/examples/web-wagmi/src/misc/UseUnreadNotificationCount.tsx
+++ b/examples/web-wagmi/src/misc/UseUnreadNotificationCount.tsx
@@ -1,7 +1,7 @@
 import { ProfileFieldsFragment, useUnreadNotificationCount } from '@lens-protocol/react';
 
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 
 type NotificationCountInnerProps = {
   profile: ProfileFieldsFragment;
@@ -30,7 +30,9 @@ export function UseUnreadNotificationCount() {
   return (
     <>
       <h2>Notification count</h2>
-      <WhenLoggedIn>{({ profile }) => <NotificationCountInner profile={profile} />}</WhenLoggedIn>
+      <WhenLoggedInWithProfile>
+        {({ profile }) => <NotificationCountInner profile={profile} />}
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>You must be logged in to use this example.</p>

--- a/examples/web-wagmi/src/profiles/UseFollowAndUnfollow.tsx
+++ b/examples/web-wagmi/src/profiles/UseFollowAndUnfollow.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
 
@@ -77,7 +77,9 @@ export function UseFollowAndUnfollow() {
       <h1>
         <code>useFollow / useUnFollow</code>
       </h1>
-      <WhenLoggedIn>{({ profile }) => <UseFollowInner activeProfile={profile} />}</WhenLoggedIn>
+      <WhenLoggedInWithProfile>
+        {({ profile }) => <UseFollowInner activeProfile={profile} />}
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>Log in to follow profiles.</p>

--- a/examples/web-wagmi/src/publications/UseCreateComment.tsx
+++ b/examples/web-wagmi/src/publications/UseCreateComment.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 import { CommentComposer } from './components/CommentComposer';
 import { PublicationComments } from './components/PublicationComments';
 
@@ -13,7 +13,7 @@ export function UseCreateComment() {
       <h1>
         <code>useCreateComment</code>
       </h1>
-      <WhenLoggedIn>
+      <WhenLoggedInWithProfile>
         {({ profile }) => (
           <>
             <p>
@@ -36,7 +36,7 @@ export function UseCreateComment() {
             )}
           </>
         )}
-      </WhenLoggedIn>
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>Log in to create a post.</p>

--- a/examples/web-wagmi/src/publications/UseCreateMirror.tsx
+++ b/examples/web-wagmi/src/publications/UseCreateMirror.tsx
@@ -6,7 +6,7 @@ import {
 } from '@lens-protocol/react';
 
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 import { Loading } from '../components/loading/Loading';
 import { PublicationCard } from './components/PublicationCard';
 
@@ -60,7 +60,9 @@ export function UseCreateMirror() {
       <h1>
         <code>useMirror</code>
       </h1>
-      <WhenLoggedIn>{({ profile }) => <MirrorInner profile={profile} />}</WhenLoggedIn>
+      <WhenLoggedInWithProfile>
+        {({ profile }) => <MirrorInner profile={profile} />}
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>You must be logged in to use this example.</p>

--- a/examples/web-wagmi/src/publications/UseCreatePost.tsx
+++ b/examples/web-wagmi/src/publications/UseCreatePost.tsx
@@ -1,5 +1,5 @@
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 import { MyFeed } from './components/MyFeed';
 import { PostComposer } from './components/PostComposer';
 
@@ -10,7 +10,7 @@ export function UseCreatePost() {
         <code>useCreatePost</code>
       </h1>
 
-      <WhenLoggedIn>
+      <WhenLoggedInWithProfile>
         {({ profile }) => (
           <>
             <PostComposer profile={profile} />
@@ -18,7 +18,7 @@ export function UseCreatePost() {
             <MyFeed profileId={profile.id} />
           </>
         )}
-      </WhenLoggedIn>
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>Log in to create a post.</p>

--- a/examples/web-wagmi/src/publications/UseReaction.tsx
+++ b/examples/web-wagmi/src/publications/UseReaction.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lens-protocol/react';
 
 import { LoginButton } from '../components/auth/LoginButton';
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth/auth';
+import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 import { Loading } from '../components/loading/Loading';
 import { PublicationCard } from './components/PublicationCard';
 
@@ -84,7 +84,9 @@ export function UseReaction() {
       <h1>
         <code>useReaction</code>
       </h1>
-      <WhenLoggedIn>{({ profile }) => <ReactionInner profile={profile} />}</WhenLoggedIn>
+      <WhenLoggedInWithProfile>
+        {({ profile }) => <ReactionInner profile={profile} />}
+      </WhenLoggedInWithProfile>
       <WhenLoggedOut>
         <div>
           <p>You must be logged in to use this example.</p>

--- a/packages/react/src/transactions/useFollow.ts
+++ b/packages/react/src/transactions/useFollow.ts
@@ -21,8 +21,8 @@ import {
 import { assertNever, EthereumAddress, invariant } from '@lens-protocol/shared-kernel';
 import { useState } from 'react';
 
-import { useActiveProfile } from '../profile';
-import { useActiveWallet } from '../wallet';
+import { useActiveProfileVar } from '../profile/adapters/ActiveProfilePresenter';
+import { useActiveWalletVar } from '../wallet/adapters/ActiveWalletPresenter';
 import { useFollowController } from './adapters/useFollowController';
 
 type FollowProfilesFlowRequest = {
@@ -94,8 +94,8 @@ export function useFollow({ profile }: UseFollowArgs) {
   >(null);
   const [isPending, setIsPending] = useState<boolean>(false);
   const follow = useFollowController();
-  const activeWallet = useActiveWallet();
-  const { data: activeProfile } = useActiveProfile();
+  const activeWallet = useActiveWalletVar();
+  const activeProfile = useActiveProfileVar();
 
   return {
     follow: async () => {

--- a/packages/react/src/wallet/adapters/ActiveWalletPresenter.ts
+++ b/packages/react/src/wallet/adapters/ActiveWalletPresenter.ts
@@ -9,6 +9,6 @@ export class ActiveWalletPresenter implements IActiveWalletPresenter {
   }
 }
 
-export const useActiveWallet = () => {
+export function useActiveWalletVar() {
   return useReactiveVar(activeWalletVar);
-};
+}

--- a/packages/react/src/wallet/index.ts
+++ b/packages/react/src/wallet/index.ts
@@ -1,6 +1,6 @@
+export * from './useActiveWallet';
 export * from './useWalletLogin';
 export * from './useWalletLogout';
-export { useActiveWallet } from './adapters/ActiveWalletPresenter';
 export type { LogoutHandler } from './adapters/LogoutPresenter';
 
 export { WalletType } from '@lens-protocol/domain/entities';

--- a/packages/react/src/wallet/useActiveWallet.ts
+++ b/packages/react/src/wallet/useActiveWallet.ts
@@ -1,0 +1,32 @@
+import { WalletData } from '@lens-protocol/domain/dist/use-cases/wallets';
+
+import { ReadResult } from '../helpers';
+import { ApplicationsState, useAppState } from '../lifecycle/adapters/ApplicationPresenter';
+import { useActiveWalletVar } from './adapters/ActiveWalletPresenter';
+
+export type { WalletData };
+
+export function useActiveWallet(): ReadResult<WalletData | null> {
+  const state = useAppState();
+
+  const wallet = useActiveWalletVar();
+
+  if (state === ApplicationsState.LOADING) {
+    return {
+      loading: true,
+      data: undefined,
+    };
+  }
+
+  if (!wallet) {
+    return {
+      loading: false,
+      data: null,
+    };
+  }
+
+  return {
+    loading: false,
+    data: wallet,
+  };
+}


### PR DESCRIPTION
It also aligns `useActiveWallet` to what `useActiveProfile` waits for.