### PR TITLE
chore: allow to build packages separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
+    "build:packages": "turbo run build:packages",
     "test": "turbo run test --no-cache",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint --parallel",

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,11 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "build:packages": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["src/packages/**/*.tsx", "src/packages/**/*.ts"]
+    },
     "test": {
       "outputs": [],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"]


### PR DESCRIPTION
the number of packages and examples is growing, as devs we don't need to rebuild examples when working, so this PR introduces a new turbo script to rebuild only packages