### PR TITLE
chore: enable dependabot T-1334

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  # Configuration for monorepo packages, one per directory
+  # - package-ecosystem: "npm"
+  #   directory: "/packages/client"
+  #   schedule:
+  #     interval: "weekly"


### PR DESCRIPTION
this is a simple dependabot config, if it won't work for monorepo, then we have to configure each directory separately, as in the example

but first we have to merge https://github.com/lens-protocol/lens-sdk/pull/171