### PR TITLE
feat: surface onChainIdentity

### DIFF
--- a/packages/api-bindings/src/graphql/__helpers__/fragments.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/fragments.ts
@@ -105,6 +105,22 @@ export function mockProfileFragment(overrides?: Partial<ProfileFragment>): Profi
 
     dispatcher: null,
 
+    onChainIdentity: {
+      proofOfHumanity: false,
+      ens: null,
+      sybilDotOrg: {
+        verified: false,
+        source: {
+          twitter: {
+            handle: null,
+          },
+        },
+      },
+      worldcoin: {
+        isHuman: false,
+      },
+    },
+
     __followModule: null,
     followPolicy: mockAnyoneFollowPolicy(),
 

--- a/packages/api-bindings/src/graphql/generated.tsx
+++ b/packages/api-bindings/src/graphql/generated.tsx
@@ -4464,6 +4464,13 @@ export type ProfileFragment = { __typename: 'Profile' } & Pick<
     >;
     __attributes: Maybe<Array<AttributeFragment>>;
     dispatcher: Maybe<Pick<Dispatcher, 'address' | 'canUseRelay'>>;
+    onChainIdentity: Pick<OnChainIdentity, 'proofOfHumanity'> & {
+      ens: Maybe<Pick<EnsOnChainIdentity, 'name'>>;
+      sybilDotOrg: Pick<SybilDotOrgIdentity, 'verified'> & {
+        source: { twitter: Pick<SybilDotOrgTwitterIdentity, 'handle'> };
+      };
+      worldcoin: Pick<WorldcoinIdentity, 'isHuman'>;
+    };
   };
 
 export type ProfilesToFollowQueryVariables = Exact<{
@@ -5031,6 +5038,23 @@ export const ProfileFragmentDoc = gql`
     dispatcher {
       address
       canUseRelay
+    }
+    onChainIdentity {
+      proofOfHumanity
+      ens {
+        name
+      }
+      sybilDotOrg {
+        verified
+        source {
+          twitter {
+            handle
+          }
+        }
+      }
+      worldcoin {
+        isHuman
+      }
     }
     isFollowedByMe(isFinalisedOnChain: true)
     isFollowing(who: $observerId)

--- a/packages/api-bindings/src/graphql/profile.graphql
+++ b/packages/api-bindings/src/graphql/profile.graphql
@@ -91,6 +91,24 @@ fragment Profile on Profile {
     canUseRelay
   }
 
+  onChainIdentity {
+    proofOfHumanity
+    ens {
+      name
+    }
+    sybilDotOrg {
+      verified
+      source {
+        twitter {
+          handle
+        }
+      }
+    }
+    worldcoin {
+      isHuman
+    }
+  }
+
   isFollowedByMe(isFinalisedOnChain: true)
   isFollowing(who: $observerId)
 


### PR DESCRIPTION
 Checked the network response of Profile within wagmi, and the additional properties are present:
```
"onChainIdentity": {
	"proofOfHumanity": true,
	"ens": {
		"name": "yoginth.eth",
		"__typename": "EnsOnChainIdentity"
	},
	"sybilDotOrg": {
		"verified": true,
		"source": {
			"twitter": {
				"handle": "yogicodes",
				"__typename": "SybilDotOrgTwitterIdentity"
			},
			"__typename": "SybilDotOrgIdentitySource"
		},
		"__typename": "SybilDotOrgIdentity"
	},
	"worldcoin": {
		"isHuman": false,
		"__typename": "WorldcoinIdentity"
	},
	"__typename": "OnChainIdentity"
},
```