### PR TITLE
feat: added RevenueAggregate.totalAmount: Amount<Erc20>

### DIFF
--- a/.changeset/rotten-candles-teach.md
+++ b/.changeset/rotten-candles-teach.md
@@ -1,0 +1,5 @@
+---
+"@lens-protocol/api-bindings": minor
+---
+
+Added `RevenueAggregate.totalAmount: Amount<Erc20>`

--- a/examples/web-wagmi/src/profiles/ProfilesPage.tsx
+++ b/examples/web-wagmi/src/profiles/ProfilesPage.tsx
@@ -27,11 +27,6 @@ const profileHooks = [
     path: '/profiles/useProfilesToFollow',
   },
   {
-    label: 'useSearchProfiles',
-    description: `Fetch a list of profiles that match a query`,
-    path: '/profiles/useSearchProfiles',
-  },
-  {
     label: 'useFollow / useUnfollow',
     description: `Follow or unfollow a profile.`,
     path: '/profiles/useFollow',

--- a/examples/web-wagmi/src/profiles/ProfilesPage.tsx
+++ b/examples/web-wagmi/src/profiles/ProfilesPage.tsx
@@ -27,6 +27,11 @@ const profileHooks = [
     path: '/profiles/useProfilesToFollow',
   },
   {
+    label: 'useSearchProfiles',
+    description: `Fetch a list of profiles that match a query`,
+    path: '/profiles/useSearchProfiles',
+  },
+  {
     label: 'useFollow / useUnfollow',
     description: `Follow or unfollow a profile.`,
     path: '/profiles/useFollow',

--- a/examples/web-wagmi/src/revenue/UseProfileFollowRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UseProfileFollowRevenue.tsx
@@ -21,7 +21,7 @@ function UseProfileFollowRevenueInner({ profileId }: { profileId: string }) {
       <h3>Follow revenue</h3>
       {publicationRevenue.length ? (
         publicationRevenue.map((revenue) => (
-          <RevenueCard key={revenue.total.asset.symbol} revenue={revenue} />
+          <RevenueCard key={revenue.totalAmount.asset.symbol} revenue={revenue} />
         ))
       ) : (
         <p>No revenue from following.</p>

--- a/examples/web-wagmi/src/revenue/components/RevenueCard.tsx
+++ b/examples/web-wagmi/src/revenue/components/RevenueCard.tsx
@@ -7,9 +7,9 @@ type RevenueCardProps = {
 export function RevenueCard({ revenue }: RevenueCardProps) {
   return (
     <article>
-      <p>{`Currency: ${revenue.total.asset.name} `}</p>
-      <p>{`Symbol: ${revenue.total.asset.symbol}`}</p>
-      <p>{`Amount: ${revenue.total.value}`}</p>
+      <p>{`Currency: ${revenue.totalAmount.asset.name} `}</p>
+      <p>{`Symbol: ${revenue.totalAmount.asset.symbol}`}</p>
+      <p>{`Amount: ${revenue.totalAmount.toFixed(2)}`}</p>
     </article>
   );
 }

--- a/packages/api-bindings/codegen-api.yml
+++ b/packages/api-bindings/codegen-api.yml
@@ -11,6 +11,7 @@ config:
     Attach: string
     BroadcastId: string
     ChainId: number
+    ClientErc20Amount: ClientErc20Amount
     ContractAddress: string
     Cursor: string
     DateTime: string
@@ -49,7 +50,11 @@ generates:
       - 'typescript':
           nonOptionalTypename: true
       - add:
-          content: "import type { ProfileAttributes } from './ProfileAttributes';"
+          content:
+            [
+              "import type { ClientErc20Amount } from './ClientErc20Amount';",
+              "import type { ProfileAttributes } from './ProfileAttributes';",
+            ]
       - 'typescript-operations':
           skipTypename: true
       - 'typescript-react-apollo'

--- a/packages/api-bindings/src/apollo/createApolloCache.ts
+++ b/packages/api-bindings/src/apollo/createApolloCache.ts
@@ -21,6 +21,7 @@ import { createProfileTypePolicy } from './createProfileTypePolicy';
 import { createProfilesFieldPolicy } from './createProfilesFieldPolicy';
 import { createPublicationTypePolicy } from './createPublicationTypePolicy';
 import { createPublicationsFieldPolicy } from './createPublicationsFieldPolicy';
+import { createRevenueAggregateTypePolicy } from './createRevenueAggregateTypePolicy';
 import { createSearchFieldPolicy } from './createSearchFieldPolicy';
 import { createWhoReactedPublicationFieldPolicy } from './createWhoReactedPublicationFieldPolicy';
 
@@ -67,6 +68,8 @@ function createTypePolicies(): TypePolicies {
     MediaSet: createMediaSetTypePolicy(),
     NftImage: createNftImageTypePolicy(),
     Media: createMediaTypePolicy(),
+
+    RevenueAggregate: createRevenueAggregateTypePolicy(),
 
     Query: {
       fields: {

--- a/packages/api-bindings/src/apollo/createRevenueAggregateTypePolicy.ts
+++ b/packages/api-bindings/src/apollo/createRevenueAggregateTypePolicy.ts
@@ -1,0 +1,15 @@
+import { never } from '@lens-protocol/shared-kernel';
+
+import { erc20Amount, RevenueAggregate } from '../graphql';
+import { TypePolicy } from './TypePolicy';
+
+export function createRevenueAggregateTypePolicy(): TypePolicy<RevenueAggregate> {
+  return {
+    fields: {
+      totalAmount(_, { readField }) {
+        const total = readField('total') ?? never('total is null');
+        return erc20Amount({ from: total });
+      },
+    },
+  };
+}

--- a/packages/api-bindings/src/graphql/ClientErc20Amount.ts
+++ b/packages/api-bindings/src/graphql/ClientErc20Amount.ts
@@ -1,0 +1,3 @@
+import { Amount, Erc20 } from '@lens-protocol/shared-kernel';
+
+export type ClientErc20Amount = Amount<Erc20>;

--- a/packages/api-bindings/src/graphql/__helpers__/fragments.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/fragments.ts
@@ -29,6 +29,7 @@ import {
   RevenueFragment,
   WhoReactedResultFragment,
 } from '../generated';
+import { erc20Amount } from '../utils';
 
 export function mockMediaFragment(overrides?: Partial<MediaFragment>): MediaFragment {
   return {
@@ -296,9 +297,11 @@ export function mockErc20AmountFragment(amount = mockDaiAmount(42)): Erc20Amount
 }
 
 function mockRevenueAggregateFragment(amount?: Amount<Erc20>): RevenueAggregateFragment {
+  const total = mockErc20AmountFragment(amount);
   return {
     __typename: 'RevenueAggregate',
-    total: mockErc20AmountFragment(amount),
+    __total: total,
+    totalAmount: erc20Amount({ from: total }),
   };
 }
 

--- a/packages/api-bindings/src/graphql/client.graphql
+++ b/packages/api-bindings/src/graphql/client.graphql
@@ -1,3 +1,4 @@
+scalar ClientErc20Amount
 scalar ProfileAttributes
 
 extend type Profile {
@@ -34,3 +35,7 @@ type PendingPost {
 }
 
 extend union FeedItemRoot = PendingPost
+
+extend type RevenueAggregate {
+  totalAmount: ClientErc20Amount!
+}

--- a/packages/api-bindings/src/graphql/generated.tsx
+++ b/packages/api-bindings/src/graphql/generated.tsx
@@ -1,3 +1,4 @@
+import type { ClientErc20Amount } from './ClientErc20Amount';
 import type { ProfileAttributes } from './ProfileAttributes';
 import gql from 'graphql-tag';
 import * as Apollo from '@apollo/client';
@@ -20,6 +21,7 @@ export type Scalars = {
   BroadcastId: string;
   /** ChainId custom scalar type */
   ChainId: number;
+  ClientErc20Amount: ClientErc20Amount;
   /** collect module data scalar type */
   CollectModuleData: unknown;
   /** ContentEncryptionKey scalar type */
@@ -3430,6 +3432,7 @@ export type ReservedClaimableHandle = {
 export type RevenueAggregate = {
   __typename: 'RevenueAggregate';
   total: Erc20Amount;
+  totalAmount: Scalars['ClientErc20Amount'];
 };
 
 export type RevertCollectModuleSettings = {
@@ -4622,9 +4625,10 @@ export type ReportPublicationMutationVariables = Exact<{
 
 export type ReportPublicationMutation = Pick<Mutation, 'reportPublication'>;
 
-export type RevenueAggregateFragment = { __typename: 'RevenueAggregate' } & {
-  total: Erc20AmountFragment;
-};
+export type RevenueAggregateFragment = { __typename: 'RevenueAggregate' } & Pick<
+  RevenueAggregate,
+  'totalAmount'
+> & { __total: Erc20AmountFragment };
 
 export type PublicationRevenueFragment = { __typename: 'PublicationRevenue' } & {
   publication: PostFragment | CommentFragment | MirrorFragment;
@@ -5399,9 +5403,10 @@ export const Erc20AmountFragmentDoc = gql`
 export const RevenueAggregateFragmentDoc = gql`
   fragment RevenueAggregate on RevenueAggregate {
     __typename
-    total {
+    __total: total {
       ...Erc20Amount
     }
+    totalAmount
   }
   ${Erc20AmountFragmentDoc}
 `;
@@ -10425,9 +10430,14 @@ export type ReservedClaimableHandleFieldPolicy = {
   source?: FieldPolicy<any> | FieldReadFunction<any>;
   expiry?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type RevenueAggregateKeySpecifier = ('total' | RevenueAggregateKeySpecifier)[];
+export type RevenueAggregateKeySpecifier = (
+  | 'total'
+  | 'totalAmount'
+  | RevenueAggregateKeySpecifier
+)[];
 export type RevenueAggregateFieldPolicy = {
   total?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalAmount?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type RevertCollectModuleSettingsKeySpecifier = (
   | 'type'

--- a/packages/api-bindings/src/graphql/revenue.graphql
+++ b/packages/api-bindings/src/graphql/revenue.graphql
@@ -1,8 +1,10 @@
 fragment RevenueAggregate on RevenueAggregate {
   __typename
-  total {
+  __total: total {
     ...Erc20Amount
   }
+
+  totalAmount
 }
 
 fragment PublicationRevenue on PublicationRevenue {


### PR DESCRIPTION
This PR extracts the excellent work done by @JoaquinBattilana in this PR: https://github.com/lens-protocol/lens-sdk/pull/76 so it's mergeable with most recent `main` changes.

It focused those changes to address just the `RevenueAggregate.totalAmount: Amount<Erc20>` local-only field.

It basically avoids changes to instances of `ModuleFeeAmount` simply because it make sense to be tackle as part of a new client scalar `FollowPolicy`  which will be taken care by @reecejohnson in https://github.com/lens-protocol/lens-sdk/pull/85.