### PR TITLE
feat: Allow other followPolicy instead of "unknown"

### DIFF
--- a/packages/react/src/transactions/useFollow.ts
+++ b/packages/react/src/transactions/useFollow.ts
@@ -97,7 +97,7 @@ export function useFollow({ profile }: UseFollowArgs) {
       try {
         invariant(activeWallet && activeProfile, 'You must be logged in to follow a profile');
         invariant(
-          profile.followPolicy?.type === FollowPolicyType.UNKNOWN,
+          profile.followPolicy?.type !== FollowPolicyType.UNKNOWN,
           'Unsupported follow module',
         );
         setIsPending(true);


### PR DESCRIPTION
I'm from [nosociallab](https://github.com/nosocialxyz). During our development with lens api, we found something weird about the follow policy. I assume this is a bug fix. 😄 