### PR TITLE
chore: remove Fields suffix from fragments

### DIFF
--- a/.changeset/famous-keys-breathe.md
+++ b/.changeset/famous-keys-breathe.md
@@ -1,0 +1,6 @@
+---
+"@lens-protocol/api-bindings": minor
+"@lens-protocol/react": minor
+---
+
+Removes Fields suffix from GQL fragments type definitions

--- a/examples/web-wagmi/src/components/auth/auth.tsx
+++ b/examples/web-wagmi/src/components/auth/auth.tsx
@@ -1,5 +1,5 @@
 import {
-  ProfileFieldsFragment,
+  ProfileFragment,
   useActiveProfile,
   useActiveWallet,
   WalletData,
@@ -8,7 +8,7 @@ import { ReactNode } from 'react';
 
 type LoggedInConfig = {
   wallet: WalletData;
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export type WhenLoggedInWithProfileProps = {

--- a/examples/web-wagmi/src/misc/UseNotifications.tsx
+++ b/examples/web-wagmi/src/misc/UseNotifications.tsx
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment, useNotifications } from '@lens-protocol/react';
+import { ProfileFragment, useNotifications } from '@lens-protocol/react';
 
 import { LoginButton } from '../components/auth/LoginButton';
 import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
@@ -6,7 +6,7 @@ import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { NotificationItem } from './components/NotificationItem';
 
 type NotificationsInnerProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function NotificationsInner({ profile }: NotificationsInnerProps) {

--- a/examples/web-wagmi/src/misc/UseUnreadNotificationCount.tsx
+++ b/examples/web-wagmi/src/misc/UseUnreadNotificationCount.tsx
@@ -1,10 +1,10 @@
-import { ProfileFieldsFragment, useUnreadNotificationCount } from '@lens-protocol/react';
+import { ProfileFragment, useUnreadNotificationCount } from '@lens-protocol/react';
 
 import { LoginButton } from '../components/auth/LoginButton';
 import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 
 type NotificationCountInnerProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function NotificationCountInner({ profile }: NotificationCountInnerProps) {

--- a/examples/web-wagmi/src/misc/components/NotificationItem.tsx
+++ b/examples/web-wagmi/src/misc/components/NotificationItem.tsx
@@ -1,11 +1,11 @@
 import {
   Notification,
-  NewFollowerNotificationFieldsFragment,
-  NewCollectNotificationFieldsFragment,
-  NewCommentNotificationFieldsFragment,
-  NewMentionNotificationFieldsFragment,
-  NewMirrorNotificationFieldsFragment,
-  NewReactionNotificationFieldsFragment,
+  NewFollowerNotificationFragment,
+  NewCollectNotificationFragment,
+  NewCommentNotificationFragment,
+  NewMentionNotificationFragment,
+  NewMirrorNotificationFragment,
+  NewReactionNotificationFragment,
 } from '@lens-protocol/react';
 import { ReactNode } from 'react';
 
@@ -16,7 +16,7 @@ function NotificationItemWrapper({ children }: { children: ReactNode }) {
 function NewReactionNotification({
   notification,
 }: {
-  notification: NewReactionNotificationFieldsFragment;
+  notification: NewReactionNotificationFragment;
 }) {
   return (
     <NotificationItemWrapper>
@@ -27,11 +27,7 @@ function NewReactionNotification({
     </NotificationItemWrapper>
   );
 }
-function NewMirrorNotification({
-  notification,
-}: {
-  notification: NewMirrorNotificationFieldsFragment;
-}) {
+function NewMirrorNotification({ notification }: { notification: NewMirrorNotificationFragment }) {
   return (
     <NotificationItemWrapper>
       <p>
@@ -44,7 +40,7 @@ function NewMirrorNotification({
 function NewMentionNotification({
   notification,
 }: {
-  notification: NewMentionNotificationFieldsFragment;
+  notification: NewMentionNotificationFragment;
 }) {
   return (
     <NotificationItemWrapper>
@@ -59,7 +55,7 @@ function NewMentionNotification({
 function NewCommentNotification({
   notification,
 }: {
-  notification: NewCommentNotificationFieldsFragment;
+  notification: NewCommentNotificationFragment;
 }) {
   return (
     <NotificationItemWrapper>
@@ -74,7 +70,7 @@ function NewCommentNotification({
 function NewCollectNotification({
   notification,
 }: {
-  notification: NewCollectNotificationFieldsFragment;
+  notification: NewCollectNotificationFragment;
 }) {
   return (
     <NotificationItemWrapper>
@@ -89,7 +85,7 @@ function NewCollectNotification({
 function NewFollowerNotification({
   notification,
 }: {
-  notification: NewFollowerNotificationFieldsFragment;
+  notification: NewFollowerNotificationFragment;
 }) {
   return (
     <NotificationItemWrapper>

--- a/examples/web-wagmi/src/profiles/UseActiveProfileSwitch.tsx
+++ b/examples/web-wagmi/src/profiles/UseActiveProfileSwitch.tsx
@@ -1,7 +1,7 @@
 import {
   EthereumAddress,
   useProfilesOwnedBy,
-  ProfileFieldsFragment,
+  ProfileFragment,
   useActiveProfileSwitch,
 } from '@lens-protocol/react';
 import { useState } from 'react';
@@ -12,7 +12,7 @@ import { Loading } from '../components/loading/Loading';
 
 type ProfilesSwitcherProps = {
   address: EthereumAddress;
-  current: ProfileFieldsFragment;
+  current: ProfileFragment;
 };
 
 function ProfilesSwitcher({ address, current }: ProfilesSwitcherProps) {

--- a/examples/web-wagmi/src/profiles/UseFollowAndUnfollow.tsx
+++ b/examples/web-wagmi/src/profiles/UseFollowAndUnfollow.tsx
@@ -1,9 +1,4 @@
-import {
-  ProfileFieldsFragment,
-  useExploreProfiles,
-  useFollow,
-  useUnfollow,
-} from '@lens-protocol/react';
+import { ProfileFragment, useExploreProfiles, useFollow, useUnfollow } from '@lens-protocol/react';
 import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 
@@ -13,7 +8,7 @@ import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
 
 type FollowButtonProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 const toastNotification = (error: Error) => toast.error(error.message);
@@ -41,7 +36,7 @@ function FollowButton({ profile }: FollowButtonProps) {
 }
 
 type ProfileFollowProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function ProfileFollow({ profile }: ProfileFollowProps) {
@@ -54,7 +49,7 @@ function ProfileFollow({ profile }: ProfileFollowProps) {
 }
 
 type UseFollowInnerProps = {
-  activeProfile: ProfileFieldsFragment;
+  activeProfile: ProfileFragment;
 };
 
 function UseFollowInner({ activeProfile }: UseFollowInnerProps) {
@@ -64,7 +59,7 @@ function UseFollowInner({ activeProfile }: UseFollowInnerProps) {
 
   return (
     <>
-      {data.map((profile: ProfileFieldsFragment) => (
+      {data.map((profile: ProfileFragment) => (
         <ProfileFollow key={profile.handle} profile={profile} />
       ))}
     </>

--- a/examples/web-wagmi/src/profiles/UseProfilesToFollow.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfilesToFollow.tsx
@@ -1,10 +1,10 @@
-import { useProfilesToFollow, ProfileFieldsFragment } from '@lens-protocol/react';
+import { useProfilesToFollow, ProfileFragment } from '@lens-protocol/react';
 
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
 
 type ProfileListProps = {
-  profiles: ProfileFieldsFragment[];
+  profiles: ProfileFragment[];
 };
 
 function ProfileList({ profiles }: ProfileListProps) {

--- a/examples/web-wagmi/src/profiles/UseUpdateDispatcherConfig.tsx
+++ b/examples/web-wagmi/src/profiles/UseUpdateDispatcherConfig.tsx
@@ -1,11 +1,11 @@
-import { ProfileFieldsFragment, useUpdateDispatcherConfig } from '@lens-protocol/react';
+import { ProfileFragment, useUpdateDispatcherConfig } from '@lens-protocol/react';
 import { useState } from 'react';
 
 import { LoginButton } from '../components/auth/LoginButton';
 import { WhenLoggedInWithProfile, WhenLoggedOut } from '../components/auth/auth';
 
 type UpdateDispatcherConfigFormProps = {
-  activeProfile: ProfileFieldsFragment;
+  activeProfile: ProfileFragment;
 };
 
 function UpdateDispatcherConfigForm({ activeProfile }: UpdateDispatcherConfigFormProps) {

--- a/examples/web-wagmi/src/profiles/UseUpdateProfileDetails.tsx
+++ b/examples/web-wagmi/src/profiles/UseUpdateProfileDetails.tsx
@@ -1,14 +1,10 @@
-import {
-  ProfileFieldsFragment,
-  useActiveProfile,
-  useUpdateProfileDetails,
-} from '@lens-protocol/react';
+import { ProfileFragment, useActiveProfile, useUpdateProfileDetails } from '@lens-protocol/react';
 
 import { upload } from '../upload';
 import { ProfileCard } from './components/ProfileCard';
 
 type UpdateProfileFormProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function UpdateProfileForm({ profile }: UpdateProfileFormProps) {

--- a/examples/web-wagmi/src/profiles/UseUpdateProfileImage.tsx
+++ b/examples/web-wagmi/src/profiles/UseUpdateProfileImage.tsx
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment, useUpdateProfileImage } from '@lens-protocol/react';
+import { ProfileFragment, useUpdateProfileImage } from '@lens-protocol/react';
 import { ChangeEvent, useState } from 'react';
 
 import { LoginButton } from '../components/auth/LoginButton';
@@ -9,7 +9,7 @@ import { uploadImage } from '../upload';
 import { invariant } from '../utils';
 import { SmallProfileCard } from './components/ProfileCard';
 
-function UpdateUploadedImage({ profile }: { profile: ProfileFieldsFragment }) {
+function UpdateUploadedImage({ profile }: { profile: ProfileFragment }) {
   const [inputValue, setInputValue] = useState(
     'https://arweave.net/dOKOqiZVvSs14n54GIRH9nkSlLKArzK7-SPc2sBVmAM',
   );
@@ -43,7 +43,7 @@ function UpdateUploadedImage({ profile }: { profile: ProfileFieldsFragment }) {
   );
 }
 
-function UploadAndUpdateNewImage({ profile }: { profile: ProfileFieldsFragment }) {
+function UploadAndUpdateNewImage({ profile }: { profile: ProfileFragment }) {
   const [candidateFile, setCandidateFile] = useState<ILocalFile<ImageType> | null>(null);
   const [uploadError, setUploadError] = useState<Error | null>();
   const [isUploading, setIsUploading] = useState(false);
@@ -128,7 +128,7 @@ function UploadAndUpdateNewImage({ profile }: { profile: ProfileFieldsFragment }
   );
 }
 
-function UpdateProfileImageInner({ profile }: { profile: ProfileFieldsFragment }) {
+function UpdateProfileImageInner({ profile }: { profile: ProfileFragment }) {
   return (
     <div>
       <SmallProfileCard profile={profile} />

--- a/examples/web-wagmi/src/profiles/components/ProfileCard.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileCard.tsx
@@ -1,9 +1,9 @@
-import { ProfileFieldsFragment } from '@lens-protocol/react';
+import { ProfileFragment } from '@lens-protocol/react';
 
 import { ProfilePicture } from './ProfilePicture';
 
 type ProfileCardProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function ProfileCard({ profile }: ProfileCardProps) {
@@ -18,7 +18,7 @@ export function ProfileCard({ profile }: ProfileCardProps) {
 }
 
 type ProfileButtonProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function SmallProfileCard({ profile }: ProfileButtonProps) {

--- a/examples/web-wagmi/src/profiles/components/ProfilePicture.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfilePicture.tsx
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment } from '@lens-protocol/react';
+import { ProfileFragment } from '@lens-protocol/react';
 
 import { useBuildResourceSrc } from '../../hooks/useBuildResourceSrc';
 
@@ -37,7 +37,7 @@ function RemoteProfilePicture({ url }: RemoteProfilePictureProps) {
 }
 
 type ProfilePictureProps = {
-  picture: ProfileFieldsFragment['picture'];
+  picture: ProfileFragment['picture'];
 };
 
 export function ProfilePicture({ picture }: ProfilePictureProps) {

--- a/examples/web-wagmi/src/publications/UseCreateMirror.tsx
+++ b/examples/web-wagmi/src/publications/UseCreateMirror.tsx
@@ -1,5 +1,5 @@
 import {
-  ProfileFieldsFragment,
+  ProfileFragment,
   usePublication,
   useCreateMirror,
   isMirrorPublication,
@@ -11,7 +11,7 @@ import { Loading } from '../components/loading/Loading';
 import { PublicationCard } from './components/PublicationCard';
 
 type MirrorInnerProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function MirrorInner({ profile }: MirrorInnerProps) {

--- a/examples/web-wagmi/src/publications/UseHidePublication.tsx
+++ b/examples/web-wagmi/src/publications/UseHidePublication.tsx
@@ -1,5 +1,5 @@
 import {
-  ProfileFieldsFragment,
+  ProfileFragment,
   usePublication,
   useHidePublication,
   PublicationOwnedByMeFragment,
@@ -33,7 +33,7 @@ function HidePublicationButton({ publication }: HidePublicationButtonProps) {
 
 type HidePublicationInnerProps = {
   publicationId: string;
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function HidePublicationInner({ publicationId, profile }: HidePublicationInnerProps) {

--- a/examples/web-wagmi/src/publications/UseReaction.tsx
+++ b/examples/web-wagmi/src/publications/UseReaction.tsx
@@ -1,5 +1,5 @@
 import {
-  ProfileFieldsFragment,
+  ProfileFragment,
   Publication,
   ReactionType,
   usePublication,
@@ -52,7 +52,7 @@ function ReactionButton({ publication, profileId, reactionType }: ReactionButton
 }
 
 type ReactionInnerProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 function ReactionInner({ profile }: ReactionInnerProps) {

--- a/examples/web-wagmi/src/publications/components/CommentComposer.tsx
+++ b/examples/web-wagmi/src/publications/components/CommentComposer.tsx
@@ -1,7 +1,7 @@
 import {
   CollectPolicyType,
   ContentFocus,
-  ProfileFieldsFragment,
+  ProfileFragment,
   ReferencePolicy,
   useCreateComment,
 } from '@lens-protocol/react';
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import { upload } from '../../upload';
 
 type CommentComposerProps = {
-  activeProfile: ProfileFieldsFragment;
+  activeProfile: ProfileFragment;
   publicationId: string;
 };
 

--- a/examples/web-wagmi/src/publications/components/PostComposer.tsx
+++ b/examples/web-wagmi/src/publications/components/PostComposer.tsx
@@ -1,5 +1,5 @@
 import {
-  ProfileFieldsFragment,
+  ProfileFragment,
   useCreatePost,
   ContentFocus,
   CollectPolicyType,
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import { upload } from '../../upload';
 
 export type PostComposerProps = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function PostComposer({ profile }: PostComposerProps) {

--- a/packages/api-bindings/src/apollo/__tests__/ApolloCache.spec.ts
+++ b/packages/api-bindings/src/apollo/__tests__/ApolloCache.spec.ts
@@ -2,14 +2,14 @@ import { ApolloCache, makeVar } from '@apollo/client';
 import { WalletData } from '@lens-protocol/domain/use-cases/wallets';
 import { never } from '@lens-protocol/shared-kernel';
 
-import { ProfileFieldsFragment, ProfileFieldsFragmentDoc } from '../../graphql';
-import { mockAttributeFragment, mockProfileFieldsFragment } from '../../mocks';
+import { ProfileFragment, ProfileFragmentDoc } from '../../graphql';
+import { mockAttributeFragment, mockProfileFragment } from '../../mocks';
 import { createApolloCache } from '../createApolloCache';
 
 describe(`Given an instance of the ${ApolloCache.name}`, () => {
-  describe('when retrieving a ProfileFieldsFragment with attributes', () => {
+  describe('when retrieving a ProfileFragment with attributes', () => {
     const date = new Date();
-    const profile = mockProfileFieldsFragment({
+    const profile = mockProfileFragment({
       __attributes: [
         mockAttributeFragment({
           key: 'validDate',
@@ -44,14 +44,14 @@ describe(`Given an instance of the ${ApolloCache.name}`, () => {
     const cache = createApolloCache({ activeWalletVar: makeVar<WalletData | null>(null) });
     cache.writeFragment({
       data: profile,
-      fragment: ProfileFieldsFragmentDoc,
-      fragmentName: 'ProfileFields',
+      fragment: ProfileFragmentDoc,
+      fragmentName: 'Profile',
     });
 
     const read =
-      cache.readFragment<ProfileFieldsFragment>({
-        fragment: ProfileFieldsFragmentDoc,
-        fragmentName: 'ProfileFields',
+      cache.readFragment<ProfileFragment>({
+        fragment: ProfileFragmentDoc,
+        fragmentName: 'Profile',
         id: cache.identify(profile),
       }) ?? never();
 

--- a/packages/api-bindings/src/graphql/__helpers__/fragments.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/fragments.ts
@@ -15,7 +15,7 @@ import {
   MetadataFragment,
   MirrorFragment,
   PostFragment,
-  ProfileFieldsFragment,
+  ProfileFragment,
   ProfileFollowRevenueFragment,
   ProfileMediaFragment,
   PublicationMainFocus,
@@ -64,14 +64,12 @@ export function mockAttributeFragment(overrides?: Partial<AttributeFragment>): A
 export function mockWalletFragment(): WalletFragment {
   return {
     __typename: 'Wallet',
-    defaultProfile: mockProfileFieldsFragment(),
+    defaultProfile: mockProfileFragment(),
     address: mockEthereumAddress(),
   };
 }
 
-export function mockProfileFieldsFragment(
-  overrides?: Partial<ProfileFieldsFragment>,
-): ProfileFieldsFragment {
+export function mockProfileFragment(overrides?: Partial<ProfileFragment>): ProfileFragment {
   const firstName = faker.name.firstName();
   const lastName = faker.name.lastName();
 
@@ -166,7 +164,7 @@ export function mockPostFragment(
     createdAt: faker.datatype.datetime().toISOString(),
     stats: mockPublicationStatsFragment(),
     metadata: mockMetadataFragment(),
-    profile: mockProfileFieldsFragment(),
+    profile: mockProfileFragment(),
     collectedBy: null,
     collectModule: mockFreeCollectModuleSettings(),
     referenceModule: null,
@@ -205,7 +203,7 @@ export function mockCommentFragment(
       content: faker.lorem.paragraph(1),
       media: [],
     },
-    profile: mockProfileFieldsFragment(),
+    profile: mockProfileFragment(),
     createdAt: faker.date.past().toISOString(),
     collectedBy: null,
     commentOn: mainPost,
@@ -247,7 +245,7 @@ export function mockMirrorFragment(
       content: faker.lorem.paragraph(1),
       media: [],
     },
-    profile: mockProfileFieldsFragment(),
+    profile: mockProfileFragment(),
     createdAt: faker.date.past().toISOString(),
     collectModule: mockFreeCollectModuleSettings(),
     referenceModule: null,
@@ -357,7 +355,7 @@ export function mockWhoReactedResultFragment(
     reactionId: faker.datatype.uuid(),
     reaction: ReactionTypes.Upvote,
     reactionAt: faker.date.past().toISOString(),
-    profile: mockProfileFieldsFragment(),
+    profile: mockProfileFragment(),
     ...overrides,
   };
 }

--- a/packages/api-bindings/src/graphql/__helpers__/queries.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/queries.ts
@@ -28,7 +28,7 @@ import {
   MutualFollowersProfilesQuery,
   MutualFollowersProfilesQueryVariables,
   PostFragment,
-  ProfileFieldsFragment,
+  ProfileFragment,
   ProfileFollowRevenueDocument,
   ProfileFollowRevenueFragment,
   ProfileFollowRevenueQuery,
@@ -73,10 +73,10 @@ import {
   WhoReactedPublicationQueryVariables,
   WhoReactedResultFragment,
 } from '../generated';
-import { mockFeedItemFragment, mockPostFragment, mockProfileFieldsFragment } from './fragments';
+import { mockFeedItemFragment, mockPostFragment, mockProfileFragment } from './fragments';
 
 export function createProfilesToFollowQueryMockedResponse(args: {
-  profiles: ProfileFieldsFragment[];
+  profiles: ProfileFragment[];
 }): MockedResponse<ProfilesToFollowQuery> {
   return {
     request: {
@@ -90,18 +90,18 @@ export function createProfilesToFollowQueryMockedResponse(args: {
   };
 }
 
-export function mockGetProfileQuery(profile: Maybe<ProfileFieldsFragment>): GetProfileQuery {
+export function mockGetProfileQuery(profile: Maybe<ProfileFragment>): GetProfileQuery {
   return {
     result: profile,
   };
 }
 
 export function mockGetProfileQueryMockedResponse({
-  profile = mockProfileFieldsFragment(),
+  profile = mockProfileFragment(),
   request,
   observerId,
 }: {
-  profile?: Maybe<ProfileFieldsFragment>;
+  profile?: Maybe<ProfileFragment>;
   request: SingleProfileQueryRequest;
   observerId?: string;
 }): MockedResponse<GetProfileQuery> {
@@ -120,7 +120,7 @@ export function mockGetProfileQueryMockedResponse({
 }
 
 function mockGetAllProfilesByOwnerAddressQuery(
-  profiles: ProfileFieldsFragment[],
+  profiles: ProfileFragment[],
 ): GetAllProfilesByOwnerAddressQuery {
   return {
     result: {
@@ -137,13 +137,13 @@ function mockGetAllProfilesByOwnerAddressQuery(
 
 export function createGetAllProfilesByOwnerAddressQueryMockedResponse({
   address,
-  profiles = [mockProfileFieldsFragment()],
+  profiles = [mockProfileFragment()],
   observerId,
   limit = 10,
   cursor,
 }: {
   address: EthereumAddress;
-  profiles?: ProfileFieldsFragment[];
+  profiles?: ProfileFragment[];
   observerId?: string;
   limit?: number;
   cursor?: string;
@@ -288,7 +288,7 @@ export function createWhoCollectedPublicationQueryMockedResponse(args: {
 
 export function createMutualFollowersQueryMockedResponse(args: {
   variables: MutualFollowersProfilesQueryVariables;
-  profiles: ProfileFieldsFragment[];
+  profiles: ProfileFragment[];
 }): MockedResponse<MutualFollowersProfilesQuery> {
   return {
     request: {
@@ -517,7 +517,7 @@ export function createProfileFollowRevenueQueryMockedResponse({
 
 export function createSearchProfilesQueryMockedResponse(args: {
   variables: SearchProfilesQueryVariables;
-  items: ProfileFieldsFragment[];
+  items: ProfileFragment[];
 }): MockedResponse<SearchProfilesQuery> {
   return {
     request: {

--- a/packages/api-bindings/src/graphql/common.graphql
+++ b/packages/api-bindings/src/graphql/common.graphql
@@ -120,7 +120,7 @@ fragment Wallet on Wallet {
   __typename
   address
   defaultProfile {
-    ...ProfileFields
+    ...Profile
   }
 }
 
@@ -175,7 +175,7 @@ fragment MirrorBase on Mirror {
     ...Metadata
   }
   profile {
-    ...ProfileFields
+    ...Profile
   }
   collectModule {
     ...CollectModule
@@ -223,7 +223,7 @@ fragment CommentBase on Comment {
     ...Metadata
   }
   profile {
-    ...ProfileFields
+    ...Profile
   }
   collectedBy {
     ...Wallet
@@ -295,7 +295,7 @@ fragment Post on Post {
     ...Metadata
   }
   profile {
-    ...ProfileFields
+    ...Profile
   }
   collectedBy {
     ...Wallet
@@ -331,7 +331,7 @@ fragment PendingPost on PendingPost {
     ...Media
   }
   profile {
-    ...ProfileFields
+    ...Profile
   }
   locale
   mainContentFocus

--- a/packages/api-bindings/src/graphql/feed.graphql
+++ b/packages/api-bindings/src/graphql/feed.graphql
@@ -46,7 +46,7 @@ query ExploreProfiles($observerId: ProfileId, $limit: LimitScalar!, $cursor: Cur
     request: { limit: $limit, cursor: $cursor, sortCriteria: MOST_COMMENTS }
   ) {
     items {
-      ...ProfileFields
+      ...Profile
     }
     pageInfo {
       ...CommonPaginatedResultInfo

--- a/packages/api-bindings/src/graphql/generated.tsx
+++ b/packages/api-bindings/src/graphql/generated.tsx
@@ -4031,7 +4031,7 @@ export type CollectModuleFragment =
   | CollectModule_UnknownCollectModuleSettings_Fragment;
 
 export type WalletFragment = { __typename: 'Wallet' } & Pick<Wallet, 'address'> & {
-    defaultProfile: Maybe<ProfileFieldsFragment>;
+    defaultProfile: Maybe<ProfileFragment>;
   };
 
 export type MediaFragment = { __typename: 'Media' } & Pick<Media, 'url' | 'mimeType'>;
@@ -4066,7 +4066,7 @@ export type MirrorBaseFragment = { __typename: 'Mirror' } & Pick<
 > & {
     stats: PublicationStatsFragment;
     metadata: MetadataFragment;
-    profile: ProfileFieldsFragment;
+    profile: ProfileFragment;
     collectModule:
       | CollectModule_FreeCollectModuleSettings_Fragment
       | CollectModule_FeeCollectModuleSettings_Fragment
@@ -4102,7 +4102,7 @@ export type CommentBaseFragment = { __typename: 'Comment' } & Pick<
 > & {
     stats: PublicationStatsFragment;
     metadata: MetadataFragment;
-    profile: ProfileFieldsFragment;
+    profile: ProfileFragment;
     collectedBy: Maybe<WalletFragment>;
     collectModule:
       | CollectModule_FreeCollectModuleSettings_Fragment
@@ -4145,7 +4145,7 @@ export type PostFragment = { __typename: 'Post' } & Pick<
 > & {
     stats: PublicationStatsFragment;
     metadata: MetadataFragment;
-    profile: ProfileFieldsFragment;
+    profile: ProfileFragment;
     collectedBy: Maybe<WalletFragment>;
     collectModule:
       | CollectModule_FreeCollectModuleSettings_Fragment
@@ -4167,7 +4167,7 @@ export type PostFragment = { __typename: 'Post' } & Pick<
 export type PendingPostFragment = { __typename: 'PendingPost' } & Pick<
   PendingPost,
   'id' | 'content' | 'locale' | 'mainContentFocus'
-> & { media: Maybe<Array<MediaFragment>>; profile: ProfileFieldsFragment };
+> & { media: Maybe<Array<MediaFragment>>; profile: ProfileFragment };
 
 export type Eip712TypedDataDomainFragment = { __typename: 'EIP712TypedDataDomain' } & Pick<
   Eip712TypedDataDomain,
@@ -4203,7 +4203,7 @@ export type ExploreProfilesQueryVariables = Exact<{
 }>;
 
 export type ExploreProfilesQuery = {
-  result: { items: Array<ProfileFieldsFragment>; pageInfo: CommonPaginatedResultInfoFragment };
+  result: { items: Array<ProfileFragment>; pageInfo: CommonPaginatedResultInfoFragment };
 };
 
 export type CreateFollowTypedDataMutationVariables = Exact<{
@@ -4254,17 +4254,16 @@ export type CreateMirrorViaDispatcherMutation = {
   result: RelayerResultFragment | RelayErrorFragment;
 };
 
-export type CommentWithCommentedPublicationFieldsFragment = { __typename: 'Comment' } & {
+export type CommentWithCommentedPublicationFragment = { __typename: 'Comment' } & {
   commentOn: Maybe<PostFragment | CommentFragment | MirrorFragment>;
 } & CommentFragment;
 
-export type NewFollowerNotificationFieldsFragment = {
-  __typename: 'NewFollowerNotification';
-} & Pick<NewFollowerNotification, 'notificationId' | 'createdAt' | 'isFollowedByMe'> & {
-    wallet: WalletFragment;
-  };
+export type NewFollowerNotificationFragment = { __typename: 'NewFollowerNotification' } & Pick<
+  NewFollowerNotification,
+  'notificationId' | 'createdAt' | 'isFollowedByMe'
+> & { wallet: WalletFragment };
 
-export type NewCollectNotificationFieldsFragment = { __typename: 'NewCollectNotification' } & Pick<
+export type NewCollectNotificationFragment = { __typename: 'NewCollectNotification' } & Pick<
   NewCollectNotification,
   'notificationId' | 'createdAt'
 > & {
@@ -4272,27 +4271,25 @@ export type NewCollectNotificationFieldsFragment = { __typename: 'NewCollectNoti
     collectedPublication: PostFragment | CommentFragment | MirrorFragment;
   };
 
-export type NewMirrorNotificationFieldsFragment = { __typename: 'NewMirrorNotification' } & Pick<
+export type NewMirrorNotificationFragment = { __typename: 'NewMirrorNotification' } & Pick<
   NewMirrorNotification,
   'notificationId' | 'createdAt'
-> & { profile: ProfileFieldsFragment; publication: PostFragment | CommentFragment };
+> & { profile: ProfileFragment; publication: PostFragment | CommentFragment };
 
-export type NewCommentNotificationFieldsFragment = { __typename: 'NewCommentNotification' } & Pick<
+export type NewCommentNotificationFragment = { __typename: 'NewCommentNotification' } & Pick<
   NewCommentNotification,
   'notificationId' | 'createdAt'
-> & { profile: ProfileFieldsFragment; comment: CommentWithCommentedPublicationFieldsFragment };
+> & { profile: ProfileFragment; comment: CommentWithCommentedPublicationFragment };
 
-export type NewMentionNotificationFieldsFragment = { __typename: 'NewMentionNotification' } & Pick<
+export type NewMentionNotificationFragment = { __typename: 'NewMentionNotification' } & Pick<
   NewMentionNotification,
   'notificationId' | 'createdAt'
 > & { mentionPublication: PostFragment | CommentFragment };
 
-export type NewReactionNotificationFieldsFragment = {
-  __typename: 'NewReactionNotification';
-} & Pick<NewReactionNotification, 'notificationId' | 'createdAt' | 'reaction'> & {
-    profile: ProfileFieldsFragment;
-    publication: PostFragment | CommentFragment | MirrorFragment;
-  };
+export type NewReactionNotificationFragment = { __typename: 'NewReactionNotification' } & Pick<
+  NewReactionNotification,
+  'notificationId' | 'createdAt' | 'reaction'
+> & { profile: ProfileFragment; publication: PostFragment | CommentFragment | MirrorFragment };
 
 export type NotificationsQueryVariables = Exact<{
   observerId: Scalars['ProfileId'];
@@ -4304,12 +4301,12 @@ export type NotificationsQueryVariables = Exact<{
 export type NotificationsQuery = {
   result: {
     items: Array<
-      | NewFollowerNotificationFieldsFragment
-      | NewCollectNotificationFieldsFragment
-      | NewCommentNotificationFieldsFragment
-      | NewMirrorNotificationFieldsFragment
-      | NewMentionNotificationFieldsFragment
-      | NewReactionNotificationFieldsFragment
+      | NewFollowerNotificationFragment
+      | NewCollectNotificationFragment
+      | NewCommentNotificationFragment
+      | NewMirrorNotificationFragment
+      | NewMentionNotificationFragment
+      | NewReactionNotificationFragment
     >;
     pageInfo: CommonPaginatedResultInfoFragment;
   };
@@ -4412,7 +4409,7 @@ export type AttributeFragment = { __typename: 'Attribute' } & Pick<
   'displayType' | 'key' | 'value'
 >;
 
-export type ProfileFieldsFragment = { __typename: 'Profile' } & Pick<
+export type ProfileFragment = { __typename: 'Profile' } & Pick<
   Profile,
   | 'id'
   | 'name'
@@ -4443,14 +4440,14 @@ export type ProfilesToFollowQueryVariables = Exact<{
   observerId?: Maybe<Scalars['ProfileId']>;
 }>;
 
-export type ProfilesToFollowQuery = { result: Array<ProfileFieldsFragment> };
+export type ProfilesToFollowQuery = { result: Array<ProfileFragment> };
 
 export type GetProfileQueryVariables = Exact<{
   request: SingleProfileQueryRequest;
   observerId?: Maybe<Scalars['ProfileId']>;
 }>;
 
-export type GetProfileQuery = { result: Maybe<ProfileFieldsFragment> };
+export type GetProfileQuery = { result: Maybe<ProfileFragment> };
 
 export type GetAllProfilesByOwnerAddressQueryVariables = Exact<{
   address: Scalars['EthereumAddress'];
@@ -4460,7 +4457,7 @@ export type GetAllProfilesByOwnerAddressQueryVariables = Exact<{
 }>;
 
 export type GetAllProfilesByOwnerAddressQuery = {
-  result: { items: Array<ProfileFieldsFragment>; pageInfo: CommonPaginatedResultInfoFragment };
+  result: { items: Array<ProfileFragment>; pageInfo: CommonPaginatedResultInfoFragment };
 };
 
 export type CreateProfileMutationVariables = Exact<{
@@ -4477,7 +4474,7 @@ export type MutualFollowersProfilesQueryVariables = Exact<{
 }>;
 
 export type MutualFollowersProfilesQuery = {
-  result: { items: Array<ProfileFieldsFragment>; pageInfo: CommonPaginatedResultInfoFragment };
+  result: { items: Array<ProfileFragment>; pageInfo: CommonPaginatedResultInfoFragment };
 };
 
 export type CreateSetProfileImageUriTypedDataMutationVariables = Exact<{
@@ -4538,7 +4535,7 @@ export type CreateSetProfileMetadataViaDispatcherMutation = {
 
 export type FollowerFragment = { __typename: 'Follower' } & { wallet: WalletFragment };
 
-export type FollowingFragment = { __typename: 'Following' } & { profile: ProfileFieldsFragment };
+export type FollowingFragment = { __typename: 'Following' } & { profile: ProfileFragment };
 
 export type ProfileFollowersQueryVariables = Exact<{
   profileId: Scalars['ProfileId'];
@@ -4671,7 +4668,7 @@ export type RemoveReactionMutation = Pick<Mutation, 'removeReaction'>;
 export type WhoReactedResultFragment = { __typename: 'WhoReactedResult' } & Pick<
   WhoReactedResult,
   'reactionId' | 'reaction' | 'reactionAt'
-> & { profile: ProfileFieldsFragment };
+> & { profile: ProfileFragment };
 
 export type WhoReactedPublicationQueryVariables = Exact<{
   limit?: Maybe<Scalars['LimitScalar']>;
@@ -4748,7 +4745,7 @@ export type SearchProfilesQueryVariables = Exact<{
 
 export type SearchProfilesQuery = {
   result: { __typename: 'ProfileSearchResult' } & {
-    items: Array<ProfileFieldsFragment>;
+    items: Array<ProfileFragment>;
     pageInfo: CommonPaginatedResultInfoFragment;
   };
 };
@@ -4927,8 +4924,8 @@ export const AttributeFragmentDoc = gql`
     value
   }
 `;
-export const ProfileFieldsFragmentDoc = gql`
-  fragment ProfileFields on Profile {
+export const ProfileFragmentDoc = gql`
+  fragment Profile on Profile {
     __typename
     id
     name
@@ -4982,10 +4979,10 @@ export const WalletFragmentDoc = gql`
     __typename
     address
     defaultProfile {
-      ...ProfileFields
+      ...Profile
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
 `;
 export const FreeCollectModuleSettingsFragmentDoc = gql`
   fragment FreeCollectModuleSettings on FreeCollectModuleSettings {
@@ -5104,7 +5101,7 @@ export const CommentBaseFragmentDoc = gql`
       ...Metadata
     }
     profile {
-      ...ProfileFields
+      ...Profile
     }
     collectedBy {
       ...Wallet
@@ -5132,7 +5129,7 @@ export const CommentBaseFragmentDoc = gql`
   }
   ${PublicationStatsFragmentDoc}
   ${MetadataFragmentDoc}
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${WalletFragmentDoc}
   ${CollectModuleFragmentDoc}
   ${ReferenceModuleFragmentDoc}
@@ -5148,7 +5145,7 @@ export const PostFragmentDoc = gql`
       ...Metadata
     }
     profile {
-      ...ProfileFields
+      ...Profile
     }
     collectedBy {
       ...Wallet
@@ -5176,7 +5173,7 @@ export const PostFragmentDoc = gql`
   }
   ${PublicationStatsFragmentDoc}
   ${MetadataFragmentDoc}
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${WalletFragmentDoc}
   ${CollectModuleFragmentDoc}
   ${ReferenceModuleFragmentDoc}
@@ -5192,7 +5189,7 @@ export const MirrorBaseFragmentDoc = gql`
       ...Metadata
     }
     profile {
-      ...ProfileFields
+      ...Profile
     }
     collectModule {
       ...CollectModule
@@ -5216,7 +5213,7 @@ export const MirrorBaseFragmentDoc = gql`
   }
   ${PublicationStatsFragmentDoc}
   ${MetadataFragmentDoc}
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${CollectModuleFragmentDoc}
   ${ReferenceModuleFragmentDoc}
 `;
@@ -5275,13 +5272,13 @@ export const PendingPostFragmentDoc = gql`
       ...Media
     }
     profile {
-      ...ProfileFields
+      ...Profile
     }
     locale
     mainContentFocus
   }
   ${MediaFragmentDoc}
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
 `;
 export const Eip712TypedDataDomainFragmentDoc = gql`
   fragment EIP712TypedDataDomain on EIP712TypedDataDomain {
@@ -5310,8 +5307,8 @@ export const FeedItemFragmentDoc = gql`
   ${PostFragmentDoc}
   ${CommentFragmentDoc}
 `;
-export const NewFollowerNotificationFieldsFragmentDoc = gql`
-  fragment NewFollowerNotificationFields on NewFollowerNotification {
+export const NewFollowerNotificationFragmentDoc = gql`
+  fragment NewFollowerNotification on NewFollowerNotification {
     __typename
     notificationId
     createdAt
@@ -5339,8 +5336,8 @@ export const MirrorFragmentDoc = gql`
   ${PostFragmentDoc}
   ${CommentFragmentDoc}
 `;
-export const NewCollectNotificationFieldsFragmentDoc = gql`
-  fragment NewCollectNotificationFields on NewCollectNotification {
+export const NewCollectNotificationFragmentDoc = gql`
+  fragment NewCollectNotification on NewCollectNotification {
     __typename
     notificationId
     createdAt
@@ -5364,13 +5361,13 @@ export const NewCollectNotificationFieldsFragmentDoc = gql`
   ${MirrorFragmentDoc}
   ${CommentFragmentDoc}
 `;
-export const NewMirrorNotificationFieldsFragmentDoc = gql`
-  fragment NewMirrorNotificationFields on NewMirrorNotification {
+export const NewMirrorNotificationFragmentDoc = gql`
+  fragment NewMirrorNotification on NewMirrorNotification {
     __typename
     notificationId
     createdAt
     profile {
-      ...ProfileFields
+      ...Profile
     }
     publication {
       ... on Post {
@@ -5381,12 +5378,12 @@ export const NewMirrorNotificationFieldsFragmentDoc = gql`
       }
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${PostFragmentDoc}
   ${CommentFragmentDoc}
 `;
-export const CommentWithCommentedPublicationFieldsFragmentDoc = gql`
-  fragment CommentWithCommentedPublicationFields on Comment {
+export const CommentWithCommentedPublicationFragmentDoc = gql`
+  fragment CommentWithCommentedPublication on Comment {
     __typename
     ...Comment
     commentOn {
@@ -5405,23 +5402,23 @@ export const CommentWithCommentedPublicationFieldsFragmentDoc = gql`
   ${PostFragmentDoc}
   ${MirrorFragmentDoc}
 `;
-export const NewCommentNotificationFieldsFragmentDoc = gql`
-  fragment NewCommentNotificationFields on NewCommentNotification {
+export const NewCommentNotificationFragmentDoc = gql`
+  fragment NewCommentNotification on NewCommentNotification {
     __typename
     notificationId
     createdAt
     profile {
-      ...ProfileFields
+      ...Profile
     }
     comment {
-      ...CommentWithCommentedPublicationFields
+      ...CommentWithCommentedPublication
     }
   }
-  ${ProfileFieldsFragmentDoc}
-  ${CommentWithCommentedPublicationFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
+  ${CommentWithCommentedPublicationFragmentDoc}
 `;
-export const NewMentionNotificationFieldsFragmentDoc = gql`
-  fragment NewMentionNotificationFields on NewMentionNotification {
+export const NewMentionNotificationFragmentDoc = gql`
+  fragment NewMentionNotification on NewMentionNotification {
     __typename
     notificationId
     createdAt
@@ -5437,13 +5434,13 @@ export const NewMentionNotificationFieldsFragmentDoc = gql`
   ${PostFragmentDoc}
   ${CommentFragmentDoc}
 `;
-export const NewReactionNotificationFieldsFragmentDoc = gql`
-  fragment NewReactionNotificationFields on NewReactionNotification {
+export const NewReactionNotificationFragmentDoc = gql`
+  fragment NewReactionNotification on NewReactionNotification {
     __typename
     notificationId
     createdAt
     profile {
-      ...ProfileFields
+      ...Profile
     }
     reaction
     publication {
@@ -5458,7 +5455,7 @@ export const NewReactionNotificationFieldsFragmentDoc = gql`
       }
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${PostFragmentDoc}
   ${CommentFragmentDoc}
   ${MirrorFragmentDoc}
@@ -5505,10 +5502,10 @@ export const FollowingFragmentDoc = gql`
   fragment Following on Following {
     __typename
     profile {
-      ...ProfileFields
+      ...Profile
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
 `;
 export const ProxyActionStatusResultFragmentDoc = gql`
   fragment ProxyActionStatusResult on ProxyActionStatusResult {
@@ -5538,10 +5535,10 @@ export const WhoReactedResultFragmentDoc = gql`
     reaction
     reactionAt
     profile {
-      ...ProfileFields
+      ...Profile
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
 `;
 export const RevenueFragmentDoc = gql`
   fragment Revenue on PublicationRevenue {
@@ -6066,14 +6063,14 @@ export const ExploreProfilesDocument = gql`
       request: { limit: $limit, cursor: $cursor, sortCriteria: MOST_COMMENTS }
     ) {
       items {
-        ...ProfileFields
+        ...Profile
       }
       pageInfo {
         ...CommonPaginatedResultInfo
       }
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${CommonPaginatedResultInfoFragmentDoc}
 `;
 
@@ -6332,22 +6329,22 @@ export const NotificationsDocument = gql`
     ) {
       items {
         ... on NewFollowerNotification {
-          ...NewFollowerNotificationFields
+          ...NewFollowerNotification
         }
         ... on NewMirrorNotification {
-          ...NewMirrorNotificationFields
+          ...NewMirrorNotification
         }
         ... on NewCollectNotification {
-          ...NewCollectNotificationFields
+          ...NewCollectNotification
         }
         ... on NewCommentNotification {
-          ...NewCommentNotificationFields
+          ...NewCommentNotification
         }
         ... on NewMentionNotification {
-          ...NewMentionNotificationFields
+          ...NewMentionNotification
         }
         ... on NewReactionNotification {
-          ...NewReactionNotificationFields
+          ...NewReactionNotification
         }
       }
       pageInfo {
@@ -6355,12 +6352,12 @@ export const NotificationsDocument = gql`
       }
     }
   }
-  ${NewFollowerNotificationFieldsFragmentDoc}
-  ${NewMirrorNotificationFieldsFragmentDoc}
-  ${NewCollectNotificationFieldsFragmentDoc}
-  ${NewCommentNotificationFieldsFragmentDoc}
-  ${NewMentionNotificationFieldsFragmentDoc}
-  ${NewReactionNotificationFieldsFragmentDoc}
+  ${NewFollowerNotificationFragmentDoc}
+  ${NewMirrorNotificationFragmentDoc}
+  ${NewCollectNotificationFragmentDoc}
+  ${NewCommentNotificationFragmentDoc}
+  ${NewMentionNotificationFragmentDoc}
+  ${NewReactionNotificationFragmentDoc}
   ${CommonPaginatedResultInfoFragmentDoc}
 `;
 
@@ -6733,10 +6730,10 @@ export type ProfileFollowRevenueQueryResult = Apollo.QueryResult<
 export const ProfilesToFollowDocument = gql`
   query ProfilesToFollow($observerId: ProfileId) {
     result: recommendedProfiles {
-      ...ProfileFields
+      ...Profile
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
 `;
 
 /**
@@ -6782,10 +6779,10 @@ export type ProfilesToFollowQueryResult = Apollo.QueryResult<
 export const GetProfileDocument = gql`
   query GetProfile($request: SingleProfileQueryRequest!, $observerId: ProfileId) {
     result: profile(request: $request) {
-      ...ProfileFields
+      ...Profile
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
 `;
 
 /**
@@ -6832,14 +6829,14 @@ export const GetAllProfilesByOwnerAddressDocument = gql`
   ) {
     result: profiles(request: { ownedBy: [$address], limit: $limit, cursor: $cursor }) {
       items {
-        ...ProfileFields
+        ...Profile
       }
       pageInfo {
         ...CommonPaginatedResultInfo
       }
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${CommonPaginatedResultInfoFragmentDoc}
 `;
 
@@ -6963,14 +6960,14 @@ export const MutualFollowersProfilesDocument = gql`
       }
     ) {
       items {
-        ...ProfileFields
+        ...Profile
       }
       pageInfo {
         ...CommonPaginatedResultInfo
       }
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${CommonPaginatedResultInfoFragmentDoc}
 `;
 
@@ -8390,7 +8387,7 @@ export const SearchProfilesDocument = gql`
       ... on ProfileSearchResult {
         __typename
         items {
-          ...ProfileFields
+          ...Profile
         }
         pageInfo {
           ...CommonPaginatedResultInfo
@@ -8398,7 +8395,7 @@ export const SearchProfilesDocument = gql`
       }
     }
   }
-  ${ProfileFieldsFragmentDoc}
+  ${ProfileFragmentDoc}
   ${CommonPaginatedResultInfoFragmentDoc}
 `;
 

--- a/packages/api-bindings/src/graphql/notification.graphql
+++ b/packages/api-bindings/src/graphql/notification.graphql
@@ -1,4 +1,4 @@
-fragment CommentWithCommentedPublicationFields on Comment {
+fragment CommentWithCommentedPublication on Comment {
   __typename
   ...Comment
   commentOn {
@@ -14,7 +14,7 @@ fragment CommentWithCommentedPublicationFields on Comment {
   }
 }
 
-fragment NewFollowerNotificationFields on NewFollowerNotification {
+fragment NewFollowerNotification on NewFollowerNotification {
   __typename
   notificationId
   createdAt
@@ -24,7 +24,7 @@ fragment NewFollowerNotificationFields on NewFollowerNotification {
   }
 }
 
-fragment NewCollectNotificationFields on NewCollectNotification {
+fragment NewCollectNotification on NewCollectNotification {
   __typename
   notificationId
   createdAt
@@ -46,12 +46,12 @@ fragment NewCollectNotificationFields on NewCollectNotification {
   }
 }
 
-fragment NewMirrorNotificationFields on NewMirrorNotification {
+fragment NewMirrorNotification on NewMirrorNotification {
   __typename
   notificationId
   createdAt
   profile {
-    ...ProfileFields
+    ...Profile
   }
   publication {
     ... on Post {
@@ -63,19 +63,19 @@ fragment NewMirrorNotificationFields on NewMirrorNotification {
   }
 }
 
-fragment NewCommentNotificationFields on NewCommentNotification {
+fragment NewCommentNotification on NewCommentNotification {
   __typename
   notificationId
   createdAt
   profile {
-    ...ProfileFields
+    ...Profile
   }
   comment {
-    ...CommentWithCommentedPublicationFields
+    ...CommentWithCommentedPublication
   }
 }
 
-fragment NewMentionNotificationFields on NewMentionNotification {
+fragment NewMentionNotification on NewMentionNotification {
   __typename
   notificationId
   createdAt
@@ -89,12 +89,12 @@ fragment NewMentionNotificationFields on NewMentionNotification {
   }
 }
 
-fragment NewReactionNotificationFields on NewReactionNotification {
+fragment NewReactionNotification on NewReactionNotification {
   __typename
   notificationId
   createdAt
   profile {
-    ...ProfileFields
+    ...Profile
   }
   reaction
   publication {
@@ -121,26 +121,26 @@ query Notifications(
   ) {
     items {
       ... on NewFollowerNotification {
-        ...NewFollowerNotificationFields
+        ...NewFollowerNotification
       }
 
       ... on NewMirrorNotification {
-        ...NewMirrorNotificationFields
+        ...NewMirrorNotification
       }
 
       ... on NewCollectNotification {
-        ...NewCollectNotificationFields
+        ...NewCollectNotification
       }
 
       ... on NewCommentNotification {
-        ...NewCommentNotificationFields
+        ...NewCommentNotification
       }
 
       ... on NewMentionNotification {
-        ...NewMentionNotificationFields
+        ...NewMentionNotification
       }
       ... on NewReactionNotification {
-        ...NewReactionNotificationFields
+        ...NewReactionNotification
       }
     }
     pageInfo {

--- a/packages/api-bindings/src/graphql/profile.graphql
+++ b/packages/api-bindings/src/graphql/profile.graphql
@@ -38,7 +38,7 @@ fragment Attribute on Attribute {
   value
 }
 
-fragment ProfileFields on Profile {
+fragment Profile on Profile {
   __typename
   id
   name
@@ -91,13 +91,13 @@ fragment ProfileFields on Profile {
 
 query ProfilesToFollow($observerId: ProfileId) {
   result: recommendedProfiles {
-    ...ProfileFields
+    ...Profile
   }
 }
 
 query GetProfile($request: SingleProfileQueryRequest!, $observerId: ProfileId) {
   result: profile(request: $request) {
-    ...ProfileFields
+    ...Profile
   }
 }
 
@@ -109,7 +109,7 @@ query GetAllProfilesByOwnerAddress(
 ) {
   result: profiles(request: { ownedBy: [$address], limit: $limit, cursor: $cursor }) {
     items {
-      ...ProfileFields
+      ...Profile
     }
     pageInfo {
       ...CommonPaginatedResultInfo
@@ -144,7 +144,7 @@ query MutualFollowersProfiles(
     }
   ) {
     items {
-      ...ProfileFields
+      ...Profile
     }
     pageInfo {
       ...CommonPaginatedResultInfo

--- a/packages/api-bindings/src/graphql/profiles-followers-following.graphql
+++ b/packages/api-bindings/src/graphql/profiles-followers-following.graphql
@@ -8,7 +8,7 @@ fragment Follower on Follower {
 fragment Following on Following {
   __typename
   profile {
-    ...ProfileFields
+    ...Profile
   }
 }
 

--- a/packages/api-bindings/src/graphql/reactions.graphql
+++ b/packages/api-bindings/src/graphql/reactions.graphql
@@ -24,7 +24,7 @@ fragment WhoReactedResult on WhoReactedResult {
   reaction
   reactionAt
   profile {
-    ...ProfileFields
+    ...Profile
   }
 }
 

--- a/packages/api-bindings/src/graphql/search.graphql
+++ b/packages/api-bindings/src/graphql/search.graphql
@@ -36,7 +36,7 @@ query SearchProfiles(
     ... on ProfileSearchResult {
       __typename
       items {
-        ...ProfileFields
+        ...Profile
       }
       pageInfo {
         ...CommonPaginatedResultInfo

--- a/packages/api-bindings/src/graphql/utils/profile.ts
+++ b/packages/api-bindings/src/graphql/utils/profile.ts
@@ -3,7 +3,7 @@ import { Overwrite } from '@lens-protocol/shared-kernel';
 
 import {
   FeeFollowModuleSettingsFragment,
-  ProfileFieldsFragment,
+  ProfileFragment,
   ProfileFollowModuleSettingsFragment,
   RevertFollowModuleSettingsFragment,
 } from '../generated';
@@ -14,42 +14,42 @@ export type SupportedFollowModuleSettingsFragment =
   | RevertFollowModuleSettingsFragment
   | null;
 
-export type ProfileFieldsFragmentWithSupportedFollowModule = Overwrite<
-  ProfileFieldsFragment,
+export type ProfileFragmentWithSupportedFollowModule = Overwrite<
+  ProfileFragment,
   { followModule: SupportedFollowModuleSettingsFragment }
 >;
 
-export type ProfileFieldsFragmentWithRevertFollowModule = Overwrite<
-  ProfileFieldsFragment,
+export type ProfileFragmentWithRevertFollowModule = Overwrite<
+  ProfileFragment,
   { followModule: RevertFollowModuleSettingsFragment }
 >;
 
-export type ProfileFieldsFragmentWithFeeFollowModule = Overwrite<
-  ProfileFieldsFragment,
+export type ProfileFragmentWithFeeFollowModule = Overwrite<
+  ProfileFragment,
   { followModule: FeeFollowModuleSettingsFragment }
 >;
 
-export function isProfileFieldsFragmentWithSupportedFollowModule(
-  profile: ProfileFieldsFragment,
-): profile is ProfileFieldsFragmentWithSupportedFollowModule {
-  const followPolicyType = getFollowPolicyTypeFromProfileFieldsFragment(profile);
+export function isProfileFragmentWithSupportedFollowModule(
+  profile: ProfileFragment,
+): profile is ProfileFragmentWithSupportedFollowModule {
+  const followPolicyType = getFollowPolicyTypeFromProfileFragment(profile);
   return followPolicyType !== null;
 }
 
-export function isProfileFieldsFragmentWithRevertFollowModule(
-  profile: ProfileFieldsFragment,
-): profile is ProfileFieldsFragmentWithRevertFollowModule {
-  return getFollowPolicyTypeFromProfileFieldsFragment(profile) === FollowPolicyType.NO_ONE;
+export function isProfileFragmentWithRevertFollowModule(
+  profile: ProfileFragment,
+): profile is ProfileFragmentWithRevertFollowModule {
+  return getFollowPolicyTypeFromProfileFragment(profile) === FollowPolicyType.NO_ONE;
 }
 
-export function isProfileFieldsFragmentWithFeeFollowModule(
-  profile: ProfileFieldsFragment,
-): profile is ProfileFieldsFragmentWithFeeFollowModule {
-  return getFollowPolicyTypeFromProfileFieldsFragment(profile) === FollowPolicyType.CHARGE;
+export function isProfileFragmentWithFeeFollowModule(
+  profile: ProfileFragment,
+): profile is ProfileFragmentWithFeeFollowModule {
+  return getFollowPolicyTypeFromProfileFragment(profile) === FollowPolicyType.CHARGE;
 }
 
-export function getFollowPolicyTypeFromProfileFieldsFragment(
-  profile: ProfileFieldsFragment,
+export function getFollowPolicyTypeFromProfileFragment(
+  profile: ProfileFragment,
 ): FollowPolicyType | null {
   if (profile.followModule === null) {
     return FollowPolicyType.ANYONE;

--- a/packages/api-bindings/src/graphql/utils/publication.ts
+++ b/packages/api-bindings/src/graphql/utils/publication.ts
@@ -8,7 +8,7 @@ import {
   MirrorFragment,
   Post,
   PostFragment,
-  ProfileFieldsFragment,
+  ProfileFragment,
   ReactionTypes,
 } from '../generated';
 import { Typename, PickByTypename, JustTypename } from './types';
@@ -90,7 +90,7 @@ export type PublicationFragment = PostFragment | CommentFragment | MirrorFragmen
 
 export type PublicationOwnedByMeFragment = Overwrite<
   PublicationFragment,
-  { profile: Overwrite<ProfileFieldsFragment, { ownedByMe: true }> }
+  { profile: Overwrite<ProfileFragment, { ownedByMe: true }> }
 >;
 
 export const isPublicationOwnedByMe = (

--- a/packages/react/src/notifications/index.ts
+++ b/packages/react/src/notifications/index.ts
@@ -1,10 +1,10 @@
 import {
-  NewCollectNotificationFieldsFragment,
-  NewCommentNotificationFieldsFragment,
-  NewFollowerNotificationFieldsFragment,
-  NewMentionNotificationFieldsFragment,
-  NewMirrorNotificationFieldsFragment,
-  NewReactionNotificationFieldsFragment,
+  NewCollectNotificationFragment,
+  NewCommentNotificationFragment,
+  NewFollowerNotificationFragment,
+  NewMentionNotificationFragment,
+  NewMirrorNotificationFragment,
+  NewReactionNotificationFragment,
 } from '@lens-protocol/api-bindings';
 
 export { useUnreadNotificationCount } from './useUnreadNotificationCount';
@@ -12,10 +12,10 @@ export { useNotifications } from './useNotifications';
 
 export type { Notification } from './useNotifications';
 export type {
-  NewCollectNotificationFieldsFragment,
-  NewCommentNotificationFieldsFragment,
-  NewFollowerNotificationFieldsFragment,
-  NewMentionNotificationFieldsFragment,
-  NewMirrorNotificationFieldsFragment,
-  NewReactionNotificationFieldsFragment,
+  NewCollectNotificationFragment,
+  NewCommentNotificationFragment,
+  NewFollowerNotificationFragment,
+  NewMentionNotificationFragment,
+  NewMirrorNotificationFragment,
+  NewReactionNotificationFragment,
 };

--- a/packages/react/src/notifications/useNotifications.ts
+++ b/packages/react/src/notifications/useNotifications.ts
@@ -1,10 +1,10 @@
 import {
-  NewCollectNotificationFieldsFragment,
-  NewCommentNotificationFieldsFragment,
-  NewFollowerNotificationFieldsFragment,
-  NewMentionNotificationFieldsFragment,
-  NewMirrorNotificationFieldsFragment,
-  NewReactionNotificationFieldsFragment,
+  NewCollectNotificationFragment,
+  NewCommentNotificationFragment,
+  NewFollowerNotificationFragment,
+  NewMentionNotificationFragment,
+  NewMirrorNotificationFragment,
+  NewReactionNotificationFragment,
   useNotificationsQuery,
 } from '@lens-protocol/api-bindings';
 
@@ -16,12 +16,12 @@ type UseNotificationsArgs = PaginatedArgs<{
 }>;
 
 export type Notification =
-  | NewFollowerNotificationFieldsFragment
-  | NewCollectNotificationFieldsFragment
-  | NewCommentNotificationFieldsFragment
-  | NewMirrorNotificationFieldsFragment
-  | NewMentionNotificationFieldsFragment
-  | NewReactionNotificationFieldsFragment;
+  | NewFollowerNotificationFragment
+  | NewCollectNotificationFragment
+  | NewCommentNotificationFragment
+  | NewMirrorNotificationFragment
+  | NewMentionNotificationFragment
+  | NewReactionNotificationFragment;
 
 export function useNotifications({
   profileId,

--- a/packages/react/src/profile/__tests__/useMutualFollowers.spec.ts
+++ b/packages/react/src/profile/__tests__/useMutualFollowers.spec.ts
@@ -1,19 +1,19 @@
 import {
   createMockApolloClientWithMultipleResponses,
   createMutualFollowersQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
 import { useMutualFollowers } from '../useMutualFollowers';
-import { ProfileFieldsFragment } from '../useProfilesToFollow';
+import { ProfileFragment } from '../useProfilesToFollow';
 
 describe('Given the useMutualFollowers hook', () => {
-  const observer = mockProfileFieldsFragment();
-  const viewingProfile = mockProfileFieldsFragment();
+  const observer = mockProfileFragment();
+  const viewingProfile = mockProfileFragment();
 
-  const mockProfiles: ProfileFieldsFragment[] = [mockProfileFieldsFragment()];
+  const mockProfiles: ProfileFragment[] = [mockProfileFragment()];
 
   describe('when the query returns data successfully', () => {
     it('should return mutual followers profiles', async () => {

--- a/packages/react/src/profile/__tests__/useProfile.spec.ts
+++ b/packages/react/src/profile/__tests__/useProfile.spec.ts
@@ -1,18 +1,18 @@
 import {
   createMockApolloClientWithMultipleResponses,
   mockGetProfileQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
 import { useProfile } from '../useProfile';
-import { ProfileFieldsFragment } from '../useProfilesToFollow';
+import { ProfileFragment } from '../useProfilesToFollow';
 
 describe(`Given the ${useProfile.name} hook`, () => {
   const profileId = '0x2000';
   const handle = 'aave.lens';
-  const mockProfile: ProfileFieldsFragment = mockProfileFieldsFragment({ id: profileId, handle });
+  const mockProfile: ProfileFragment = mockProfileFragment({ id: profileId, handle });
 
   describe('when supplied with a profile id', () => {
     describe('and the query returns data successfully', () => {

--- a/packages/react/src/profile/__tests__/useProfilesOwnedBy.spec.ts
+++ b/packages/react/src/profile/__tests__/useProfilesOwnedBy.spec.ts
@@ -1,7 +1,7 @@
 import {
   createGetAllProfilesByOwnerAddressQueryMockedResponse,
   createMockApolloClientWithMultipleResponses,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { mockEthereumAddress } from '@lens-protocol/shared-kernel/mocks';
 import { waitFor } from '@testing-library/react';
@@ -11,10 +11,10 @@ import { useProfilesOwnedBy } from '../useProfilesOwnedBy';
 
 describe(`Given the ${useProfilesOwnedBy.name} hook`, () => {
   const address = mockEthereumAddress();
-  const observer = mockProfileFieldsFragment();
+  const observer = mockProfileFragment();
   const profiles = [
-    mockProfileFieldsFragment({ ownedBy: address }),
-    mockProfileFieldsFragment({ ownedBy: address }),
+    mockProfileFragment({ ownedBy: address }),
+    mockProfileFragment({ ownedBy: address }),
   ];
 
   describe('when the query returns data successfully', () => {

--- a/packages/react/src/profile/__tests__/useProfilesToFollow.spec.ts
+++ b/packages/react/src/profile/__tests__/useProfilesToFollow.spec.ts
@@ -1,15 +1,15 @@
 import {
   createMockApolloClientWithMultipleResponses,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   createProfilesToFollowQueryMockedResponse,
 } from '@lens-protocol/api-bindings/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
-import { ProfileFieldsFragment, useProfilesToFollow } from '../useProfilesToFollow';
+import { ProfileFragment, useProfilesToFollow } from '../useProfilesToFollow';
 
 describe(`Given the ${useProfilesToFollow.name} hook`, () => {
-  const mockProfiles: ProfileFieldsFragment[] = [mockProfileFieldsFragment()];
+  const mockProfiles: ProfileFragment[] = [mockProfileFragment()];
 
   describe('when the query returns data successfully', () => {
     it('should return profiles to follow', async () => {

--- a/packages/react/src/profile/__tests__/useSearchProfiles.spec.ts
+++ b/packages/react/src/profile/__tests__/useSearchProfiles.spec.ts
@@ -1,19 +1,19 @@
 import {
   createMockApolloClientWithMultipleResponses,
   createSearchProfilesQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
-import { ProfileFieldsFragment } from '../useProfilesToFollow';
+import { ProfileFragment } from '../useProfilesToFollow';
 import { useSearchProfiles } from '../useSearchProfiles';
 
 describe(`Given the ${useSearchProfiles.name} hook`, () => {
-  const observer = mockProfileFieldsFragment();
+  const observer = mockProfileFragment();
   const query = 'query_test';
 
-  const mockProfiles: ProfileFieldsFragment[] = [mockProfileFieldsFragment()];
+  const mockProfiles: ProfileFragment[] = [mockProfileFragment()];
 
   describe('when the query returns data successfully', () => {
     it('should return profiles that match the search result', async () => {

--- a/packages/react/src/profile/adapters/ActiveProfilePresenter.ts
+++ b/packages/react/src/profile/adapters/ActiveProfilePresenter.ts
@@ -3,11 +3,11 @@ import {
   GetProfileDocument,
   GetProfileQuery,
   GetProfileQueryVariables,
-  ProfileFieldsFragment,
+  ProfileFragment,
 } from '@lens-protocol/api-bindings';
 import { IActiveProfilePresenter, ProfileData } from '@lens-protocol/domain/use-cases/profile';
 
-export const activeProfileVar = makeVar<ProfileFieldsFragment | null>(null);
+export const activeProfileVar = makeVar<ProfileFragment | null>(null);
 
 export class ActiveProfilePresenter implements IActiveProfilePresenter {
   private activeProfileCacheSubscription: { unsubscribe: () => void } | null = null;

--- a/packages/react/src/profile/adapters/__tests__/ActiveProfilePresenter.spec.ts
+++ b/packages/react/src/profile/adapters/__tests__/ActiveProfilePresenter.spec.ts
@@ -1,9 +1,9 @@
 import { ApolloClient } from '@apollo/client';
-import { GetProfileDocument, ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { GetProfileDocument, ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   createMockApolloCache,
   mockGetProfileQuery,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 
 import { ActiveProfilePresenter, activeProfileVar } from '../ActiveProfilePresenter';
@@ -13,10 +13,10 @@ import { ActiveProfilePresenter, activeProfileVar } from '../ActiveProfilePresen
 // https://www.apollographql.com/docs/react/development-testing/testing/#testing-the-success-state
 const waitForResponse = () => new Promise((res) => setTimeout(res, 0));
 
-function setupApolloClient({ profile }: { profile: ProfileFieldsFragment }) {
+function setupApolloClient({ profile }: { profile: ProfileFragment }) {
   const cache = createMockApolloCache();
 
-  const updateProfileCache = (profilePatch: Omit<ProfileFieldsFragment, 'id'>) => {
+  const updateProfileCache = (profilePatch: Omit<ProfileFragment, 'id'>) => {
     cache.writeQuery({
       query: GetProfileDocument,
       data: mockGetProfileQuery({ ...profile, ...profilePatch }),
@@ -41,7 +41,7 @@ describe(`Given the ${ActiveProfilePresenter.name}`, () => {
     it(`should
         - set active profile reactive var
         - update the active profile reactive var on cache updates`, async () => {
-      const activeProfile = mockProfileFieldsFragment();
+      const activeProfile = mockProfileFragment();
 
       const { client, updateProfileCache } = setupApolloClient({
         profile: activeProfile,
@@ -52,7 +52,7 @@ describe(`Given the ${ActiveProfilePresenter.name}`, () => {
 
       expect(activeProfileVar()).toEqual(activeProfile);
 
-      const newActiveProfile = mockProfileFieldsFragment({ id: activeProfile.id });
+      const newActiveProfile = mockProfileFragment({ id: activeProfile.id });
       updateProfileCache(newActiveProfile);
 
       await waitForResponse();
@@ -64,7 +64,7 @@ describe(`Given the ${ActiveProfilePresenter.name}`, () => {
       it(`should
           - set the active profile to null
           - stops watching for cache updates`, async () => {
-        const activeProfile = mockProfileFieldsFragment();
+        const activeProfile = mockProfileFragment();
 
         const { client, updateProfileCache } = setupApolloClient({
           profile: activeProfile,
@@ -77,7 +77,7 @@ describe(`Given the ${ActiveProfilePresenter.name}`, () => {
 
         expect(activeProfileVar()).toBeNull();
 
-        const newActiveProfile = mockProfileFieldsFragment({ id: activeProfile.id });
+        const newActiveProfile = mockProfileFragment({ id: activeProfile.id });
         updateProfileCache(newActiveProfile);
 
         await waitForResponse();

--- a/packages/react/src/profile/adapters/__tests__/ProfileGateway.spec.ts
+++ b/packages/react/src/profile/adapters/__tests__/ProfileGateway.spec.ts
@@ -4,7 +4,7 @@ import {
   createMockApolloClientWithMultipleResponses,
   createGetAllProfilesByOwnerAddressQueryMockedResponse,
   mockGetProfileQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { Profile } from '@lens-protocol/domain/entities';
 import { mockProfileId } from '@lens-protocol/domain/mocks';
@@ -24,7 +24,7 @@ describe(`Given an instance of the ${ProfileGateway.name}`, () => {
   describe(`when "${ProfileGateway.prototype.getAllProfilesByOwnerAddress.name}" method is invoked`, () => {
     it('should return all Profile entities owned by the given address', async () => {
       const address = mockEthereumAddress();
-      const profileDataFragment = mockProfileFieldsFragment();
+      const profileDataFragment = mockProfileFragment();
       const apolloClient = createMockApolloClientWithMultipleResponses([
         createGetAllProfilesByOwnerAddressQueryMockedResponse({
           address,
@@ -46,7 +46,7 @@ describe(`Given an instance of the ${ProfileGateway.name}`, () => {
 
   describe(`when "${ProfileGateway.prototype.getProfileByHandle.name}" method is invoked`, () => {
     it('should return the Profile entity associated with the given handle', async () => {
-      const profileDataFragment = mockProfileFieldsFragment();
+      const profileDataFragment = mockProfileFragment();
       const apolloClient = createMockApolloClientWithMultipleResponses([
         mockGetProfileQueryMockedResponse({
           request: { handle: profileDataFragment.handle },
@@ -79,7 +79,7 @@ describe(`Given an instance of the ${ProfileGateway.name}`, () => {
 
   describe(`when "${ProfileGateway.prototype.getProfileById.name}" method is invoked`, () => {
     it('should return the corresponding Profile entity', async () => {
-      const profileDataFragment = mockProfileFieldsFragment();
+      const profileDataFragment = mockProfileFragment();
       const apolloClient = createMockApolloClientWithMultipleResponses([
         mockGetProfileQueryMockedResponse({
           request: { profileId: profileDataFragment.id },

--- a/packages/react/src/profile/index.ts
+++ b/packages/react/src/profile/index.ts
@@ -15,7 +15,7 @@ export * from './useProfilesOwnedBy';
 export type {
   ProfileAttributes,
   ProfileAttributeReader,
-  ProfileFieldsFragment,
+  ProfileFragment,
   FollowingFragment,
   FollowerFragment,
 } from '@lens-protocol/api-bindings';

--- a/packages/react/src/profile/useActiveProfile.ts
+++ b/packages/react/src/profile/useActiveProfile.ts
@@ -1,10 +1,10 @@
-import { ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { ProfileFragment } from '@lens-protocol/api-bindings';
 
 import { ReadResult } from '../helpers';
 import { ApplicationsState, useAppState } from '../lifecycle/adapters/ApplicationPresenter';
 import { useActiveProfileVar } from './adapters/ActiveProfilePresenter';
 
-export function useActiveProfile(): ReadResult<ProfileFieldsFragment | null> {
+export function useActiveProfile(): ReadResult<ProfileFragment | null> {
   const state = useAppState();
 
   const profile = useActiveProfileVar();

--- a/packages/react/src/profile/useExploreProfiles.ts
+++ b/packages/react/src/profile/useExploreProfiles.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment, useExploreProfilesQuery } from '@lens-protocol/api-bindings';
+import { ProfileFragment, useExploreProfilesQuery } from '@lens-protocol/api-bindings';
 
 import { PaginatedReadResult, PaginatedArgs, usePaginatedReadResult } from '../helpers';
 import { useSharedDependencies } from '../shared';
@@ -7,9 +7,7 @@ type UseFeedArgs = PaginatedArgs<{
   observerId?: string;
 }>;
 
-export function useExploreProfiles(
-  args?: UseFeedArgs,
-): PaginatedReadResult<ProfileFieldsFragment[]> {
+export function useExploreProfiles(args?: UseFeedArgs): PaginatedReadResult<ProfileFragment[]> {
   const { apolloClient } = useSharedDependencies();
 
   return usePaginatedReadResult(

--- a/packages/react/src/profile/useMutualFollowers.ts
+++ b/packages/react/src/profile/useMutualFollowers.ts
@@ -1,7 +1,4 @@
-import {
-  ProfileFieldsFragment,
-  useMutualFollowersProfilesQuery,
-} from '@lens-protocol/api-bindings';
+import { ProfileFragment, useMutualFollowersProfilesQuery } from '@lens-protocol/api-bindings';
 import { ProfileId } from '@lens-protocol/domain/entities';
 
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers';
@@ -17,7 +14,7 @@ export function useMutualFollowers({
   observerId,
   viewingProfileId,
   limit,
-}: UseMutualFollowersArgs): PaginatedReadResult<ProfileFieldsFragment[]> {
+}: UseMutualFollowersArgs): PaginatedReadResult<ProfileFragment[]> {
   const { apolloClient } = useSharedDependencies();
 
   return usePaginatedReadResult(

--- a/packages/react/src/profile/useProfile.ts
+++ b/packages/react/src/profile/useProfile.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment, useGetProfileQuery } from '@lens-protocol/api-bindings';
+import { ProfileFragment, useGetProfileQuery } from '@lens-protocol/api-bindings';
 import { invariant, XOR } from '@lens-protocol/shared-kernel';
 
 import { ReadResult, useReadResult } from '../helpers';
@@ -22,7 +22,7 @@ export function useProfile({
   profileId,
   handle,
   observerId,
-}: UseProfileArgs): ReadResult<ProfileFieldsFragment> {
+}: UseProfileArgs): ReadResult<ProfileFragment> {
   const { apolloClient } = useSharedDependencies();
 
   invariant(

--- a/packages/react/src/profile/useProfilesOwnedBy.ts
+++ b/packages/react/src/profile/useProfilesOwnedBy.ts
@@ -1,7 +1,4 @@
-import {
-  ProfileFieldsFragment,
-  useGetAllProfilesByOwnerAddressQuery,
-} from '@lens-protocol/api-bindings';
+import { ProfileFragment, useGetAllProfilesByOwnerAddressQuery } from '@lens-protocol/api-bindings';
 import { EthereumAddress } from '@lens-protocol/shared-kernel';
 
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers';
@@ -17,7 +14,7 @@ export function useProfilesOwnedBy({
   address,
   observerId,
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
-}: UseProfilesOwnedByArgs): PaginatedReadResult<ProfileFieldsFragment[]> {
+}: UseProfilesOwnedByArgs): PaginatedReadResult<ProfileFragment[]> {
   const { apolloClient } = useSharedDependencies();
 
   return usePaginatedReadResult(

--- a/packages/react/src/profile/useProfilesToFollow.ts
+++ b/packages/react/src/profile/useProfilesToFollow.ts
@@ -1,11 +1,11 @@
-import { ProfileFieldsFragment, useProfilesToFollowQuery } from '@lens-protocol/api-bindings';
+import { ProfileFragment, useProfilesToFollowQuery } from '@lens-protocol/api-bindings';
 
 import { useReadResult, ReadResult } from '../helpers';
 import { useSharedDependencies } from '../shared';
 
-export type { ProfileFieldsFragment };
+export type { ProfileFragment };
 
-export function useProfilesToFollow(): ReadResult<ProfileFieldsFragment[]> {
+export function useProfilesToFollow(): ReadResult<ProfileFragment[]> {
   const { apolloClient } = useSharedDependencies();
 
   return useReadResult(useProfilesToFollowQuery({ client: apolloClient }));

--- a/packages/react/src/profile/useSearchProfiles.ts
+++ b/packages/react/src/profile/useSearchProfiles.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment, useSearchProfilesQuery } from '@lens-protocol/api-bindings';
+import { ProfileFragment, useSearchProfilesQuery } from '@lens-protocol/api-bindings';
 
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers';
 import { useSharedDependencies } from '../shared';
@@ -14,7 +14,7 @@ export function useSearchProfiles({
   query,
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
   observerId,
-}: UseSearchProfilesArgs): PaginatedReadResult<ProfileFieldsFragment[]> {
+}: UseSearchProfilesArgs): PaginatedReadResult<ProfileFragment[]> {
   const { apolloClient } = useSharedDependencies();
 
   return usePaginatedReadResult(

--- a/packages/react/src/profile/useUpdateProfileImage.ts
+++ b/packages/react/src/profile/useUpdateProfileImage.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
   TransactionKind,
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import { useUpdateProfileImageController } from './adapters/useUpdateProfileImageController';
 
 export type UseUpdateProfileImageArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function useUpdateProfileImage({ profile }: UseUpdateProfileImageArgs) {

--- a/packages/react/src/publication/__tests__/useSearchPublications.spec.ts
+++ b/packages/react/src/publication/__tests__/useSearchPublications.spec.ts
@@ -4,7 +4,7 @@ import {
   createSearchPublicationsQueryMockedResponse,
   mockCommentFragment,
   mockPostFragment,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { waitFor } from '@testing-library/react';
 
@@ -12,7 +12,7 @@ import { renderHookWithMocks } from '../../__helpers__/testing-library';
 import { useSearchPublications } from '../useSearchPublications';
 
 describe(`Given the ${useSearchPublications.name} hook`, () => {
-  const observer = mockProfileFieldsFragment();
+  const observer = mockProfileFragment();
   const query = 'query_test';
 
   const mockPublications: (PostFragment | CommentFragment)[] = [

--- a/packages/react/src/publication/__tests__/useWhoCollectedPublication.spec.ts
+++ b/packages/react/src/publication/__tests__/useWhoCollectedPublication.spec.ts
@@ -2,7 +2,7 @@ import { PostFragment, WalletFragment } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockPostFragment,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   mockWalletFragment,
   createWhoCollectedPublicationQueryMockedResponse,
 } from '@lens-protocol/api-bindings/mocks';
@@ -12,7 +12,7 @@ import { renderHookWithMocks } from '../../__helpers__/testing-library';
 import { useWhoCollectedPublication } from '../useWhoCollectedPublication';
 
 describe('Given the useWhoCollectedPublication hook', () => {
-  const observer = mockProfileFieldsFragment();
+  const observer = mockProfileFragment();
   const mockPublication: PostFragment = mockPostFragment();
   const mockWallets: WalletFragment[] = [mockWalletFragment()];
 

--- a/packages/react/src/revenue/__tests__/useProfilePublicationRevenue.spec.ts
+++ b/packages/react/src/revenue/__tests__/useProfilePublicationRevenue.spec.ts
@@ -1,7 +1,7 @@
 import {
   createMockApolloClientWithMultipleResponses,
   createProfilePublicationRevenueQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   mockPublicationRevenueFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { waitFor } from '@testing-library/react';
@@ -11,7 +11,7 @@ import { useProfilePublicationRevenue } from '../useProfilePublicationRevenue';
 
 describe(`Given the ${useProfilePublicationRevenue.name} hook`, () => {
   const mockPedublicationRevenueFragments = [mockPublicationRevenueFragment()];
-  const mockedProfile = mockProfileFieldsFragment();
+  const mockedProfile = mockProfileFragment();
 
   describe('when supplied with a profile id', () => {
     describe('and the query returns data successfully', () => {

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/ProfileMetadataCallGateway.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/ProfileMetadataCallGateway.ts
@@ -10,7 +10,7 @@ import {
   GetProfileQuery,
   GetProfileQueryVariables,
   omitTypename,
-  ProfileFieldsFragment,
+  ProfileFragment,
   CreatePublicSetProfileMetadataUriRequest,
 } from '@lens-protocol/api-bindings';
 import {
@@ -126,7 +126,7 @@ export class ProfileMetadataCallGateway
     };
   }
 
-  private async retrieveProfileDetails(profileId: string): Promise<ProfileFieldsFragment> {
+  private async retrieveProfileDetails(profileId: string): Promise<ProfileFragment> {
     const { data } = await this.apolloClient.query<GetProfileQuery, GetProfileQueryVariables>({
       fetchPolicy: 'cache-first',
       query: GetProfileDocument,

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/__tests__/ProfileMetadataCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/__tests__/ProfileMetadataCallGateway.spec.ts
@@ -7,7 +7,7 @@ import {
   createMockApolloClientWithMultipleResponses,
   mockCreateSetProfileMetadataTypedDataMutation,
   mockGetProfileQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   mockRelayerResultFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import { NativeTransaction } from '@lens-protocol/domain/entities';
@@ -45,7 +45,7 @@ function setupTestScenario({
 }
 
 describe(`Given an instance of the ${ProfileMetadataCallGateway.name}`, () => {
-  const existingProfile = mockProfileFieldsFragment();
+  const existingProfile = mockProfileFragment();
   const getProfilesByIdQueryMockedResponse = mockGetProfileQueryMockedResponse({
     observerId: existingProfile.id,
     profile: existingProfile,

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/__tests__/createProfileMetadata.spec.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/__tests__/createProfileMetadata.spec.ts
@@ -1,7 +1,4 @@
-import {
-  mockAttributeFragment,
-  mockProfileFieldsFragment,
-} from '@lens-protocol/api-bindings/mocks';
+import { mockAttributeFragment, mockProfileFragment } from '@lens-protocol/api-bindings/mocks';
 import { mockUpdateProfileDetailsRequest } from '@lens-protocol/domain/mocks';
 import { never, UnknownObject } from '@lens-protocol/shared-kernel';
 
@@ -19,7 +16,7 @@ function expectedMetadata(others: UnknownObject) {
 describe(`Given the ${createProfileMetadata.name} helper`, () => {
   describe(`when called with a profile data and a UpdateProfileDetailsRequest`, () => {
     it('should create profile metadata with the new details as specified in the request', () => {
-      const profile = mockProfileFieldsFragment({
+      const profile = mockProfileFragment({
         __attributes: [],
       });
       const request = mockUpdateProfileDetailsRequest({ profileId: profile.id });
@@ -37,7 +34,7 @@ describe(`Given the ${createProfileMetadata.name} helper`, () => {
     });
 
     it('should be able to preserve "bio" and "cover_picture" if they are not specified in the request', () => {
-      const profile = mockProfileFieldsFragment({
+      const profile = mockProfileFragment({
         __attributes: [],
       });
       const request = mockUpdateProfileDetailsRequest({
@@ -60,7 +57,7 @@ describe(`Given the ${createProfileMetadata.name} helper`, () => {
     });
 
     it('should be able to delete "bio" and "cover_picture" by passing "null" into the request', () => {
-      const profile = mockProfileFieldsFragment({
+      const profile = mockProfileFragment({
         __attributes: [],
       });
       const request = mockUpdateProfileDetailsRequest({
@@ -80,7 +77,7 @@ describe(`Given the ${createProfileMetadata.name} helper`, () => {
     });
 
     it('should create profile metadata adding attributes as specified in the request', () => {
-      const profile = mockProfileFieldsFragment({
+      const profile = mockProfileFragment({
         __attributes: [],
       });
       const request = mockUpdateProfileDetailsRequest({
@@ -124,7 +121,7 @@ describe(`Given the ${createProfileMetadata.name} helper`, () => {
     });
 
     it('should omit attributes that are marked with "null" in the request', () => {
-      const profile = mockProfileFieldsFragment({
+      const profile = mockProfileFragment({
         __attributes: [
           mockAttributeFragment({
             key: 'foo',
@@ -150,7 +147,7 @@ describe(`Given the ${createProfileMetadata.name} helper`, () => {
 
     it('should create profile metadata preserving attributes that might already have been there', () => {
       const existingAttribute = mockAttributeFragment();
-      const profile = mockProfileFieldsFragment({
+      const profile = mockProfileFragment({
         __attributes: [existingAttribute],
       });
       const request = mockUpdateProfileDetailsRequest({ profileId: profile.id });

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/createProfileMetadata.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/createProfileMetadata.ts
@@ -1,4 +1,4 @@
-import { AttributeFragment, ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { AttributeFragment, ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   PartialAttributesUpdate,
   ProfileAttributeValue,
@@ -29,7 +29,7 @@ function newAttribute(key: string, value: ProfileAttributeValue): AttributeData 
   };
 }
 
-function extractCoverImageUrl(existingProfile: ProfileFieldsFragment): string | null {
+function extractCoverImageUrl(existingProfile: ProfileFragment): string | null {
   return existingProfile.coverPicture?.__typename === 'MediaSet'
     ? existingProfile.coverPicture.original.url
     : null;
@@ -74,7 +74,7 @@ function resolveAttributes(attributes: AttributeFragment[], update: PartialAttri
 }
 
 export function createProfileMetadata(
-  existingProfile: ProfileFieldsFragment,
+  existingProfile: ProfileFragment,
   request: UpdateProfileDetailsRequest,
 ) {
   return {

--- a/packages/react/src/transactions/adapters/responders/CreatePostResponder.ts
+++ b/packages/react/src/transactions/adapters/responders/CreatePostResponder.ts
@@ -8,7 +8,7 @@ import {
   PublicationByTxHashQuery,
   PublicationByTxHashQueryVariables,
   PublicationByTxHashDocument,
-  ProfileFieldsFragment,
+  ProfileFragment,
   PostFragment,
   isPostPublication,
 } from '@lens-protocol/api-bindings';
@@ -26,7 +26,7 @@ function pendingPostFragment({
   request,
 }: {
   id: string;
-  author: ProfileFieldsFragment;
+  author: ProfileFragment;
   request: CreatePostRequest;
 }): PendingPostFragment {
   return {

--- a/packages/react/src/transactions/adapters/responders/FollowProfilesResponder.tsx
+++ b/packages/react/src/transactions/adapters/responders/FollowProfilesResponder.tsx
@@ -1,5 +1,5 @@
 import { ApolloCache, NormalizedCacheObject } from '@apollo/client';
-import { ProfileFieldsFragment, ProfileFieldsFragmentDoc } from '@lens-protocol/api-bindings';
+import { ProfileFragment, ProfileFragmentDoc } from '@lens-protocol/api-bindings';
 import { FollowRequest } from '@lens-protocol/domain/use-cases/profile';
 import {
   BroadcastedTransactionData,
@@ -16,17 +16,17 @@ export class FollowProfilesResponder implements ITransactionResponder<FollowRequ
       id: request.profileId,
     });
 
-    const snapshot = this.apolloCache.readFragment<ProfileFieldsFragment>({
+    const snapshot = this.apolloCache.readFragment<ProfileFragment>({
       id: profileIdentifier,
-      fragmentName: 'ProfileFields',
-      fragment: ProfileFieldsFragmentDoc,
+      fragmentName: 'Profile',
+      fragment: ProfileFragmentDoc,
     });
 
     if (snapshot) {
       this.apolloCache.writeFragment({
         id: profileIdentifier,
-        fragmentName: 'ProfileFields',
-        fragment: ProfileFieldsFragmentDoc,
+        fragmentName: 'Profile',
+        fragment: ProfileFragmentDoc,
         data: {
           ...snapshot,
           isOptimisticFollowedByMe: true,
@@ -45,17 +45,17 @@ export class FollowProfilesResponder implements ITransactionResponder<FollowRequ
       id: request.profileId,
     });
 
-    const snapshot = this.apolloCache.readFragment<ProfileFieldsFragment>({
+    const snapshot = this.apolloCache.readFragment<ProfileFragment>({
       id: profileIdentifier,
-      fragmentName: 'ProfileFields',
-      fragment: ProfileFieldsFragmentDoc,
+      fragmentName: 'Profile',
+      fragment: ProfileFragmentDoc,
     });
 
     if (snapshot) {
       this.apolloCache.writeFragment({
         id: profileIdentifier,
-        fragmentName: 'ProfileFields',
-        fragment: ProfileFieldsFragmentDoc,
+        fragmentName: 'Profile',
+        fragment: ProfileFragmentDoc,
         data: {
           ...snapshot,
           isFollowedByMe: true,
@@ -71,17 +71,17 @@ export class FollowProfilesResponder implements ITransactionResponder<FollowRequ
       id: request.profileId,
     });
 
-    const snapshot = this.apolloCache.readFragment<ProfileFieldsFragment>({
+    const snapshot = this.apolloCache.readFragment<ProfileFragment>({
       id: profileIdentifier,
-      fragmentName: 'ProfileFields',
-      fragment: ProfileFieldsFragmentDoc,
+      fragmentName: 'Profile',
+      fragment: ProfileFragmentDoc,
     });
 
     if (snapshot) {
       this.apolloCache.writeFragment({
         id: profileIdentifier,
-        fragmentName: 'ProfileFields',
-        fragment: ProfileFieldsFragmentDoc,
+        fragmentName: 'Profile',
+        fragment: ProfileFragmentDoc,
         data: {
           ...snapshot,
           isOptimisticFollowedByMe: false,

--- a/packages/react/src/transactions/adapters/responders/UpdateProfileMetadataResponder.ts
+++ b/packages/react/src/transactions/adapters/responders/UpdateProfileMetadataResponder.ts
@@ -6,8 +6,8 @@ import {
   GetProfileQuery,
   GetProfileQueryVariables,
   Maybe,
-  ProfileFieldsFragment,
-  ProfileFieldsFragmentDoc,
+  ProfileFragment,
+  ProfileFragmentDoc,
 } from '@lens-protocol/api-bindings';
 import {
   ProfileAttributeValue,
@@ -40,7 +40,7 @@ function newAttributeFragment(key: string, value: ProfileAttributeValue): Attrib
 export class UpdateProfileMetadataResponder
   implements ITransactionResponder<UpdateProfileDetailsRequest>
 {
-  private snapshots = new Map<UpdateProfileDetailsRequest, ProfileFieldsFragment | null>();
+  private snapshots = new Map<UpdateProfileDetailsRequest, ProfileFragment | null>();
 
   constructor(private readonly apolloClient: ApolloClient<NormalizedCacheObject>) {}
 
@@ -54,10 +54,10 @@ export class UpdateProfileMetadataResponder
       id: request.profileId,
     });
 
-    const snapshot = this.apolloCache.readFragment<ProfileFieldsFragment>({
+    const snapshot = this.apolloCache.readFragment<ProfileFragment>({
       id: profileIdentifier,
-      fragmentName: 'ProfileFields',
-      fragment: ProfileFieldsFragmentDoc,
+      fragmentName: 'Profile',
+      fragment: ProfileFragmentDoc,
     });
 
     this.snapshots.set(request, snapshot);
@@ -80,8 +80,8 @@ export class UpdateProfileMetadataResponder
     if (snapshot) {
       this.apolloCache.writeFragment({
         id: profileIdentifier,
-        fragment: ProfileFieldsFragmentDoc,
-        fragmentName: 'ProfileFields',
+        fragment: ProfileFragmentDoc,
+        fragmentName: 'Profile',
         data: snapshot,
       });
     }

--- a/packages/react/src/transactions/adapters/responders/__tests__/CreateMirrorResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/CreateMirrorResponder.spec.ts
@@ -2,7 +2,7 @@ import { PostFragment, PostFragmentDoc } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockPostFragment,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   mockPublicationByTxHashMockedResponse,
 } from '@lens-protocol/api-bindings/mocks';
 import {
@@ -62,7 +62,7 @@ function setupTestScenario({
 }
 
 describe(`Given an instance of the ${CreateMirrorResponder.name}`, () => {
-  const author = mockProfileFieldsFragment();
+  const author = mockProfileFragment();
 
   describe(`when "${CreateMirrorResponder.prototype.prepare.name}" method is invoked`, () => {
     it(`should mark as optimistically mirrored by me and update total mirrors count`, async () => {

--- a/packages/react/src/transactions/adapters/responders/__tests__/CreatePostResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/CreatePostResponder.spec.ts
@@ -1,9 +1,9 @@
-import { PostFragment, ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { PostFragment, ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockGetProfileQueryMockedResponse,
   mockPostFragment,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   mockPublicationByTxHashMockedResponse,
 } from '@lens-protocol/api-bindings/mocks';
 import { mockCreatePostRequest, mockBroadcastedTransactionData } from '@lens-protocol/domain/mocks';
@@ -17,7 +17,7 @@ function setupTestScenario({
   post = mockPostFragment(),
   transactionData = mockBroadcastedTransactionData(),
 }: {
-  author: ProfileFieldsFragment;
+  author: ProfileFragment;
   post?: PostFragment;
   transactionData?: BroadcastedTransactionData<CreatePostRequest>;
 }) {
@@ -39,7 +39,7 @@ function setupTestScenario({
 }
 
 describe(`Given an instance of the ${CreatePostResponder.name}`, () => {
-  const author = mockProfileFieldsFragment();
+  const author = mockProfileFragment();
 
   afterEach(() => {
     recentPosts([]);

--- a/packages/react/src/transactions/adapters/responders/__tests__/FollowProfilesResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/FollowProfilesResponder.spec.ts
@@ -1,8 +1,5 @@
-import { ProfileFieldsFragment, ProfileFieldsFragmentDoc } from '@lens-protocol/api-bindings';
-import {
-  createMockApolloCache,
-  mockProfileFieldsFragment,
-} from '@lens-protocol/api-bindings/mocks';
+import { ProfileFragment, ProfileFragmentDoc } from '@lens-protocol/api-bindings';
+import { createMockApolloCache, mockProfileFragment } from '@lens-protocol/api-bindings/mocks';
 import {
   mockBroadcastedTransactionData,
   mockUnconstrainedFollowRequest,
@@ -10,7 +7,7 @@ import {
 
 import { FollowProfilesResponder } from '../FollowProfilesResponder';
 
-function setupTestScenario({ existingProfile }: { existingProfile: ProfileFieldsFragment }) {
+function setupTestScenario({ existingProfile }: { existingProfile: ProfileFragment }) {
   const apolloCache = createMockApolloCache();
 
   apolloCache.writeFragment({
@@ -18,8 +15,8 @@ function setupTestScenario({ existingProfile }: { existingProfile: ProfileFields
       __typename: 'Profile',
       id: existingProfile.id,
     }),
-    fragment: ProfileFieldsFragmentDoc,
-    fragmentName: 'ProfileFields',
+    fragment: ProfileFragmentDoc,
+    fragmentName: 'Profile',
     data: existingProfile,
   });
 
@@ -34,8 +31,8 @@ function setupTestScenario({ existingProfile }: { existingProfile: ProfileFields
           __typename: 'Profile',
           id: existingProfile.id,
         }),
-        fragment: ProfileFieldsFragmentDoc,
-        fragmentName: 'ProfileFields',
+        fragment: ProfileFragmentDoc,
+        fragmentName: 'Profile',
       });
     },
   };
@@ -46,7 +43,7 @@ describe(`Given the ${FollowProfilesResponder.name}`, () => {
     it(`should update apollo cache with follow information`, async () => {
       const request = mockUnconstrainedFollowRequest();
       const transactionData = mockBroadcastedTransactionData({ request });
-      const existingProfile = mockProfileFieldsFragment({
+      const existingProfile = mockProfileFragment({
         id: transactionData.request.profileId,
         stats: {
           __typename: 'ProfileStats',
@@ -77,7 +74,7 @@ describe(`Given the ${FollowProfilesResponder.name}`, () => {
     it(`should update apollo cache with follow information`, async () => {
       const request = mockUnconstrainedFollowRequest();
       const transactionData = mockBroadcastedTransactionData({ request });
-      const existingProfile = mockProfileFieldsFragment({
+      const existingProfile = mockProfileFragment({
         id: transactionData.request.profileId,
         isFollowedByMe: false,
         isOptimisticFollowedByMe: true,
@@ -100,7 +97,7 @@ describe(`Given the ${FollowProfilesResponder.name}`, () => {
     it(`should update apollo cache with follow information`, async () => {
       const request = mockUnconstrainedFollowRequest();
       const transactionData = mockBroadcastedTransactionData({ request });
-      const existingProfile = mockProfileFieldsFragment({
+      const existingProfile = mockProfileFragment({
         id: transactionData.request.profileId,
         isFollowedByMe: false,
         isOptimisticFollowedByMe: true,

--- a/packages/react/src/transactions/adapters/responders/__tests__/UnfollowProfileResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/UnfollowProfileResponder.spec.ts
@@ -1,6 +1,6 @@
 import { InMemoryCache } from '@apollo/client';
-import { ProfileFieldsFragmentDoc } from '@lens-protocol/api-bindings';
-import { mockProfileFieldsFragment } from '@lens-protocol/api-bindings/mocks';
+import { ProfileFragmentDoc } from '@lens-protocol/api-bindings';
+import { mockProfileFragment } from '@lens-protocol/api-bindings/mocks';
 import {
   mockBroadcastedTransactionData,
   mockUnfollowRequest,
@@ -22,7 +22,7 @@ function setupTestScenario({
     addTypename: true,
   });
 
-  const existingProfile = mockProfileFieldsFragment({
+  const existingProfile = mockProfileFragment({
     id: transactionData.request.profileId,
     isFollowedByMe: true,
     stats: {
@@ -38,8 +38,8 @@ function setupTestScenario({
       __typename: 'Profile',
       id: existingProfile.id,
     }),
-    fragment: ProfileFieldsFragmentDoc,
-    fragmentName: 'ProfileFields',
+    fragment: ProfileFragmentDoc,
+    fragmentName: 'Profile',
     data: existingProfile,
   });
 
@@ -56,8 +56,8 @@ function setupTestScenario({
           __typename: 'Profile',
           id: transactionData.request.profileId,
         }),
-        fragment: ProfileFieldsFragmentDoc,
-        fragmentName: 'ProfileFields',
+        fragment: ProfileFragmentDoc,
+        fragmentName: 'Profile',
       });
     },
   };

--- a/packages/react/src/transactions/adapters/responders/__tests__/UpdateDispatcherConfigResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/UpdateDispatcherConfigResponder.spec.ts
@@ -1,7 +1,7 @@
-import { ProfileFieldsFragment, ProfileFieldsFragmentDoc } from '@lens-protocol/api-bindings';
+import { ProfileFragment, ProfileFragmentDoc } from '@lens-protocol/api-bindings';
 import {
   mockGetProfileQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   createMockApolloClientWithMultipleResponses,
 } from '@lens-protocol/api-bindings/mocks';
 import {
@@ -13,7 +13,7 @@ import { mockEthereumAddress } from '@lens-protocol/shared-kernel/mocks';
 
 import { UpdateDispatcherConfigResponder } from '../UpdateDispatcherConfigResponder';
 
-function setupTestScenario({ profile }: { profile: ProfileFieldsFragment }) {
+function setupTestScenario({ profile }: { profile: ProfileFragment }) {
   const apolloClient = createMockApolloClientWithMultipleResponses([
     mockGetProfileQueryMockedResponse({
       profile,
@@ -35,8 +35,8 @@ function setupTestScenario({ profile }: { profile: ProfileFieldsFragment }) {
             __typename: 'Profile',
             id: profile.id,
           }),
-          fragment: ProfileFieldsFragmentDoc,
-          fragmentName: 'ProfileFields',
+          fragment: ProfileFragmentDoc,
+          fragmentName: 'Profile',
         }),
         'Profile not found in cache',
       );
@@ -47,8 +47,8 @@ function setupTestScenario({ profile }: { profile: ProfileFieldsFragment }) {
 describe(`Given the ${UpdateDispatcherConfigResponder.name}`, () => {
   describe(`when "${UpdateDispatcherConfigResponder.prototype.commit.name}" method is invoked`, () => {
     it(`should update apollo cache with the new dispatcher configuration`, async () => {
-      const profileWithoutDispatcherConfig = mockProfileFieldsFragment({ dispatcher: null });
-      const profileWithDispatcherConfig = mockProfileFieldsFragment({
+      const profileWithoutDispatcherConfig = mockProfileFragment({ dispatcher: null });
+      const profileWithDispatcherConfig = mockProfileFragment({
         ...profileWithoutDispatcherConfig,
         dispatcher: { address: mockEthereumAddress(), canUseRelay: true },
       });

--- a/packages/react/src/transactions/adapters/responders/__tests__/UpdateProfileImageResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/UpdateProfileImageResponder.spec.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker';
-import { ProfileFieldsFragment, ProfileFieldsFragmentDoc } from '@lens-protocol/api-bindings';
+import { ProfileFragment, ProfileFragmentDoc } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockGetProfileQueryMockedResponse,
   mockMediaFragment,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
   mockProfileMediaFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import {
@@ -15,8 +15,8 @@ import {
 import { UpdateProfileImageResponder } from '../UpdateProfileImageResponder';
 
 type SetupTestScenarioArgs = {
-  cacheProfile: ProfileFieldsFragment;
-  responseProfile: ProfileFieldsFragment;
+  cacheProfile: ProfileFragment;
+  responseProfile: ProfileFragment;
 };
 
 function setupTestScenario({ cacheProfile, responseProfile }: SetupTestScenarioArgs) {
@@ -32,8 +32,8 @@ function setupTestScenario({ cacheProfile, responseProfile }: SetupTestScenarioA
 
   apolloClient.cache.writeFragment({
     id: apolloClient.cache.identify(cacheProfile),
-    fragment: ProfileFieldsFragmentDoc,
-    fragmentName: 'ProfileFields',
+    fragment: ProfileFragmentDoc,
+    fragmentName: 'Profile',
     data: cacheProfile,
   });
 
@@ -45,15 +45,15 @@ function setupTestScenario({ cacheProfile, responseProfile }: SetupTestScenarioA
     get profileFromCache() {
       return apolloClient.cache.readFragment({
         id: apolloClient.cache.identify(cacheProfile),
-        fragment: ProfileFieldsFragmentDoc,
-        fragmentName: 'ProfileFields',
+        fragment: ProfileFragmentDoc,
+        fragmentName: 'Profile',
       });
     },
   };
 }
 
 describe(`Given an instance of the ${UpdateProfileImageResponder.name}`, () => {
-  const profile = mockProfileFieldsFragment();
+  const profile = mockProfileFragment();
   const newImageUrl = faker.image.imageUrl(600, 600, 'cat', true);
 
   const transactionData = mockBroadcastedTransactionData({
@@ -63,7 +63,7 @@ describe(`Given an instance of the ${UpdateProfileImageResponder.name}`, () => {
     }),
   });
 
-  const profileWithNewImage: ProfileFieldsFragment = {
+  const profileWithNewImage: ProfileFragment = {
     ...profile,
     picture: mockProfileMediaFragment({
       original: mockMediaFragment({

--- a/packages/react/src/transactions/adapters/responders/__tests__/UpdateProfileMetadataResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/UpdateProfileMetadataResponder.spec.ts
@@ -1,12 +1,12 @@
 import {
   ProfileAttributeReader,
-  ProfileFieldsFragment,
-  ProfileFieldsFragmentDoc,
+  ProfileFragment,
+  ProfileFragmentDoc,
 } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockGetProfileQueryMockedResponse,
-  mockProfileFieldsFragment,
+  mockProfileFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import {
   mockUpdateProfileDetailsRequest,
@@ -21,11 +21,11 @@ import { UpdateProfileMetadataResponder } from '../UpdateProfileMetadataResponde
 function setupUpdateProfileMetadataResponder({
   transactionData,
   existingProfile,
-  updatedProfile = mockProfileFieldsFragment(),
+  updatedProfile = mockProfileFragment(),
 }: {
   transactionData: TransactionData<UpdateProfileDetailsRequest>;
-  existingProfile: ProfileFieldsFragment | null;
-  updatedProfile?: ProfileFieldsFragment;
+  existingProfile: ProfileFragment | null;
+  updatedProfile?: ProfileFragment;
 }) {
   const apolloClient = createMockApolloClientWithMultipleResponses([
     mockGetProfileQueryMockedResponse({
@@ -42,8 +42,8 @@ function setupUpdateProfileMetadataResponder({
 
   apolloClient.cache.writeFragment({
     id: profileIdentifier,
-    fragment: ProfileFieldsFragmentDoc,
-    fragmentName: 'ProfileFields',
+    fragment: ProfileFragmentDoc,
+    fragmentName: 'Profile',
     data: existingProfile,
   });
 
@@ -55,8 +55,8 @@ function setupUpdateProfileMetadataResponder({
     get profileFromCache() {
       return apolloClient.cache.readFragment({
         id: profileIdentifier,
-        fragmentName: 'ProfileFields',
-        fragment: ProfileFieldsFragmentDoc,
+        fragmentName: 'Profile',
+        fragment: ProfileFragmentDoc,
       });
     },
   };
@@ -72,7 +72,7 @@ describe(`Given the ${UpdateProfileMetadataResponder.name}`, () => {
 
   describe(`when "${UpdateProfileMetadataResponder.prototype.prepare.name}" method is invoked with PendingTransactionData<UpdateProfileDetailsRequest>`, () => {
     it(`should update the correct Profile in the Apollo Cache`, async () => {
-      const existingProfile = mockProfileFieldsFragment({ id: request.profileId });
+      const existingProfile = mockProfileFragment({ id: request.profileId });
       const scenario = setupUpdateProfileMetadataResponder({
         existingProfile,
         transactionData: pendingTransactionData,
@@ -104,7 +104,7 @@ describe(`Given the ${UpdateProfileMetadataResponder.name}`, () => {
 
   describe(`when "${UpdateProfileMetadataResponder.prototype.rollback.name}" method is invoked with TransactionData<UpdateProfileDetailsRequest>`, () => {
     it(`should revert the previous changes to the correct Profile in the Apollo Cache`, async () => {
-      const existingProfile = mockProfileFieldsFragment({ id: request.profileId });
+      const existingProfile = mockProfileFragment({ id: request.profileId });
       const scenario = setupUpdateProfileMetadataResponder({
         existingProfile,
         transactionData: pendingTransactionData,
@@ -134,8 +134,8 @@ describe(`Given the ${UpdateProfileMetadataResponder.name}`, () => {
     const transactionData = mockBroadcastedTransactionData({ request });
 
     it(`should confirm the cache changes on the correct Profile with fresh data from the server`, async () => {
-      const existingProfile = mockProfileFieldsFragment({ id: request.profileId });
-      const updatedProfile = mockProfileFieldsFragment({ id: request.profileId });
+      const existingProfile = mockProfileFragment({ id: request.profileId });
+      const updatedProfile = mockProfileFragment({ id: request.profileId });
       const scenario = setupUpdateProfileMetadataResponder({
         existingProfile,
         transactionData,
@@ -149,8 +149,8 @@ describe(`Given the ${UpdateProfileMetadataResponder.name}`, () => {
     });
 
     it('should clear any previous profile snapshot for the given request', async () => {
-      const existingProfile = mockProfileFieldsFragment({ id: request.profileId });
-      const updatedProfile = mockProfileFieldsFragment({ id: request.profileId });
+      const existingProfile = mockProfileFragment({ id: request.profileId });
+      const updatedProfile = mockProfileFragment({ id: request.profileId });
       const scenario = setupUpdateProfileMetadataResponder({
         existingProfile,
         transactionData,

--- a/packages/react/src/transactions/useCreateComment.ts
+++ b/packages/react/src/transactions/useCreateComment.ts
@@ -7,12 +7,12 @@ import {
 import { CreateCommentRequest } from '@lens-protocol/domain/use-cases/publications';
 import { useState } from 'react';
 
-import { ProfileFieldsFragment } from '../profile';
+import { ProfileFragment } from '../profile';
 import { FailedUploadError, MetadataUploadHandler } from './adapters/MetadataUploadAdapter';
 import { useCreateCommentController } from './adapters/useCreateCommentController';
 
 export type UseCreateCommentArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
   upload: MetadataUploadHandler;
 };
 

--- a/packages/react/src/transactions/useCreateMirror.ts
+++ b/packages/react/src/transactions/useCreateMirror.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment, CommentFragment, PostFragment } from '@lens-protocol/api-bindings';
+import { ProfileFragment, CommentFragment, PostFragment } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
   TransactionKind,
@@ -11,7 +11,7 @@ import { useCreateMirrorController } from './adapters/useCreateMirrorController'
 
 export type CreateMirrorArgs = {
   publication: PostFragment | CommentFragment;
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function useCreateMirror() {

--- a/packages/react/src/transactions/useCreatePost.ts
+++ b/packages/react/src/transactions/useCreatePost.ts
@@ -7,12 +7,12 @@ import {
 import { CreatePostRequest } from '@lens-protocol/domain/use-cases/publications';
 import { useState } from 'react';
 
-import { ProfileFieldsFragment } from '../profile';
+import { ProfileFragment } from '../profile';
 import { MetadataUploadHandler, FailedUploadError } from './adapters/MetadataUploadAdapter';
 import { useCreatePostController } from './adapters/useCreatePostController';
 
 export type UseCreatePostArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
   upload: MetadataUploadHandler;
 };
 

--- a/packages/react/src/transactions/useFollow.ts
+++ b/packages/react/src/transactions/useFollow.ts
@@ -1,10 +1,10 @@
 import {
   erc20Amount,
   FeeFollowModuleSettingsFragment,
-  getFollowPolicyTypeFromProfileFieldsFragment,
-  isProfileFieldsFragmentWithFeeFollowModule,
-  ProfileFieldsFragment,
-  ProfileFieldsFragmentWithSupportedFollowModule,
+  getFollowPolicyTypeFromProfileFragment,
+  isProfileFragmentWithFeeFollowModule,
+  ProfileFragment,
+  ProfileFragmentWithSupportedFollowModule,
 } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
@@ -41,11 +41,11 @@ function createFollowRequestFee(followModule: FeeFollowModuleSettingsFragment): 
 }
 
 function createFollowProfilesFlowRequest(
-  profile: ProfileFieldsFragmentWithSupportedFollowModule,
+  profile: ProfileFragmentWithSupportedFollowModule,
   activeWallet: WalletData,
-  activeProfile: ProfileFieldsFragment,
+  activeProfile: ProfileFragment,
 ): FollowProfilesFlowRequest {
-  const followPolicyType = getFollowPolicyTypeFromProfileFieldsFragment(profile);
+  const followPolicyType = getFollowPolicyTypeFromProfileFragment(profile);
 
   const baseRequest: Pick<FollowProfilesFlowRequest, 'profileId' | 'followerAddress'> = {
     profileId: profile.id,
@@ -55,7 +55,7 @@ function createFollowProfilesFlowRequest(
   switch (followPolicyType) {
     case FollowPolicyType.CHARGE:
       invariant(
-        isProfileFieldsFragmentWithFeeFollowModule(profile),
+        isProfileFragmentWithFeeFollowModule(profile),
         'Profile is not with a fee follow module',
       );
 
@@ -80,7 +80,7 @@ function createFollowProfilesFlowRequest(
 }
 
 export type UseFollowArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function useFollow({ profile }: UseFollowArgs) {

--- a/packages/react/src/transactions/useUnfollow.ts
+++ b/packages/react/src/transactions/useUnfollow.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
   TransactionKind,
@@ -19,7 +19,7 @@ export class PrematureUnfollowError extends Error {
 }
 
 export type UseUnfollowArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export function useUnfollow({ profile }: UseUnfollowArgs) {

--- a/packages/react/src/transactions/useUpdateDispatcherConfig.ts
+++ b/packages/react/src/transactions/useUpdateDispatcherConfig.ts
@@ -7,12 +7,12 @@ import {
 import { UpdateDispatcherConfigRequest } from '@lens-protocol/domain/use-cases/profile';
 import { useState } from 'react';
 
-import { ProfileFieldsFragment } from '../profile';
+import { ProfileFragment } from '../profile';
 import { TransactionState, useHasPendingTransaction } from './adapters/TransactionQueuePresenter';
 import { useUpdateDispatcherConfigController } from './adapters/useUpdateDispatcherConfigController';
 
 export type UseUpdateDispatcherConfigArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
 };
 
 export type UseUpdateDispatcherConfigParams = {

--- a/packages/react/src/transactions/useUpdateProfileDetails.ts
+++ b/packages/react/src/transactions/useUpdateProfileDetails.ts
@@ -1,4 +1,4 @@
-import { ProfileFieldsFragment } from '@lens-protocol/api-bindings';
+import { ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
   TransactionKind,
@@ -12,7 +12,7 @@ import { FailedUploadError, MetadataUploadHandler } from './adapters/MetadataUpl
 import { useUpdateProfileDetailsController } from './adapters/useUpdateProfileDetailsController';
 
 type UseUpdateProfileDetailsArgs = {
-  profile: ProfileFieldsFragment;
+  profile: ProfileFragment;
   upload: MetadataUploadHandler;
 };
 


### PR DESCRIPTION
I also already updated all documentation pages I found that mentioned `ProfileFieldsFragment`. Even if they are published already, I guess the harm is minimal compared to the effort of maintaining two versions of each doc page.