### PR TITLE
chore: configure dependabot for monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,62 @@ updates:
     open-pull-requests-limit: 2
 
   # Configuration for monorepo packages, one per directory
-  # - package-ecosystem: "npm"
-  #   directory: "/packages/client"
-  #   schedule:
-  #     interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/packages/api-bindings"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/blockchain-bindings"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/client"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/domain"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/eslint-config"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/prettier-config"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/react"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/shared-kernel"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/storage"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/packages/wagmi"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,71 +1,44 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+__: &npm_config
+  package-ecosystem: "npm"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 2
+
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
   # Configuration for monorepo packages, one per directory
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/api-bindings"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/blockchain-bindings"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/client"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/domain"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/eslint-config"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/prettier-config"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/react"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/shared-kernel"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/storage"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
+  - <<: *npm_config
     directory: "/packages/wagmi"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2


### PR DESCRIPTION
I assume the current setup for dependabot is only on root package.json and all packages are up-to-date there.
so let's add all our packages to the config too.
I excluded `gated-sdk` and all `examples` for now.