### PR TITLE
bug: followers following queries are missing field policy that allows infinite scroll

### DIFF
--- a/examples/web-wagmi/src/App.tsx
+++ b/examples/web-wagmi/src/App.tsx
@@ -53,6 +53,7 @@ import { RevenuePage } from './revenue/RevenuePage';
 import { UseProfileFollowRevenue } from './revenue/UseProfileFollowRevenue';
 import { UseProfilePublicationRevenue } from './revenue/UseProfilePublicationRevenue';
 import { UsePublicationRevenue } from './revenue/UsePublicationRevenue';
+import { UseProfileFollowers } from './profiles/UseProfileFollowers';
 
 const { provider, webSocketProvider } = configureChains([polygon, optimism], [publicProvider()]);
 
@@ -129,6 +130,7 @@ export function App() {
                   element={<UseActiveProfileSwitch />}
                 />
                 <Route path="/profiles/useProfilesOwnedBy" element={<UseProfilesOwnedBy />} />
+                <Route path="/profiles/useProfileFollowers" element={<UseProfileFollowers />} />
 
                 <Route path="/discovery" element={<DiscoveryPage />} />
                 <Route path="/discovery/useFeed" element={<Feed />} />

--- a/examples/web-wagmi/src/App.tsx
+++ b/examples/web-wagmi/src/App.tsx
@@ -31,6 +31,8 @@ import { UseFollowAndUnfollow } from './profiles/UseFollowAndUnfollow';
 import { UseMutualFollowers } from './profiles/UseMutualFollowers';
 import { ProfileByHandle } from './profiles/UseProfileByHandle';
 import { ProfileById } from './profiles/UseProfileById';
+import { UseProfileFollowers } from './profiles/UseProfileFollowers';
+import { UseProfileFollowing } from './profiles/UseProfileFollowing';
 import { UseProfilesOwnedBy } from './profiles/UseProfileOwnedBy';
 import { ProfilesToFollow } from './profiles/UseProfilesToFollow';
 import { UseUpdateDispatcherConfig } from './profiles/UseUpdateDispatcherConfig';
@@ -53,8 +55,6 @@ import { RevenuePage } from './revenue/RevenuePage';
 import { UseProfileFollowRevenue } from './revenue/UseProfileFollowRevenue';
 import { UseProfilePublicationRevenue } from './revenue/UseProfilePublicationRevenue';
 import { UsePublicationRevenue } from './revenue/UsePublicationRevenue';
-import { UseProfileFollowers } from './profiles/UseProfileFollowers';
-import { UseProfileFollowing } from './profiles/UseProfileFollowing';
 
 const { provider, webSocketProvider } = configureChains([polygon, optimism], [publicProvider()]);
 

--- a/examples/web-wagmi/src/App.tsx
+++ b/examples/web-wagmi/src/App.tsx
@@ -54,6 +54,7 @@ import { UseProfileFollowRevenue } from './revenue/UseProfileFollowRevenue';
 import { UseProfilePublicationRevenue } from './revenue/UseProfilePublicationRevenue';
 import { UsePublicationRevenue } from './revenue/UsePublicationRevenue';
 import { UseProfileFollowers } from './profiles/UseProfileFollowers';
+import { UseProfileFollowing } from './profiles/UseProfileFollowing';
 
 const { provider, webSocketProvider } = configureChains([polygon, optimism], [publicProvider()]);
 
@@ -131,6 +132,7 @@ export function App() {
                 />
                 <Route path="/profiles/useProfilesOwnedBy" element={<UseProfilesOwnedBy />} />
                 <Route path="/profiles/useProfileFollowers" element={<UseProfileFollowers />} />
+                <Route path="/profiles/useProfileFollowing" element={<UseProfileFollowing />} />
 
                 <Route path="/discovery" element={<DiscoveryPage />} />
                 <Route path="/discovery/useFeed" element={<Feed />} />

--- a/examples/web-wagmi/src/profiles/ProfilesPage.tsx
+++ b/examples/web-wagmi/src/profiles/ProfilesPage.tsx
@@ -66,6 +66,11 @@ const profileHooks = [
     description: `Fetch a list of profiles owed by a given address.`,
     path: '/profiles/useProfilesOwnedBy',
   },
+  {
+    label: 'useProfileFollowers',
+    description: `Fetch a list of profile followers.`,
+    path: '/profiles/useProfileFollowers',
+  },
 ];
 
 export function ProfilesPage() {

--- a/examples/web-wagmi/src/profiles/ProfilesPage.tsx
+++ b/examples/web-wagmi/src/profiles/ProfilesPage.tsx
@@ -71,6 +71,11 @@ const profileHooks = [
     description: `Fetch a list of profile followers.`,
     path: '/profiles/useProfileFollowers',
   },
+  {
+    label: 'useProfileFollowing',
+    description: `Fetch a list of profile following.`,
+    path: '/profiles/useProfileFollowing',
+  },
 ];
 
 export function ProfilesPage() {

--- a/examples/web-wagmi/src/profiles/UseMutualFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/UseMutualFollowers.tsx
@@ -49,8 +49,8 @@ export function UseMutualFollowers() {
 
       <article>
         <p>Select two profiles to see their mutual followers:</p>
-        <SelectProfile onProfileSelected={(profile) => setSelectedProfileOne(profile)} />
-        <SelectProfile onProfileSelected={(profile) => setSelectedProfileTwo(profile)} />
+        <SelectProfile onProfileSelected={(p) => setSelectedProfileOne(p)} />
+        <SelectProfile onProfileSelected={(p) => setSelectedProfileTwo(p)} />
       </article>
 
       {selectedProfileOne && selectedProfileTwo && (

--- a/examples/web-wagmi/src/profiles/UseMutualFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/UseMutualFollowers.tsx
@@ -1,8 +1,8 @@
-import { useMutualFollowers, useProfile } from '@lens-protocol/react';
+import { useMutualFollowers, useProfile, ProfileFragment } from '@lens-protocol/react';
 import { useState } from 'react';
 
 import { SmallProfileCard } from './components/ProfileCard';
-import { SelectProfileId } from './components/ProfileSelector';
+import { SelectProfile } from './components/ProfileSelector';
 
 type ViewMutualFollowersProps = {
   profileToCompareOne: string;
@@ -38,8 +38,8 @@ function ViewMutualFollowers({
 }
 
 export function UseMutualFollowers() {
-  const [selectedProfileOne, setSelectedProfileOne] = useState<string | null>(null);
-  const [selectedProfileTwo, setSelectedProfileTwo] = useState<string | null>(null);
+  const [selectedProfileOne, setSelectedProfileOne] = useState<ProfileFragment | null>(null);
+  const [selectedProfileTwo, setSelectedProfileTwo] = useState<ProfileFragment | null>(null);
 
   return (
     <div>
@@ -49,14 +49,14 @@ export function UseMutualFollowers() {
 
       <article>
         <p>Select two profiles to see their mutual followers:</p>
-        <SelectProfileId onProfileSelected={(profile) => setSelectedProfileOne(profile)} />
-        <SelectProfileId onProfileSelected={(profile) => setSelectedProfileTwo(profile)} />
+        <SelectProfile onProfileSelected={(profile) => setSelectedProfileOne(profile)} />
+        <SelectProfile onProfileSelected={(profile) => setSelectedProfileTwo(profile)} />
       </article>
 
       {selectedProfileOne && selectedProfileTwo && (
         <ViewMutualFollowers
-          profileToCompareOne={selectedProfileOne}
-          profileToCompareTwo={selectedProfileTwo}
+          profileToCompareOne={selectedProfileOne.id}
+          profileToCompareTwo={selectedProfileTwo.id}
         />
       )}
     </div>

--- a/examples/web-wagmi/src/profiles/UseProfileByHandle.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileByHandle.tsx
@@ -3,8 +3,6 @@ import { useState } from 'react';
 
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
-import { ProfileFollowers } from './components/ProfileFollowers';
-import { ProfilesFollowing } from './components/ProfileFollowing';
 import { SelectProfileHandle } from './components/ProfileSelector';
 
 type ProfileByHandleLayoutProps = {
@@ -20,17 +18,6 @@ export function ProfileByHandleLayout({ handle }: ProfileByHandleLayoutProps) {
     <div>
       <h2>Profile by Handle</h2>
       <ProfileCard profile={profile} />
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(2, 1fr)',
-          gap: '1rem',
-          width: '100%',
-        }}
-      >
-        <ProfileFollowers profileId={profile.id} />
-        <ProfilesFollowing walletAddress={profile.ownedBy} />
-      </div>
     </div>
   );
 }

--- a/examples/web-wagmi/src/profiles/UseProfileByHandle.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileByHandle.tsx
@@ -28,7 +28,7 @@ export function ProfileByHandle() {
   return (
     <>
       <p>Select a handle:</p>
-      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      <SelectProfile onProfileSelected={(p) => setProfile(p)} />
       {profile && <ProfileByHandleLayout handle={profile.handle} />}
     </>
   );

--- a/examples/web-wagmi/src/profiles/UseProfileByHandle.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileByHandle.tsx
@@ -1,9 +1,9 @@
-import { useProfile } from '@lens-protocol/react';
+import { ProfileFragment, useProfile } from '@lens-protocol/react';
 import { useState } from 'react';
 
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
-import { SelectProfileHandle } from './components/ProfileSelector';
+import { SelectProfile } from './components/ProfileSelector';
 
 type ProfileByHandleLayoutProps = {
   handle: string;
@@ -23,16 +23,13 @@ export function ProfileByHandleLayout({ handle }: ProfileByHandleLayoutProps) {
 }
 
 export function ProfileByHandle() {
-  const [handle, setHandle] = useState<string | null>(null);
+  const [profile, setProfile] = useState<ProfileFragment | null>(null);
+
   return (
     <>
       <p>Select a handle:</p>
-      <SelectProfileHandle
-        onProfileSelected={(h: string) => {
-          return setHandle(h);
-        }}
-      />
-      {handle && handle !== 'default' && <ProfileByHandleLayout handle={handle} />}
+      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      {profile && <ProfileByHandleLayout handle={profile.handle} />}
     </>
   );
 }

--- a/examples/web-wagmi/src/profiles/UseProfileById.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileById.tsx
@@ -36,7 +36,7 @@ export function ProfileById() {
   return (
     <>
       <p>Select an id:</p>
-      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      <SelectProfile onProfileSelected={(p) => setProfile(p)} />
       {profile && <ProfileByIdLayout profileId={profile.id} />}
     </>
   );

--- a/examples/web-wagmi/src/profiles/UseProfileById.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileById.tsx
@@ -1,9 +1,9 @@
-import { useProfile } from '@lens-protocol/react';
+import { ProfileFragment, useProfile } from '@lens-protocol/react';
 import { useState } from 'react';
 
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
-import { SelectProfileId } from './components/ProfileSelector';
+import { SelectProfile } from './components/ProfileSelector';
 
 type ProfileByIdProps = {
   profileId: string;
@@ -32,16 +32,12 @@ function ProfileByIdLayout({ profileId }: ProfileByIdProps) {
 }
 
 export function ProfileById() {
-  const [profileId, setProfileId] = useState<string | null>(null);
+  const [profile, setProfile] = useState<ProfileFragment | null>(null);
   return (
     <>
       <p>Select an id:</p>
-      <SelectProfileId
-        onProfileSelected={(h: string) => {
-          return setProfileId(h);
-        }}
-      />
-      {profileId && profileId !== 'default' && <ProfileByIdLayout profileId={profileId} />}
+      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      {profile && <ProfileByIdLayout profileId={profile.id} />}
     </>
   );
 }

--- a/examples/web-wagmi/src/profiles/UseProfileFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileFollowers.tsx
@@ -9,7 +9,7 @@ export function UseProfileFollowers() {
   return (
     <>
       <p>Select a profile:</p>
-      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      <SelectProfile onProfileSelected={(p) => setProfile(p)} />
       {profile && <ProfileFollowers profileId={profile.id} />}
     </>
   );

--- a/examples/web-wagmi/src/profiles/UseProfileFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileFollowers.tsx
@@ -1,15 +1,16 @@
+import { ProfileFragment } from '@lens-protocol/react';
 import { useState } from 'react';
 
 import { ProfileFollowers } from './components/ProfileFollowers';
-import { SelectProfileId } from './components/ProfileSelector';
+import { SelectProfile } from './components/ProfileSelector';
 
 export function UseProfileFollowers() {
-  const [profileId, setProfileId] = useState<string | null>(null);
+  const [profile, setProfile] = useState<ProfileFragment | null>(null);
   return (
     <>
       <p>Select a profile:</p>
-      <SelectProfileId onProfileSelected={(h: string) => setProfileId(h)} />
-      {profileId && <ProfileFollowers profileId={profileId} />}
+      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      {profile && <ProfileFollowers profileId={profile.id} />}
     </>
   );
 }

--- a/examples/web-wagmi/src/profiles/UseProfileFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileFollowers.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+import { ProfileFollowers } from './components/ProfileFollowers';
+import { SelectProfileId } from './components/ProfileSelector';
+
+export function UseProfileFollowers() {
+  const [profileId, setProfileId] = useState<string | null>(null);
+  return (
+    <>
+      <p>Select a profile:</p>
+      <SelectProfileId onProfileSelected={(h: string) => setProfileId(h)} />
+      {profileId && <ProfileFollowers profileId={profileId} />}
+    </>
+  );
+}

--- a/examples/web-wagmi/src/profiles/UseProfileFollowing.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileFollowing.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+import { ProfileFollowers } from './components/ProfileFollowers';
+import { SelectProfileId } from './components/ProfileSelector';
+import { ProfilesFollowing } from './components/ProfileFollowing';
+
+export function UseProfileFollowers() {
+  const [profileId, setProfileId] = useState<string | null>(null);
+  return (
+    <>
+      <p>Select a profile:</p>
+      <SelectProfileId onProfileSelected={(h: string) => setProfileId(h)} />
+      {/*{profileId && <ProfilesFollowing walletAddress={profile.ownedBy} />}*/}
+    </>
+  );
+}

--- a/examples/web-wagmi/src/profiles/UseProfileFollowing.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileFollowing.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react';
 import { ProfileFragment } from '@lens-protocol/react';
+import { useState } from 'react';
 
-import { SelectProfile } from './components/ProfileSelector';
 import { ProfilesFollowing } from './components/ProfileFollowing';
+import { SelectProfile } from './components/ProfileSelector';
 
 export function UseProfileFollowing() {
   const [profile, setProfile] = useState<ProfileFragment | null>(null);
   return (
     <>
       <p>Select a profile:</p>
-      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      <SelectProfile onProfileSelected={(p) => setProfile(p)} />
       {profile && <ProfilesFollowing walletAddress={profile.ownedBy} />}
     </>
   );

--- a/examples/web-wagmi/src/profiles/UseProfileFollowing.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfileFollowing.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
+import { ProfileFragment } from '@lens-protocol/react';
 
-import { ProfileFollowers } from './components/ProfileFollowers';
-import { SelectProfileId } from './components/ProfileSelector';
+import { SelectProfile } from './components/ProfileSelector';
 import { ProfilesFollowing } from './components/ProfileFollowing';
 
-export function UseProfileFollowers() {
-  const [profileId, setProfileId] = useState<string | null>(null);
+export function UseProfileFollowing() {
+  const [profile, setProfile] = useState<ProfileFragment | null>(null);
   return (
     <>
       <p>Select a profile:</p>
-      <SelectProfileId onProfileSelected={(h: string) => setProfileId(h)} />
-      {/*{profileId && <ProfilesFollowing walletAddress={profile.ownedBy} />}*/}
+      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      {profile && <ProfilesFollowing walletAddress={profile.ownedBy} />}
     </>
   );
 }

--- a/examples/web-wagmi/src/profiles/components/ProfileFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileFollowers.tsx
@@ -1,8 +1,8 @@
 import { useProfileFollowers } from '@lens-protocol/react';
 
 import { Loading } from '../../components/loading/Loading';
-import { ProfileCard } from './ProfileCard';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
+import { ProfileCard } from './ProfileCard';
 
 type ProfileFollowersProps = {
   profileId: string;

--- a/examples/web-wagmi/src/profiles/components/ProfileFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileFollowers.tsx
@@ -2,14 +2,22 @@ import { useProfileFollowers } from '@lens-protocol/react';
 
 import { Loading } from '../../components/loading/Loading';
 import { ProfileCard } from './ProfileCard';
+import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
 
 type ProfileFollowersProps = {
   profileId: string;
 };
 
 export function ProfileFollowers({ profileId }: ProfileFollowersProps) {
-  const { data: followers, loading } = useProfileFollowers({ profileId });
+  const {
+    data: followers,
+    loading,
+    hasMore,
+    observeRef,
+  } = useInfiniteScroll(useProfileFollowers({ profileId }));
+
   if (loading) return <Loading />;
+
   return (
     <div>
       <h3>Followers</h3>
@@ -21,6 +29,7 @@ export function ProfileFollowers({ profileId }: ProfileFollowersProps) {
             <div key={follower.wallet.address}>{follower.wallet.address}</div>
           ),
         )}
+        {hasMore && <p ref={observeRef}>Loading more...</p>}
       </div>
     </div>
   );

--- a/examples/web-wagmi/src/profiles/components/ProfileFollowing.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileFollowing.tsx
@@ -1,8 +1,8 @@
 import { useProfileFollowing } from '@lens-protocol/react';
 
 import { Loading } from '../../components/loading/Loading';
-import { ProfileCard } from './ProfileCard';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
+import { ProfileCard } from './ProfileCard';
 
 type ProfileFollowingProps = {
   walletAddress: string;

--- a/examples/web-wagmi/src/profiles/components/ProfileFollowing.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileFollowing.tsx
@@ -2,14 +2,22 @@ import { useProfileFollowing } from '@lens-protocol/react';
 
 import { Loading } from '../../components/loading/Loading';
 import { ProfileCard } from './ProfileCard';
+import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
 
 type ProfileFollowingProps = {
   walletAddress: string;
 };
 
 export function ProfilesFollowing({ walletAddress }: ProfileFollowingProps) {
-  const { data: followings, loading } = useProfileFollowing({ walletAddress });
+  const {
+    data: followings,
+    loading,
+    hasMore,
+    observeRef,
+  } = useInfiniteScroll(useProfileFollowing({ walletAddress }));
+
   if (loading) return <Loading />;
+
   return (
     <div>
       <h3>Following</h3>
@@ -17,6 +25,7 @@ export function ProfilesFollowing({ walletAddress }: ProfileFollowingProps) {
         {followings.map((following) => (
           <ProfileCard key={following.profile.handle} profile={following.profile} />
         ))}
+        {hasMore && <p ref={observeRef}>Loading more...</p>}
       </div>
     </div>
   );

--- a/examples/web-wagmi/src/profiles/components/ProfileSelector.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileSelector.tsx
@@ -1,29 +1,6 @@
 import { useExploreProfiles, ProfileFragment } from '@lens-protocol/react';
 import { invariant } from '../../utils';
 
-type ProfileSelectorLinkProps = {
-  onProfileSelected: (profileHandle: string) => void;
-};
-
-export function SelectProfileHandle({ onProfileSelected }: ProfileSelectorLinkProps) {
-  const { data, loading } = useExploreProfiles({ limit: 30 });
-
-  if (loading) return null;
-
-  return (
-    <select
-      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onProfileSelected(e.target.value)}
-    >
-      <option value="default">Select a profile</option>
-      {data.map((item) => (
-        <option key={item.id} value={item.handle}>
-          {item.handle}
-        </option>
-      ))}
-    </select>
-  );
-}
-
 type SelectProfileProps = {
   onProfileSelected: (profile: ProfileFragment | null) => void;
 };

--- a/examples/web-wagmi/src/profiles/components/ProfileSelector.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileSelector.tsx
@@ -1,4 +1,5 @@
-import { useExploreProfiles } from '@lens-protocol/react';
+import { useExploreProfiles, ProfileFragment } from '@lens-protocol/react';
+import { invariant } from '../../utils';
 
 type ProfileSelectorLinkProps = {
   onProfileSelected: (profileHandle: string) => void;
@@ -23,14 +24,29 @@ export function SelectProfileHandle({ onProfileSelected }: ProfileSelectorLinkPr
   );
 }
 
-export function SelectProfileId({ onProfileSelected }: ProfileSelectorLinkProps) {
+type SelectProfileProps = {
+  onProfileSelected: (profile: ProfileFragment | null) => void;
+};
+
+export function SelectProfile({ onProfileSelected }: SelectProfileProps) {
   const { data, loading } = useExploreProfiles({ limit: 30 });
 
   if (loading) return null;
 
   return (
     <select
-      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onProfileSelected(e.target.value)}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+        if (e.target.value === 'default') {
+          onProfileSelected(null);
+          return;
+        }
+
+        const profile = data.find((p) => p.id === e.target.value);
+
+        invariant(profile, 'Profile with the given id should exist');
+
+        onProfileSelected(profile);
+      }}
     >
       <option value="default">Select a profile</option>
       {data.map((item) => (

--- a/examples/web-wagmi/src/profiles/components/ProfileSelector.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileSelector.tsx
@@ -1,4 +1,5 @@
 import { useExploreProfiles, ProfileFragment } from '@lens-protocol/react';
+
 import { invariant } from '../../utils';
 
 type SelectProfileProps = {

--- a/examples/web-wagmi/src/revenue/UseProfileFollowRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UseProfileFollowRevenue.tsx
@@ -1,9 +1,9 @@
-import { useProfile, useProfileFollowRevenue } from '@lens-protocol/react';
+import { ProfileFragment, useProfile, useProfileFollowRevenue } from '@lens-protocol/react';
 import { useState } from 'react';
 
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from '../profiles/components/ProfileCard';
-import { SelectProfileId } from '../profiles/components/ProfileSelector';
+import { SelectProfile } from '../profiles/components/ProfileSelector';
 import { RevenueCard } from './components/RevenueCard';
 
 function UseProfileFollowRevenueInner({ profileId }: { profileId: string }) {
@@ -31,21 +31,15 @@ function UseProfileFollowRevenueInner({ profileId }: { profileId: string }) {
 }
 
 export function UseProfileFollowRevenue() {
-  const [profileId, setProfileId] = useState<string | null>(null);
+  const [profile, setProfile] = useState<ProfileFragment | null>(null);
   return (
     <>
       <h1>
         <code>useProfileFollowRevenue</code>
       </h1>
       <p>Select a profile to see their follow revenue:</p>
-      <SelectProfileId
-        onProfileSelected={(id: string) => {
-          return setProfileId(id);
-        }}
-      />
-      {profileId && profileId !== 'default' && (
-        <UseProfileFollowRevenueInner profileId={profileId} />
-      )}
+      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      {profile && <UseProfileFollowRevenueInner profileId={profile.id} />}
     </>
   );
 }

--- a/examples/web-wagmi/src/revenue/UseProfileFollowRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UseProfileFollowRevenue.tsx
@@ -38,7 +38,7 @@ export function UseProfileFollowRevenue() {
         <code>useProfileFollowRevenue</code>
       </h1>
       <p>Select a profile to see their follow revenue:</p>
-      <SelectProfile onProfileSelected={(profile) => setProfile(profile)} />
+      <SelectProfile onProfileSelected={(p) => setProfile(p)} />
       {profile && <UseProfileFollowRevenueInner profileId={profile.id} />}
     </>
   );

--- a/examples/web-wagmi/src/revenue/UseProfilePublicationRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UseProfilePublicationRevenue.tsx
@@ -2,13 +2,16 @@ import { useProfilePublicationRevenue } from '@lens-protocol/react';
 
 import { Loading } from '../components/loading/Loading';
 import { PublicationRevenueCard } from './components/PublicationRevenueCard';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 
-const profileId = '0x4f90-0x02';
+const profileId = '0x15';
 
 export function UseProfilePublicationRevenue() {
-  const { data, loading } = useProfilePublicationRevenue({
-    profileId,
-  });
+  const { data, loading, hasMore, observeRef } = useInfiniteScroll(
+    useProfilePublicationRevenue({
+      profileId,
+    }),
+  );
 
   if (loading) {
     return <Loading />;
@@ -20,7 +23,7 @@ export function UseProfilePublicationRevenue() {
         <code>useProfilePublicationRevenue</code>
       </h1>
 
-      <h3>Profile Publication Revenue</h3>
+      <h2>Profile Publication Revenue</h2>
 
       {data.map((publicationRevenue) => {
         return (
@@ -30,6 +33,7 @@ export function UseProfilePublicationRevenue() {
           />
         );
       })}
+      {hasMore && <p ref={observeRef}>Loading more...</p>}
     </div>
   );
 }

--- a/examples/web-wagmi/src/revenue/UseProfilePublicationRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UseProfilePublicationRevenue.tsx
@@ -1,8 +1,8 @@
 import { useProfilePublicationRevenue } from '@lens-protocol/react';
 
 import { Loading } from '../components/loading/Loading';
-import { PublicationRevenueCard } from './components/PublicationRevenueCard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
+import { PublicationRevenueCard } from './components/PublicationRevenueCard';
 
 const profileId = '0x15';
 

--- a/examples/web-wagmi/src/revenue/UsePublicationRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UsePublicationRevenue.tsx
@@ -20,7 +20,7 @@ export function UsePublicationRevenue() {
         <code>usePublicationRevenue</code>
       </h1>
       <PublicationCard publication={publication} />
-      <h3>Revenue</h3>
+      <h2>Revenue</h2>
       <RevenueCard revenue={publicationRevenue} />
     </div>
   );

--- a/packages/api-bindings/src/apollo/createApolloCache.ts
+++ b/packages/api-bindings/src/apollo/createApolloCache.ts
@@ -28,6 +28,7 @@ import { createSearchFieldPolicy } from './createSearchFieldPolicy';
 import { createWhoReactedPublicationFieldPolicy } from './createWhoReactedPublicationFieldPolicy';
 import { createProfileFollowersFieldPolicy } from './createProfileFollowersFieldPolicy';
 import { createProfileFollowingFieldPolicy } from './createProfileFollowingFieldPolicy';
+import { createProfilePublicationRevenueFieldPolicy } from './createProfilePublicationRevenueFieldPolicy';
 
 type TypedFieldFunctionOptions<TAll> = Overwrite<
   FieldFunctionOptions,
@@ -91,6 +92,7 @@ function createTypePolicies({ activeWalletVar }: TypePoliciesArgs): TypePolicies
         whoReactedPublication: createWhoReactedPublicationFieldPolicy(),
         followers: createProfileFollowersFieldPolicy(),
         following: createProfileFollowingFieldPolicy(),
+        profilePublicationRevenue: createProfilePublicationRevenueFieldPolicy(),
       },
     },
   };

--- a/packages/api-bindings/src/apollo/createApolloCache.ts
+++ b/packages/api-bindings/src/apollo/createApolloCache.ts
@@ -26,6 +26,8 @@ import { createPublicationsFieldPolicy } from './createPublicationsFieldPolicy';
 import { createRevenueAggregateTypePolicy } from './createRevenueAggregateTypePolicy';
 import { createSearchFieldPolicy } from './createSearchFieldPolicy';
 import { createWhoReactedPublicationFieldPolicy } from './createWhoReactedPublicationFieldPolicy';
+import { createProfileFollowersFieldPolicy } from './createProfileFollowersFieldPolicy';
+import { createProfileFollowingFieldPolicy } from './createProfileFollowingFieldPolicy';
 
 type TypedFieldFunctionOptions<TAll> = Overwrite<
   FieldFunctionOptions,
@@ -87,6 +89,8 @@ function createTypePolicies({ activeWalletVar }: TypePoliciesArgs): TypePolicies
         publications: createPublicationsFieldPolicy(),
         search: createSearchFieldPolicy(),
         whoReactedPublication: createWhoReactedPublicationFieldPolicy(),
+        followers: createProfileFollowersFieldPolicy(),
+        following: createProfileFollowingFieldPolicy(),
       },
     },
   };

--- a/packages/api-bindings/src/apollo/createApolloCache.ts
+++ b/packages/api-bindings/src/apollo/createApolloCache.ts
@@ -19,6 +19,9 @@ import { createMediaSetTypePolicy } from './createMediaSetTypePolicy';
 import { createMediaTypePolicy } from './createMediaTypePolicy';
 import { createNftImageTypePolicy } from './createNftImageTypePolicy';
 import { createNotificationsFieldPolicy } from './createNotificationsFieldPolicy';
+import { createProfileFollowersFieldPolicy } from './createProfileFollowersFieldPolicy';
+import { createProfileFollowingFieldPolicy } from './createProfileFollowingFieldPolicy';
+import { createProfilePublicationRevenueFieldPolicy } from './createProfilePublicationRevenueFieldPolicy';
 import { createProfileTypePolicy } from './createProfileTypePolicy';
 import { createProfilesFieldPolicy } from './createProfilesFieldPolicy';
 import { createPublicationTypePolicy } from './createPublicationTypePolicy';
@@ -26,9 +29,6 @@ import { createPublicationsFieldPolicy } from './createPublicationsFieldPolicy';
 import { createRevenueAggregateTypePolicy } from './createRevenueAggregateTypePolicy';
 import { createSearchFieldPolicy } from './createSearchFieldPolicy';
 import { createWhoReactedPublicationFieldPolicy } from './createWhoReactedPublicationFieldPolicy';
-import { createProfileFollowersFieldPolicy } from './createProfileFollowersFieldPolicy';
-import { createProfileFollowingFieldPolicy } from './createProfileFollowingFieldPolicy';
-import { createProfilePublicationRevenueFieldPolicy } from './createProfilePublicationRevenueFieldPolicy';
 
 type TypedFieldFunctionOptions<TAll> = Overwrite<
   FieldFunctionOptions,

--- a/packages/api-bindings/src/apollo/createProfileFollowersFieldPolicy.ts
+++ b/packages/api-bindings/src/apollo/createProfileFollowersFieldPolicy.ts
@@ -1,0 +1,5 @@
+import { cursorBasedPagination } from './utils/cursorBasedPagination';
+
+export function createProfileFollowersFieldPolicy() {
+  return cursorBasedPagination([['request', ['profileId']]]);
+}

--- a/packages/api-bindings/src/apollo/createProfileFollowingFieldPolicy.ts
+++ b/packages/api-bindings/src/apollo/createProfileFollowingFieldPolicy.ts
@@ -1,0 +1,5 @@
+import { cursorBasedPagination } from './utils/cursorBasedPagination';
+
+export function createProfileFollowingFieldPolicy() {
+  return cursorBasedPagination([['request', ['address']]]);
+}

--- a/packages/api-bindings/src/apollo/createProfilePublicationRevenueFieldPolicy.ts
+++ b/packages/api-bindings/src/apollo/createProfilePublicationRevenueFieldPolicy.ts
@@ -1,0 +1,5 @@
+import { cursorBasedPagination } from './utils/cursorBasedPagination';
+
+export function createProfilePublicationRevenueFieldPolicy() {
+  return cursorBasedPagination([['request', ['profileId', 'publicationTypes', 'sources']]]);
+}

--- a/packages/api-bindings/src/graphql/generated.tsx
+++ b/packages/api-bindings/src/graphql/generated.tsx
@@ -5574,7 +5574,7 @@ export const RevenueAggregateFragmentDoc = gql`
     __total: total {
       ...Erc20Amount
     }
-    totalAmount
+    totalAmount @client
   }
   ${Erc20AmountFragmentDoc}
 `;

--- a/packages/api-bindings/src/graphql/revenue.graphql
+++ b/packages/api-bindings/src/graphql/revenue.graphql
@@ -4,7 +4,7 @@ fragment RevenueAggregate on RevenueAggregate {
     ...Erc20Amount
   }
 
-  totalAmount
+  totalAmount @client
 }
 
 fragment PublicationRevenue on PublicationRevenue {

--- a/packages/react/src/revenue/useProfilePublicationRevenue.ts
+++ b/packages/react/src/revenue/useProfilePublicationRevenue.ts
@@ -19,7 +19,7 @@ export function useProfilePublicationRevenue({
   profileId,
   observerId,
   sources,
-  limit,
+  limit = DEFAULT_PAGINATED_QUERY_LIMIT,
   publicationTypes,
 }: UseProfilePublicationRevenueArgs): PaginatedReadResult<PublicationRevenueFragment[]> {
   const { apolloClient } = useSharedDependencies();
@@ -27,7 +27,7 @@ export function useProfilePublicationRevenue({
   return usePaginatedReadResult(
     useProfilePublicationRevenueQuery({
       variables: {
-        limit: limit ?? DEFAULT_PAGINATED_QUERY_LIMIT,
+        limit,
         publicationTypes,
         observerId,
         profileId,


### PR DESCRIPTION
- fixed `useProfileFollowers` to support infinite scroll
- fixed `useProfileFollowing` to support infinite scroll
- fixed `useProfilePublicationRevenue` to work and support infinite scroll
- Refactored example app profile selectors to have less code and be less error-prone (e.g. the `default` string returned from callback where id or handle was expected)