### PR TITLE
feat: client sdk - add publication mutations

### DIFF
--- a/packages/client/TODO.md
+++ b/packages/client/TODO.md
@@ -115,6 +115,9 @@ Client manages the token lifecycle and storage
 - [x] [AM] client.publication.hide({ publicationId })
 - [x] [M] client.publication.createAttachMediaData(request)
 
+- [x] [AM] client.publication.report(request)
+- [x] [H] client.publication.buildReportReason(PublicationReportReason)
+
 ## ProtocolStats
 
 - [x] [Q] client.stats.fetch(request)
@@ -134,10 +137,6 @@ Client manages the token lifecycle and storage
 - [x] [AM] client.reactions.add(request)
 - [x] [AM] client.reactions.remove(request)
 - [x] [PQ] client.reactions.toPublication({ publicationId })
-
-## Reporting
-
-- [AM] client.report.publication({ publicationId, reason, additionalComments })
 
 ## Revenue
 

--- a/packages/client/TODO.md
+++ b/packages/client/TODO.md
@@ -100,21 +100,19 @@ Client manages the token lifecycle and storage
 
 ### Create or edit publications
 
-- [AM] client.publication.createPostTypedData(request)
-- [AM] client.publication.createPostViaDispatcher(request)
+- [x] [AM] client.publication.createPostTypedData(request)
+- [x] [AM] client.publication.createPostViaDispatcher(request)
 
-- [AM] client.publication.createCommentTypedData(request)
-- [AM] client.publication.createCommentViaDispatcher(request)
+- [x] [AM] client.publication.createCommentTypedData(request)
+- [x] [AM] client.publication.createCommentViaDispatcher(request)
 
-- [AM] client.publication.createMirrorTypedData(request)
-- [AM] client.publication.createMirrorViaDispatcher(request)
+- [x] [AM] client.publication.createMirrorTypedData(request)
+- [x] [AM] client.publication.createMirrorViaDispatcher(request)
 
-- [AM] client.publication.createCollectTypedData(request)
+- [x] [AM] client.publication.createCollectTypedData(request)
 
-- [AM] client.publication.hide({ publicationId })
-- [M] client.publication.createAttachMediaData(request)
-
-- gated publications TBD
+- [x] [AM] client.publication.hide({ publicationId })
+- [x] [M] client.publication.createAttachMediaData(request)
 
 ## ProtocolStats
 

--- a/packages/client/TODO.md
+++ b/packages/client/TODO.md
@@ -97,6 +97,7 @@ Client manages the token lifecycle and storage
 - [x] [PQ] client.publication.allWalletsWhoCollected({ publicationId })
 - [x] [PQ] client.publication.allForSale({ profileId })
 - [x] [Q] client.publication.metadataStatus(request)
+- [x] [Q] client.publication.stats(request)
 
 ### Create or edit publications
 

--- a/packages/client/src/LensClient.ts
+++ b/packages/client/src/LensClient.ts
@@ -56,7 +56,7 @@ export class LensClient {
   }
 
   get publication(): Publication {
-    return new Publication(this.config);
+    return new Publication(this.config, this._authentication);
   }
 
   get reactions(): Reactions {

--- a/packages/client/src/explore/graphql/explore.generated.ts
+++ b/packages/client/src/explore/graphql/explore.generated.ts
@@ -8,11 +8,11 @@ import {
   CommentFragment,
   CommonPaginatedResultInfoFragment,
   WalletFragment,
-  FollowingFragment,
-  FollowerFragment,
   Eip712TypedDataDomainFragment,
   RelayerResultFragment,
   RelayErrorFragment,
+  FollowingFragment,
+  FollowerFragment,
   Erc20AmountFragment,
 } from '../../graphql/fragments.generated';
 import { GraphQLClient } from 'graphql-request';
@@ -26,11 +26,11 @@ import {
   CommentFragmentDoc,
   CommonPaginatedResultInfoFragmentDoc,
   WalletFragmentDoc,
-  FollowingFragmentDoc,
-  FollowerFragmentDoc,
   Eip712TypedDataDomainFragmentDoc,
   RelayerResultFragmentDoc,
   RelayErrorFragmentDoc,
+  FollowingFragmentDoc,
+  FollowerFragmentDoc,
   Erc20AmountFragmentDoc,
 } from '../../graphql/fragments.generated';
 export type ExplorePublicationsQueryVariables = Types.Exact<{

--- a/packages/client/src/feed/graphql/feed.generated.ts
+++ b/packages/client/src/feed/graphql/feed.generated.ts
@@ -8,11 +8,11 @@ import {
   CommentFragment,
   CommonPaginatedResultInfoFragment,
   WalletFragment,
-  FollowingFragment,
-  FollowerFragment,
   Eip712TypedDataDomainFragment,
   RelayerResultFragment,
   RelayErrorFragment,
+  FollowingFragment,
+  FollowerFragment,
   Erc20AmountFragment,
 } from '../../graphql/fragments.generated';
 import { GraphQLClient } from 'graphql-request';
@@ -26,11 +26,11 @@ import {
   CommentFragmentDoc,
   CommonPaginatedResultInfoFragmentDoc,
   WalletFragmentDoc,
-  FollowingFragmentDoc,
-  FollowerFragmentDoc,
   Eip712TypedDataDomainFragmentDoc,
   RelayerResultFragmentDoc,
   RelayErrorFragmentDoc,
+  FollowingFragmentDoc,
+  FollowerFragmentDoc,
   Erc20AmountFragmentDoc,
 } from '../../graphql/fragments.generated';
 export type FeedItemFragment = {

--- a/packages/client/src/graphql/fragments.generated.ts
+++ b/packages/client/src/graphql/fragments.generated.ts
@@ -249,12 +249,13 @@ export type MetadataAttributeOutputFragment = {
   value: string | null;
 };
 
-export type PublicationStatsFragment = {
+export type SimplePublicationStatsFragment = {
   __typename: 'PublicationStats';
   totalAmountOfMirrors: number;
-  totalUpvotes: number;
   totalAmountOfCollects: number;
   totalAmountOfComments: number;
+  totalUpvotes: number;
+  totalDownvotes: number;
 };
 
 export type MirrorBaseFragment = {
@@ -265,7 +266,7 @@ export type MirrorBaseFragment = {
   isGated: boolean;
   reaction: Types.ReactionTypes | null;
   hasCollectedByMe: boolean;
-  stats: PublicationStatsFragment;
+  stats: SimplePublicationStatsFragment;
   metadata: MetadataFragment;
   profile: ProfileFragment;
   collectModule:
@@ -302,7 +303,7 @@ export type CommentBaseFragment = {
   reaction: Types.ReactionTypes | null;
   hasCollectedByMe: boolean;
   mirrors: Array<string>;
-  stats: PublicationStatsFragment;
+  stats: SimplePublicationStatsFragment;
   metadata: MetadataFragment;
   profile: ProfileFragment;
   collectedBy: WalletFragment | null;
@@ -341,7 +342,7 @@ export type PostFragment = {
   reaction: Types.ReactionTypes | null;
   hasCollectedByMe: boolean;
   mirrors: Array<string>;
-  stats: PublicationStatsFragment;
+  stats: SimplePublicationStatsFragment;
   metadata: MetadataFragment;
   profile: ProfileFragment;
   collectedBy: WalletFragment | null;
@@ -408,13 +409,14 @@ export const Erc20AmountFragmentDoc = gql`
   }
   ${Erc20FragmentDoc}
 `;
-export const PublicationStatsFragmentDoc = gql`
-  fragment PublicationStats on PublicationStats {
+export const SimplePublicationStatsFragmentDoc = gql`
+  fragment SimplePublicationStats on PublicationStats {
     __typename
     totalAmountOfMirrors
-    totalUpvotes
     totalAmountOfCollects
     totalAmountOfComments
+    totalUpvotes
+    totalDownvotes
   }
 `;
 export const MediaFragmentDoc = gql`
@@ -682,7 +684,7 @@ export const MirrorBaseFragmentDoc = gql`
     __typename
     id
     stats {
-      ...PublicationStats
+      ...SimplePublicationStats
     }
     metadata {
       ...Metadata
@@ -708,7 +710,7 @@ export const MirrorBaseFragmentDoc = gql`
       result
     }
   }
-  ${PublicationStatsFragmentDoc}
+  ${SimplePublicationStatsFragmentDoc}
   ${MetadataFragmentDoc}
   ${ProfileFragmentDoc}
   ${CollectModuleFragmentDoc}
@@ -729,7 +731,7 @@ export const PostFragmentDoc = gql`
     __typename
     id
     stats {
-      ...PublicationStats
+      ...SimplePublicationStats
     }
     metadata {
       ...Metadata
@@ -759,7 +761,7 @@ export const PostFragmentDoc = gql`
     }
     mirrors(by: $observerId)
   }
-  ${PublicationStatsFragmentDoc}
+  ${SimplePublicationStatsFragmentDoc}
   ${MetadataFragmentDoc}
   ${ProfileFragmentDoc}
   ${WalletFragmentDoc}
@@ -771,7 +773,7 @@ export const CommentBaseFragmentDoc = gql`
     __typename
     id
     stats {
-      ...PublicationStats
+      ...SimplePublicationStats
     }
     metadata {
       ...Metadata
@@ -801,7 +803,7 @@ export const CommentBaseFragmentDoc = gql`
     }
     mirrors(by: $observerId)
   }
-  ${PublicationStatsFragmentDoc}
+  ${SimplePublicationStatsFragmentDoc}
   ${MetadataFragmentDoc}
   ${ProfileFragmentDoc}
   ${WalletFragmentDoc}

--- a/packages/client/src/graphql/fragments.graphql
+++ b/packages/client/src/graphql/fragments.graphql
@@ -259,19 +259,20 @@ fragment MetadataAttributeOutput on MetadataAttributeOutput {
   value
 }
 
-fragment PublicationStats on PublicationStats {
+fragment SimplePublicationStats on PublicationStats {
   __typename
   totalAmountOfMirrors
-  totalUpvotes
   totalAmountOfCollects
   totalAmountOfComments
+  totalUpvotes
+  totalDownvotes
 }
 
 fragment MirrorBase on Mirror {
   __typename
   id
   stats {
-    ...PublicationStats
+    ...SimplePublicationStats
   }
   metadata {
     ...Metadata
@@ -316,7 +317,7 @@ fragment CommentBase on Comment {
   __typename
   id
   stats {
-    ...PublicationStats
+    ...SimplePublicationStats
   }
   metadata {
     ...Metadata
@@ -378,7 +379,7 @@ fragment Post on Post {
   __typename
   id
   stats {
-    ...PublicationStats
+    ...SimplePublicationStats
   }
   metadata {
     ...Metadata

--- a/packages/client/src/graphql/types.generated.ts
+++ b/packages/client/src/graphql/types.generated.ts
@@ -1120,10 +1120,14 @@ export type Erc4626FeeCollectModuleSettings = {
   endTimestamp: Maybe<Scalars['DateTime']>;
   /** True if only followers of publisher may collect the post. */
   followerOnly: Scalars['Boolean'];
+  /** The recipient of the ERC4626 vault shares */
+  recipient: Scalars['EthereumAddress'];
   /** The referral fee associated with this publication. */
   referralFee: Scalars['Float'];
   /** The collect modules enum */
   type: CollectModules;
+  /** The ERC4626 vault address */
+  vault: Scalars['ContractAddress'];
 };
 
 export type ElectedMirror = {

--- a/packages/client/src/publication/Publication.spec.ts
+++ b/packages/client/src/publication/Publication.spec.ts
@@ -7,66 +7,68 @@ const testConfig = {
 };
 
 describe(`Given the ${Publication.name} configured to work with sandbox`, () => {
-  const publication = new Publication(testConfig);
+  describe(`and is not authenticated`, () => {
+    const publication = new Publication(testConfig);
 
-  describe(`when a method ${Publication.prototype.fetch.name} is called`, () => {
-    it(`should return the requested publication`, async () => {
-      const id = '0x014e-0x0a';
-      const result = await publication.fetch({ publicationId: id });
+    describe(`when a method ${Publication.prototype.fetch.name} is called`, () => {
+      it(`should return the requested publication`, async () => {
+        const id = '0x014e-0x0a';
+        const result = await publication.fetch({ publicationId: id });
 
-      expect(result).toMatchObject({
-        id,
+        expect(result).toMatchObject({
+          id,
+        });
       });
     });
-  });
 
-  describe(`when a method ${Publication.prototype.fetchAll.name} is called`, () => {
-    it(`should run successfully`, async () => {
-      await expect(publication.fetchAll({ profileId: '0x50' })).resolves.not.toThrow();
-    });
-  });
-
-  describe(`when a method ${Publication.prototype.allWalletsWhoCollected.name} is called`, () => {
-    it(`should run successfully`, async () => {
-      await expect(
-        publication.allWalletsWhoCollected({ publicationId: '0x014e-0x0a' }),
-      ).resolves.not.toThrow();
-    });
-  });
-
-  describe(`when a method ${Publication.prototype.validateMetadata.name} is called`, () => {
-    it(`should run successfully`, async () => {
-      const result = await publication.validateMetadata({
-        name: 'Test',
-        attributes: [],
-        content: 'Test',
-        locale: 'en',
-        mainContentFocus: PublicationMainFocus.TextOnly,
-        metadata_id: '1',
-        version: '2.0.0',
+    describe(`when a method ${Publication.prototype.fetchAll.name} is called`, () => {
+      it(`should run successfully`, async () => {
+        await expect(publication.fetchAll({ profileId: '0x50' })).resolves.not.toThrow();
       });
-
-      expect(result).toMatchObject({ valid: true });
     });
-  });
 
-  describe(`when a method ${Publication.prototype.allForSale.name} is called`, () => {
-    it(`should run successfully`, async () => {
-      await expect(
-        publication.allForSale({
-          profileId: '0x014e',
-        }),
-      ).resolves.not.toThrow();
+    describe(`when a method ${Publication.prototype.allWalletsWhoCollected.name} is called`, () => {
+      it(`should run successfully`, async () => {
+        await expect(
+          publication.allWalletsWhoCollected({ publicationId: '0x014e-0x0a' }),
+        ).resolves.not.toThrow();
+      });
     });
-  });
 
-  describe(`when a method ${Publication.prototype.metadataStatus.name} is called`, () => {
-    it(`should run successfully`, async () => {
-      await expect(
-        publication.metadataStatus({
-          publicationId: '0x014e-0x0a',
-        }),
-      ).resolves.not.toThrow();
+    describe(`when a method ${Publication.prototype.validateMetadata.name} is called`, () => {
+      it(`should run successfully`, async () => {
+        const result = await publication.validateMetadata({
+          name: 'Test',
+          attributes: [],
+          content: 'Test',
+          locale: 'en',
+          mainContentFocus: PublicationMainFocus.TextOnly,
+          metadata_id: '1',
+          version: '2.0.0',
+        });
+
+        expect(result).toMatchObject({ valid: true });
+      });
+    });
+
+    describe(`when a method ${Publication.prototype.allForSale.name} is called`, () => {
+      it(`should run successfully`, async () => {
+        await expect(
+          publication.allForSale({
+            profileId: '0x014e',
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe(`when a method ${Publication.prototype.metadataStatus.name} is called`, () => {
+      it(`should run successfully`, async () => {
+        await expect(
+          publication.metadataStatus({
+            publicationId: '0x014e-0x0a',
+          }),
+        ).resolves.not.toThrow();
+      });
     });
   });
 });

--- a/packages/client/src/publication/Publication.spec.ts
+++ b/packages/client/src/publication/Publication.spec.ts
@@ -1,6 +1,7 @@
+import { Publication, PublicationReportReason } from '.';
+import { setupRandomAuthentication } from '../authentication/__helpers__/setupAuthentication';
 import { mumbaiSandbox } from '../consts/environments';
 import { PublicationMainFocus } from '../graphql/types.generated';
-import { Publication } from './Publication';
 
 const testConfig = {
   environment: mumbaiSandbox,
@@ -66,6 +67,25 @@ describe(`Given the ${Publication.name} configured to work with sandbox`, () => 
         await expect(
           publication.metadataStatus({
             publicationId: '0x014e-0x0a',
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+  });
+
+  describe(`and is authenticated`, () => {
+    const getAuthentication = setupRandomAuthentication();
+
+    describe(`when a method ${Publication.prototype.report.name} is called`, () => {
+      it(`should run successfully`, async () => {
+        const authentication = getAuthentication();
+        const publication = new Publication(testConfig, authentication);
+
+        await expect(
+          publication.report({
+            publicationId: '0x014e-0x0a',
+            reason: publication.buildReportReason(PublicationReportReason.FAKE_ENGAGEMENT),
+            additionalComments: 'comment',
           }),
         ).resolves.not.toThrow();
       });

--- a/packages/client/src/publication/Publication.ts
+++ b/packages/client/src/publication/Publication.ts
@@ -39,6 +39,7 @@ import {
   CreateMirrorTypedDataMutation,
   CreatePostTypedDataMutation,
   getSdk,
+  PublicationStatsFragment,
   Sdk,
 } from './graphql/publication.generated';
 
@@ -60,6 +61,18 @@ export class Publication {
     const result = await this.sdk.Publication({ request, observerId });
 
     return result.data.result;
+  }
+
+  async stats(
+    request: PublicationQueryRequest,
+    sources: string[],
+  ): Promise<PublicationStatsFragment | undefined> {
+    const result = await this.sdk.PublicationStats({
+      request,
+      sources,
+    });
+
+    return result.data.result?.stats;
   }
 
   async validateMetadata(

--- a/packages/client/src/publication/Publication.ts
+++ b/packages/client/src/publication/Publication.ts
@@ -27,6 +27,8 @@ import {
   PublicationsQueryRequest,
   PublicationValidateMetadataResult,
   PublicMediaRequest,
+  ReportingReasonInputParams,
+  ReportPublicationRequest,
   TypedDataOptions,
   WhoCollectedPublicationRequest,
 } from '../graphql/types.generated';
@@ -42,6 +44,7 @@ import {
   PublicationStatsFragment,
   Sdk,
 } from './graphql/publication.generated';
+import { buildReportReason, PublicationReportReason } from './helpers/buildReportReason';
 
 export class Publication {
   private readonly authentication: Authentication | undefined;
@@ -252,6 +255,14 @@ export class Publication {
     });
   }
 
+  async createAttachMediaData(
+    request: PublicMediaRequest,
+  ): Promise<InferResultType<CreateAttachMediaDataMutation>> {
+    const result = await this.sdk.CreateAttachMediaData({ request });
+
+    return result.data.result;
+  }
+
   async hide(
     request: HidePublicationRequest,
   ): PromiseResult<void, CredentialsExpiredError | NotAuthenticatedError> {
@@ -260,11 +271,15 @@ export class Publication {
     });
   }
 
-  async createAttachMediaData(
-    request: PublicMediaRequest,
-  ): Promise<InferResultType<CreateAttachMediaDataMutation>> {
-    const result = await this.sdk.CreateAttachMediaData({ request });
+  async report(
+    request: ReportPublicationRequest,
+  ): PromiseResult<void, CredentialsExpiredError | NotAuthenticatedError> {
+    return execute(this.authentication, async (headers) => {
+      await this.sdk.ReportPublication({ request }, headers);
+    });
+  }
 
-    return result.data.result;
+  buildReportReason(reason: PublicationReportReason): ReportingReasonInputParams {
+    return buildReportReason(reason);
   }
 }

--- a/packages/client/src/publication/Publication.ts
+++ b/packages/client/src/publication/Publication.ts
@@ -1,28 +1,56 @@
+import { PromiseResult } from '@lens-protocol/shared-kernel';
 import { GraphQLClient } from 'graphql-request';
 
+import { Authentication } from '../authentication';
 import { LensConfig } from '../consts/config';
-import { CommentFragment, PostFragment, WalletFragment } from '../graphql/fragments.generated';
+import { CredentialsExpiredError, NotAuthenticatedError } from '../consts/errors';
+import { InferResultType } from '../consts/types';
+import {
+  CommentFragment,
+  PostFragment,
+  RelayerResultFragment,
+  RelayErrorFragment,
+  WalletFragment,
+} from '../graphql/fragments.generated';
 import { PublicationFragment } from '../graphql/types';
 import {
+  CreateCollectRequest,
+  CreateMirrorRequest,
+  CreatePublicCommentRequest,
+  CreatePublicPostRequest,
   GetPublicationMetadataStatusRequest,
+  HidePublicationRequest,
   ProfilePublicationsForSaleRequest,
   PublicationMetadataStatus,
   PublicationMetadataV2Input,
   PublicationQueryRequest,
   PublicationsQueryRequest,
   PublicationValidateMetadataResult,
+  PublicMediaRequest,
+  TypedDataOptions,
   WhoCollectedPublicationRequest,
 } from '../graphql/types.generated';
 import { buildPaginatedQueryResult, PaginatedResult } from '../helpers/buildPaginatedQueryResult';
-import { getSdk, Sdk } from './graphql/publication.generated';
+import { execute } from '../helpers/execute';
+import {
+  CreateAttachMediaDataMutation,
+  CreateCollectTypedDataMutation,
+  CreateCommentTypedDataMutation,
+  CreateMirrorTypedDataMutation,
+  CreatePostTypedDataMutation,
+  getSdk,
+  Sdk,
+} from './graphql/publication.generated';
 
 export class Publication {
+  private readonly authentication: Authentication | undefined;
   private readonly sdk: Sdk;
 
-  constructor(config: LensConfig) {
+  constructor(config: LensConfig, authentication?: Authentication) {
     const client = new GraphQLClient(config.environment.gqlEndpoint);
 
     this.sdk = getSdk(client);
+    this.authentication = authentication;
   }
 
   async fetch(
@@ -90,5 +118,140 @@ export class Publication {
 
       return result.data.result;
     }, request);
+  }
+
+  async createPostTypedData(
+    request: CreatePublicPostRequest,
+    options?: TypedDataOptions,
+  ): PromiseResult<
+    InferResultType<CreatePostTypedDataMutation>,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreatePostTypedData(
+        {
+          request,
+          options,
+        },
+        headers,
+      );
+
+      return result.data.result;
+    });
+  }
+
+  async createPostViaDispatcher(
+    request: CreatePublicPostRequest,
+  ): PromiseResult<
+    RelayerResultFragment | RelayErrorFragment,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreatePostViaDispatcher({ request }, headers);
+
+      return result.data.result;
+    });
+  }
+
+  async createCommentTypedData(
+    request: CreatePublicCommentRequest,
+    options?: TypedDataOptions,
+  ): PromiseResult<
+    InferResultType<CreateCommentTypedDataMutation>,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreateCommentTypedData(
+        {
+          request,
+          options,
+        },
+        headers,
+      );
+
+      return result.data.result;
+    });
+  }
+
+  async createCommentViaDispatcher(
+    request: CreatePublicCommentRequest,
+  ): PromiseResult<
+    RelayerResultFragment | RelayErrorFragment,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreateCommentViaDispatcher({ request }, headers);
+
+      return result.data.result;
+    });
+  }
+
+  async createMirrorTypedData(
+    request: CreateMirrorRequest,
+    options?: TypedDataOptions,
+  ): PromiseResult<
+    InferResultType<CreateMirrorTypedDataMutation>,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreateMirrorTypedData(
+        {
+          request,
+          options,
+        },
+        headers,
+      );
+
+      return result.data.result;
+    });
+  }
+
+  async createMirrorViaDispatcher(
+    request: CreateMirrorRequest,
+  ): PromiseResult<
+    RelayerResultFragment | RelayErrorFragment,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreateMirrorViaDispatcher({ request }, headers);
+
+      return result.data.result;
+    });
+  }
+
+  async createCollectTypedData(
+    request: CreateCollectRequest,
+    options?: TypedDataOptions,
+  ): PromiseResult<
+    InferResultType<CreateCollectTypedDataMutation>,
+    CredentialsExpiredError | NotAuthenticatedError
+  > {
+    return execute(this.authentication, async (headers) => {
+      const result = await this.sdk.CreateCollectTypedData(
+        {
+          request,
+          options,
+        },
+        headers,
+      );
+
+      return result.data.result;
+    });
+  }
+
+  async hide(
+    request: HidePublicationRequest,
+  ): PromiseResult<void, CredentialsExpiredError | NotAuthenticatedError> {
+    return execute(this.authentication, async (headers) => {
+      await this.sdk.HidePublication({ request }, headers);
+    });
+  }
+
+  async createAttachMediaData(
+    request: PublicMediaRequest,
+  ): Promise<InferResultType<CreateAttachMediaDataMutation>> {
+    const result = await this.sdk.CreateAttachMediaData({ request });
+
+    return result.data.result;
   }
 }

--- a/packages/client/src/publication/graphql/publication.generated.ts
+++ b/packages/client/src/publication/graphql/publication.generated.ts
@@ -242,12 +242,6 @@ export type CreateCollectTypedDataMutation = {
   };
 };
 
-export type HidePublicationMutationVariables = Types.Exact<{
-  request: Types.HidePublicationRequest;
-}>;
-
-export type HidePublicationMutation = { hidePublication: void | null };
-
 export type CreateAttachMediaDataMutationVariables = Types.Exact<{
   request: Types.PublicMediaRequest;
 }>;
@@ -264,6 +258,18 @@ export type CreateAttachMediaDataMutation = {
     };
   };
 };
+
+export type HidePublicationMutationVariables = Types.Exact<{
+  request: Types.HidePublicationRequest;
+}>;
+
+export type HidePublicationMutation = { hidePublication: void | null };
+
+export type ReportPublicationMutationVariables = Types.Exact<{
+  request: Types.ReportPublicationRequest;
+}>;
+
+export type ReportPublicationMutation = { reportPublication: void | null };
 
 export const PublicationStatsFragmentDoc = gql`
   fragment PublicationStats on PublicationStats {
@@ -560,11 +566,6 @@ export const CreateCollectTypedDataDocument = gql`
   }
   ${Eip712TypedDataDomainFragmentDoc}
 `;
-export const HidePublicationDocument = gql`
-  mutation HidePublication($request: HidePublicationRequest!) {
-    hidePublication(request: $request)
-  }
-`;
 export const CreateAttachMediaDataDocument = gql`
   mutation CreateAttachMediaData($request: PublicMediaRequest!) {
     result: createAttachMediaData(request: $request) {
@@ -577,6 +578,16 @@ export const CreateAttachMediaDataDocument = gql`
       }
       signedUrl
     }
+  }
+`;
+export const HidePublicationDocument = gql`
+  mutation HidePublication($request: HidePublicationRequest!) {
+    hidePublication(request: $request)
+  }
+`;
+export const ReportPublicationDocument = gql`
+  mutation ReportPublication($request: ReportPublicationRequest!) {
+    reportPublication(request: $request)
   }
 `;
 
@@ -601,8 +612,9 @@ const CreateCommentViaDispatcherDocumentString = print(CreateCommentViaDispatche
 const CreateMirrorTypedDataDocumentString = print(CreateMirrorTypedDataDocument);
 const CreateMirrorViaDispatcherDocumentString = print(CreateMirrorViaDispatcherDocument);
 const CreateCollectTypedDataDocumentString = print(CreateCollectTypedDataDocument);
-const HidePublicationDocumentString = print(HidePublicationDocument);
 const CreateAttachMediaDataDocumentString = print(CreateAttachMediaDataDocument);
+const HidePublicationDocumentString = print(HidePublicationDocument);
+const ReportPublicationDocumentString = print(ReportPublicationDocument);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     Publication(
@@ -877,6 +889,26 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
         'mutation',
       );
     },
+    CreateAttachMediaData(
+      variables: CreateAttachMediaDataMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateAttachMediaDataMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateAttachMediaDataMutation>(
+            CreateAttachMediaDataDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateAttachMediaData',
+        'mutation',
+      );
+    },
     HidePublication(
       variables: HidePublicationMutationVariables,
       requestHeaders?: Dom.RequestInit['headers'],
@@ -896,23 +928,22 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
         'mutation',
       );
     },
-    CreateAttachMediaData(
-      variables: CreateAttachMediaDataMutationVariables,
+    ReportPublication(
+      variables: ReportPublicationMutationVariables,
       requestHeaders?: Dom.RequestInit['headers'],
     ): Promise<{
-      data: CreateAttachMediaDataMutation;
+      data: ReportPublicationMutation;
       extensions?: any;
       headers: Dom.Headers;
       status: number;
     }> {
       return withWrapper(
         (wrappedRequestHeaders) =>
-          client.rawRequest<CreateAttachMediaDataMutation>(
-            CreateAttachMediaDataDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'CreateAttachMediaData',
+          client.rawRequest<ReportPublicationMutation>(ReportPublicationDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'ReportPublication',
         'mutation',
       );
     },

--- a/packages/client/src/publication/graphql/publication.generated.ts
+++ b/packages/client/src/publication/graphql/publication.generated.ts
@@ -8,11 +8,11 @@ import {
   CommentFragment,
   CommonPaginatedResultInfoFragment,
   WalletFragment,
-  FollowingFragment,
-  FollowerFragment,
   Eip712TypedDataDomainFragment,
   RelayerResultFragment,
   RelayErrorFragment,
+  FollowingFragment,
+  FollowerFragment,
   Erc20AmountFragment,
 } from '../../graphql/fragments.generated';
 import { GraphQLClient } from 'graphql-request';
@@ -26,11 +26,11 @@ import {
   CommentFragmentDoc,
   CommonPaginatedResultInfoFragmentDoc,
   WalletFragmentDoc,
-  FollowingFragmentDoc,
-  FollowerFragmentDoc,
   Eip712TypedDataDomainFragmentDoc,
   RelayerResultFragmentDoc,
   RelayErrorFragmentDoc,
+  FollowingFragmentDoc,
+  FollowerFragmentDoc,
   Erc20AmountFragmentDoc,
 } from '../../graphql/fragments.generated';
 export type PublicationQueryVariables = Types.Exact<{
@@ -94,6 +94,151 @@ export type PublicationMetadataStatusQuery = {
     __typename: 'PublicationMetadataStatus';
     reason: string | null;
     status: Types.PublicationMetadataStatusType;
+  };
+};
+
+export type CreatePostTypedDataMutationVariables = Types.Exact<{
+  request: Types.CreatePublicPostRequest;
+  options?: Types.InputMaybe<Types.TypedDataOptions>;
+}>;
+
+export type CreatePostTypedDataMutation = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { PostWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomainFragment;
+      value: {
+        nonce: number;
+        deadline: string;
+        profileId: string;
+        contentURI: string;
+        collectModule: string;
+        collectModuleInitData: string;
+        referenceModule: string;
+        referenceModuleInitData: string;
+      };
+    };
+  };
+};
+
+export type CreatePostViaDispatcherMutationVariables = Types.Exact<{
+  request: Types.CreatePublicPostRequest;
+}>;
+
+export type CreatePostViaDispatcherMutation = {
+  result: RelayErrorFragment | RelayerResultFragment;
+};
+
+export type CreateCommentTypedDataMutationVariables = Types.Exact<{
+  request: Types.CreatePublicCommentRequest;
+  options?: Types.InputMaybe<Types.TypedDataOptions>;
+}>;
+
+export type CreateCommentTypedDataMutation = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { CommentWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomainFragment;
+      value: {
+        nonce: number;
+        deadline: string;
+        profileId: string;
+        contentURI: string;
+        profileIdPointed: string;
+        pubIdPointed: string;
+        collectModule: string;
+        collectModuleInitData: string;
+        referenceModuleData: string;
+        referenceModule: string;
+        referenceModuleInitData: string;
+      };
+    };
+  };
+};
+
+export type CreateCommentViaDispatcherMutationVariables = Types.Exact<{
+  request: Types.CreatePublicCommentRequest;
+}>;
+
+export type CreateCommentViaDispatcherMutation = {
+  result: RelayErrorFragment | RelayerResultFragment;
+};
+
+export type CreateMirrorTypedDataMutationVariables = Types.Exact<{
+  request: Types.CreateMirrorRequest;
+  options?: Types.InputMaybe<Types.TypedDataOptions>;
+}>;
+
+export type CreateMirrorTypedDataMutation = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { MirrorWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomainFragment;
+      value: {
+        nonce: number;
+        deadline: string;
+        profileId: string;
+        profileIdPointed: string;
+        pubIdPointed: string;
+        referenceModuleData: string;
+        referenceModule: string;
+        referenceModuleInitData: string;
+      };
+    };
+  };
+};
+
+export type CreateMirrorViaDispatcherMutationVariables = Types.Exact<{
+  request: Types.CreateMirrorRequest;
+}>;
+
+export type CreateMirrorViaDispatcherMutation = {
+  result: RelayErrorFragment | RelayerResultFragment;
+};
+
+export type CreateCollectTypedDataMutationVariables = Types.Exact<{
+  request: Types.CreateCollectRequest;
+  options?: Types.InputMaybe<Types.TypedDataOptions>;
+}>;
+
+export type CreateCollectTypedDataMutation = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { CollectWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomainFragment;
+      value: { nonce: number; deadline: string; profileId: string; pubId: string; data: string };
+    };
+  };
+};
+
+export type HidePublicationMutationVariables = Types.Exact<{
+  request: Types.HidePublicationRequest;
+}>;
+
+export type HidePublicationMutation = { hidePublication: void | null };
+
+export type CreateAttachMediaDataMutationVariables = Types.Exact<{
+  request: Types.PublicMediaRequest;
+}>;
+
+export type CreateAttachMediaDataMutation = {
+  result: {
+    signedUrl: string;
+    media: {
+      altTag: string | null;
+      cover: string | null;
+      item: string;
+      source: Types.PublicationMediaSource | null;
+      type: string | null;
+    };
   };
 };
 
@@ -194,6 +339,190 @@ export const PublicationMetadataStatusDocument = gql`
     }
   }
 `;
+export const CreatePostTypedDataDocument = gql`
+  mutation CreatePostTypedData($request: CreatePublicPostRequest!, $options: TypedDataOptions) {
+    result: createPostTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          PostWithSig {
+            name
+            type
+          }
+        }
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          contentURI
+          collectModule
+          collectModuleInitData
+          referenceModule
+          referenceModuleInitData
+        }
+      }
+    }
+  }
+  ${Eip712TypedDataDomainFragmentDoc}
+`;
+export const CreatePostViaDispatcherDocument = gql`
+  mutation CreatePostViaDispatcher($request: CreatePublicPostRequest!) {
+    result: createPostViaDispatcher(request: $request) {
+      ... on RelayerResult {
+        ...RelayerResult
+      }
+      ... on RelayError {
+        ...RelayError
+      }
+    }
+  }
+  ${RelayerResultFragmentDoc}
+  ${RelayErrorFragmentDoc}
+`;
+export const CreateCommentTypedDataDocument = gql`
+  mutation CreateCommentTypedData(
+    $request: CreatePublicCommentRequest!
+    $options: TypedDataOptions
+  ) {
+    result: createCommentTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          CommentWithSig {
+            name
+            type
+          }
+        }
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          contentURI
+          profileIdPointed
+          pubIdPointed
+          collectModule
+          collectModuleInitData
+          referenceModuleData
+          referenceModule
+          referenceModuleInitData
+        }
+      }
+    }
+  }
+  ${Eip712TypedDataDomainFragmentDoc}
+`;
+export const CreateCommentViaDispatcherDocument = gql`
+  mutation CreateCommentViaDispatcher($request: CreatePublicCommentRequest!) {
+    result: createCommentViaDispatcher(request: $request) {
+      ... on RelayerResult {
+        ...RelayerResult
+      }
+      ... on RelayError {
+        ...RelayError
+      }
+    }
+  }
+  ${RelayerResultFragmentDoc}
+  ${RelayErrorFragmentDoc}
+`;
+export const CreateMirrorTypedDataDocument = gql`
+  mutation CreateMirrorTypedData($request: CreateMirrorRequest!, $options: TypedDataOptions) {
+    result: createMirrorTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          MirrorWithSig {
+            name
+            type
+          }
+        }
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          profileIdPointed
+          pubIdPointed
+          referenceModuleData
+          referenceModule
+          referenceModuleInitData
+        }
+      }
+    }
+  }
+  ${Eip712TypedDataDomainFragmentDoc}
+`;
+export const CreateMirrorViaDispatcherDocument = gql`
+  mutation CreateMirrorViaDispatcher($request: CreateMirrorRequest!) {
+    result: createMirrorViaDispatcher(request: $request) {
+      ... on RelayerResult {
+        ...RelayerResult
+      }
+      ... on RelayError {
+        ...RelayError
+      }
+    }
+  }
+  ${RelayerResultFragmentDoc}
+  ${RelayErrorFragmentDoc}
+`;
+export const CreateCollectTypedDataDocument = gql`
+  mutation CreateCollectTypedData($request: CreateCollectRequest!, $options: TypedDataOptions) {
+    result: createCollectTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          CollectWithSig {
+            name
+            type
+          }
+        }
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          pubId
+          data
+        }
+      }
+    }
+  }
+  ${Eip712TypedDataDomainFragmentDoc}
+`;
+export const HidePublicationDocument = gql`
+  mutation HidePublication($request: HidePublicationRequest!) {
+    hidePublication(request: $request)
+  }
+`;
+export const CreateAttachMediaDataDocument = gql`
+  mutation CreateAttachMediaData($request: PublicMediaRequest!) {
+    result: createAttachMediaData(request: $request) {
+      media {
+        altTag
+        cover
+        item
+        source
+        type
+      }
+      signedUrl
+    }
+  }
+`;
 
 export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
@@ -208,6 +537,15 @@ const ValidatePublicationMetadataDocumentString = print(ValidatePublicationMetad
 const WhoCollectedPublicationDocumentString = print(WhoCollectedPublicationDocument);
 const ProfilePublicationsForSaleDocumentString = print(ProfilePublicationsForSaleDocument);
 const PublicationMetadataStatusDocumentString = print(PublicationMetadataStatusDocument);
+const CreatePostTypedDataDocumentString = print(CreatePostTypedDataDocument);
+const CreatePostViaDispatcherDocumentString = print(CreatePostViaDispatcherDocument);
+const CreateCommentTypedDataDocumentString = print(CreateCommentTypedDataDocument);
+const CreateCommentViaDispatcherDocumentString = print(CreateCommentViaDispatcherDocument);
+const CreateMirrorTypedDataDocumentString = print(CreateMirrorTypedDataDocument);
+const CreateMirrorViaDispatcherDocumentString = print(CreateMirrorViaDispatcherDocument);
+const CreateCollectTypedDataDocumentString = print(CreateCollectTypedDataDocument);
+const HidePublicationDocumentString = print(HidePublicationDocument);
+const CreateAttachMediaDataDocumentString = print(CreateAttachMediaDataDocument);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     Publication(
@@ -321,6 +659,185 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
           ),
         'PublicationMetadataStatus',
         'query',
+      );
+    },
+    CreatePostTypedData(
+      variables: CreatePostTypedDataMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreatePostTypedDataMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreatePostTypedDataMutation>(
+            CreatePostTypedDataDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreatePostTypedData',
+        'mutation',
+      );
+    },
+    CreatePostViaDispatcher(
+      variables: CreatePostViaDispatcherMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreatePostViaDispatcherMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreatePostViaDispatcherMutation>(
+            CreatePostViaDispatcherDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreatePostViaDispatcher',
+        'mutation',
+      );
+    },
+    CreateCommentTypedData(
+      variables: CreateCommentTypedDataMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateCommentTypedDataMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateCommentTypedDataMutation>(
+            CreateCommentTypedDataDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateCommentTypedData',
+        'mutation',
+      );
+    },
+    CreateCommentViaDispatcher(
+      variables: CreateCommentViaDispatcherMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateCommentViaDispatcherMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateCommentViaDispatcherMutation>(
+            CreateCommentViaDispatcherDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateCommentViaDispatcher',
+        'mutation',
+      );
+    },
+    CreateMirrorTypedData(
+      variables: CreateMirrorTypedDataMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateMirrorTypedDataMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateMirrorTypedDataMutation>(
+            CreateMirrorTypedDataDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateMirrorTypedData',
+        'mutation',
+      );
+    },
+    CreateMirrorViaDispatcher(
+      variables: CreateMirrorViaDispatcherMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateMirrorViaDispatcherMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateMirrorViaDispatcherMutation>(
+            CreateMirrorViaDispatcherDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateMirrorViaDispatcher',
+        'mutation',
+      );
+    },
+    CreateCollectTypedData(
+      variables: CreateCollectTypedDataMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateCollectTypedDataMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateCollectTypedDataMutation>(
+            CreateCollectTypedDataDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateCollectTypedData',
+        'mutation',
+      );
+    },
+    HidePublication(
+      variables: HidePublicationMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: HidePublicationMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<HidePublicationMutation>(HidePublicationDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'HidePublication',
+        'mutation',
+      );
+    },
+    CreateAttachMediaData(
+      variables: CreateAttachMediaDataMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: CreateAttachMediaDataMutation;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<CreateAttachMediaDataMutation>(
+            CreateAttachMediaDataDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'CreateAttachMediaData',
+        'mutation',
       );
     },
   };

--- a/packages/client/src/publication/graphql/publication.generated.ts
+++ b/packages/client/src/publication/graphql/publication.generated.ts
@@ -33,12 +33,35 @@ import {
   FollowerFragmentDoc,
   Erc20AmountFragmentDoc,
 } from '../../graphql/fragments.generated';
+export type PublicationStatsFragment = {
+  __typename: 'PublicationStats';
+  totalAmountOfMirrors: number;
+  totalAmountOfCollects: number;
+  totalAmountOfComments: number;
+  totalUpvotes: number;
+  totalDownvotes: number;
+  commentsTotal: number;
+};
+
 export type PublicationQueryVariables = Types.Exact<{
-  observerId?: Types.InputMaybe<Types.Scalars['ProfileId']>;
   request: Types.PublicationQueryRequest;
+  observerId?: Types.InputMaybe<Types.Scalars['ProfileId']>;
 }>;
 
 export type PublicationQuery = { result: CommentFragment | MirrorFragment | PostFragment | null };
+
+export type PublicationStatsQueryVariables = Types.Exact<{
+  request: Types.PublicationQueryRequest;
+  sources: Array<Types.Scalars['Sources']> | Types.Scalars['Sources'];
+}>;
+
+export type PublicationStatsQuery = {
+  result:
+    | { stats: PublicationStatsFragment }
+    | { stats: PublicationStatsFragment }
+    | { stats: PublicationStatsFragment }
+    | null;
+};
 
 export type PublicationsQueryVariables = Types.Exact<{
   request: Types.PublicationsQueryRequest;
@@ -242,8 +265,19 @@ export type CreateAttachMediaDataMutation = {
   };
 };
 
+export const PublicationStatsFragmentDoc = gql`
+  fragment PublicationStats on PublicationStats {
+    __typename
+    totalAmountOfMirrors
+    totalAmountOfCollects
+    totalAmountOfComments
+    totalUpvotes
+    totalDownvotes
+    commentsTotal(forSources: $sources)
+  }
+`;
 export const PublicationDocument = gql`
-  query Publication($observerId: ProfileId, $request: PublicationQueryRequest!) {
+  query Publication($request: PublicationQueryRequest!, $observerId: ProfileId) {
     result: publication(request: $request) {
       ... on Post {
         ...Post
@@ -259,6 +293,28 @@ export const PublicationDocument = gql`
   ${PostFragmentDoc}
   ${MirrorFragmentDoc}
   ${CommentFragmentDoc}
+`;
+export const PublicationStatsDocument = gql`
+  query PublicationStats($request: PublicationQueryRequest!, $sources: [Sources!]!) {
+    result: publication(request: $request) {
+      ... on Post {
+        stats {
+          ...PublicationStats
+        }
+      }
+      ... on Mirror {
+        stats {
+          ...PublicationStats
+        }
+      }
+      ... on Comment {
+        stats {
+          ...PublicationStats
+        }
+      }
+    }
+  }
+  ${PublicationStatsFragmentDoc}
 `;
 export const PublicationsDocument = gql`
   query Publications($request: PublicationsQueryRequest!, $observerId: ProfileId) {
@@ -532,6 +588,7 @@ export type SdkFunctionWrapper = <T>(
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
 const PublicationDocumentString = print(PublicationDocument);
+const PublicationStatsDocumentString = print(PublicationStatsDocument);
 const PublicationsDocumentString = print(PublicationsDocument);
 const ValidatePublicationMetadataDocumentString = print(ValidatePublicationMetadataDocument);
 const WhoCollectedPublicationDocumentString = print(WhoCollectedPublicationDocument);
@@ -559,6 +616,25 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'Publication',
+        'query',
+      );
+    },
+    PublicationStats(
+      variables: PublicationStatsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<{
+      data: PublicationStatsQuery;
+      extensions?: any;
+      headers: Dom.Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<PublicationStatsQuery>(PublicationStatsDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'PublicationStats',
         'query',
       );
     },

--- a/packages/client/src/publication/graphql/publication.graphql
+++ b/packages/client/src/publication/graphql/publication.graphql
@@ -1,3 +1,4 @@
+# queries
 query Publication($observerId: ProfileId, $request: PublicationQueryRequest!) {
   result: publication(request: $request) {
     ... on Post {
@@ -80,5 +81,171 @@ query PublicationMetadataStatus($request: GetPublicationMetadataStatusRequest!) 
     __typename
     reason
     status
+  }
+}
+
+# mutations
+mutation CreatePostTypedData($request: CreatePublicPostRequest!, $options: TypedDataOptions) {
+  result: createPostTypedData(request: $request, options: $options) {
+    id
+    expiresAt
+    typedData {
+      types {
+        PostWithSig {
+          name
+          type
+        }
+      }
+      domain {
+        ...EIP712TypedDataDomain
+      }
+      value {
+        nonce
+        deadline
+        profileId
+        contentURI
+        collectModule
+        collectModuleInitData
+        referenceModule
+        referenceModuleInitData
+      }
+    }
+  }
+}
+
+mutation CreatePostViaDispatcher($request: CreatePublicPostRequest!) {
+  result: createPostViaDispatcher(request: $request) {
+    ... on RelayerResult {
+      ...RelayerResult
+    }
+
+    ... on RelayError {
+      ...RelayError
+    }
+  }
+}
+
+mutation CreateCommentTypedData($request: CreatePublicCommentRequest!, $options: TypedDataOptions) {
+  result: createCommentTypedData(request: $request, options: $options) {
+    id
+    expiresAt
+    typedData {
+      types {
+        CommentWithSig {
+          name
+          type
+        }
+      }
+      domain {
+        ...EIP712TypedDataDomain
+      }
+      value {
+        nonce
+        deadline
+        profileId
+        contentURI
+        profileIdPointed
+        pubIdPointed
+        collectModule
+        collectModuleInitData
+        referenceModuleData
+        referenceModule
+        referenceModuleInitData
+      }
+    }
+  }
+}
+
+mutation CreateCommentViaDispatcher($request: CreatePublicCommentRequest!) {
+  result: createCommentViaDispatcher(request: $request) {
+    ... on RelayerResult {
+      ...RelayerResult
+    }
+
+    ... on RelayError {
+      ...RelayError
+    }
+  }
+}
+
+mutation CreateMirrorTypedData($request: CreateMirrorRequest!, $options: TypedDataOptions) {
+  result: createMirrorTypedData(request: $request, options: $options) {
+    id
+    expiresAt
+    typedData {
+      types {
+        MirrorWithSig {
+          name
+          type
+        }
+      }
+      domain {
+        ...EIP712TypedDataDomain
+      }
+      value {
+        nonce
+        deadline
+        profileId
+        profileIdPointed
+        pubIdPointed
+        referenceModuleData
+        referenceModule
+        referenceModuleInitData
+      }
+    }
+  }
+}
+
+mutation CreateMirrorViaDispatcher($request: CreateMirrorRequest!) {
+  result: createMirrorViaDispatcher(request: $request) {
+    ... on RelayerResult {
+      ...RelayerResult
+    }
+
+    ... on RelayError {
+      ...RelayError
+    }
+  }
+}
+
+mutation CreateCollectTypedData($request: CreateCollectRequest!, $options: TypedDataOptions) {
+  result: createCollectTypedData(request: $request, options: $options) {
+    id
+    expiresAt
+    typedData {
+      types {
+        CollectWithSig {
+          name
+          type
+        }
+      }
+      domain {
+        ...EIP712TypedDataDomain
+      }
+      value {
+        nonce
+        deadline
+        profileId
+        pubId
+        data
+      }
+    }
+  }
+}
+
+mutation HidePublication($request: HidePublicationRequest!) {
+  hidePublication(request: $request)
+}
+
+mutation CreateAttachMediaData($request: PublicMediaRequest!) {
+  result: createAttachMediaData(request: $request) {
+    media {
+      altTag
+      cover
+      item
+      source
+      type
+    }
+    signedUrl
   }
 }

--- a/packages/client/src/publication/graphql/publication.graphql
+++ b/packages/client/src/publication/graphql/publication.graphql
@@ -266,10 +266,6 @@ mutation CreateCollectTypedData($request: CreateCollectRequest!, $options: Typed
   }
 }
 
-mutation HidePublication($request: HidePublicationRequest!) {
-  hidePublication(request: $request)
-}
-
 mutation CreateAttachMediaData($request: PublicMediaRequest!) {
   result: createAttachMediaData(request: $request) {
     media {
@@ -281,4 +277,12 @@ mutation CreateAttachMediaData($request: PublicMediaRequest!) {
     }
     signedUrl
   }
+}
+
+mutation HidePublication($request: HidePublicationRequest!) {
+  hidePublication(request: $request)
+}
+
+mutation ReportPublication($request: ReportPublicationRequest!) {
+  reportPublication(request: $request)
 }

--- a/packages/client/src/publication/graphql/publication.graphql
+++ b/packages/client/src/publication/graphql/publication.graphql
@@ -1,5 +1,16 @@
+#fragments
+fragment PublicationStats on PublicationStats {
+  __typename
+  totalAmountOfMirrors
+  totalAmountOfCollects
+  totalAmountOfComments
+  totalUpvotes
+  totalDownvotes
+  commentsTotal(forSources: $sources)
+}
+
 # queries
-query Publication($observerId: ProfileId, $request: PublicationQueryRequest!) {
+query Publication($request: PublicationQueryRequest!, $observerId: ProfileId) {
   result: publication(request: $request) {
     ... on Post {
       ...Post
@@ -11,6 +22,28 @@ query Publication($observerId: ProfileId, $request: PublicationQueryRequest!) {
 
     ... on Comment {
       ...Comment
+    }
+  }
+}
+
+query PublicationStats($request: PublicationQueryRequest!, $sources: [Sources!]!) {
+  result: publication(request: $request) {
+    ... on Post {
+      stats {
+        ...PublicationStats
+      }
+    }
+
+    ... on Mirror {
+      stats {
+        ...PublicationStats
+      }
+    }
+
+    ... on Comment {
+      stats {
+        ...PublicationStats
+      }
     }
   }
 }

--- a/packages/client/src/publication/helpers/buildReportReason.ts
+++ b/packages/client/src/publication/helpers/buildReportReason.ts
@@ -1,0 +1,159 @@
+import { assertNever } from '@lens-protocol/shared-kernel';
+
+import {
+  PublicationReportingFraudSubreason,
+  PublicationReportingIllegalSubreason,
+  PublicationReportingReason,
+  PublicationReportingSensitiveSubreason,
+  PublicationReportingSpamSubreason,
+  ReportingReasonInputParams,
+} from '../../graphql/types.generated';
+
+export enum PublicationReportReason {
+  // Illegal
+  ANIMAL_ABUSE = 'ANIMAL_ABUSE',
+  HARASSMENT = 'HARASSMENT',
+  VIOLENCE = 'VIOLENCE',
+  SELF_HARM = 'SELF_HARM',
+  DIRECT_THREAT = 'DIRECT_THREAT',
+  HATE_SPEECH = 'HATE_SPEECH',
+
+  // Sensitive content
+  NUDITY = 'NUDITY',
+  OFFENSIVE = 'OFFENSIVE',
+
+  // Fraud
+  SCAM = 'SCAM',
+  UNAUTHORIZED_SALE = 'UNAUTHORIZED_SALE',
+  IMPERSONATION = 'IMPERSONATION',
+
+  // Spam
+  MISLEADING = 'MISLEADING',
+  MISUSE_HASHTAGS = 'MISUSE_HASHTAGS',
+  UNRELATED = 'UNRELATED',
+  REPETITIVE = 'REPETITIVE',
+  FAKE_ENGAGEMENT = 'FAKE_ENGAGEMENT',
+  MANIPULATION_ALGO = 'MANIPULATION_ALGO',
+  SOMETHING_ELSE = 'SOMETHING_ELSE',
+}
+
+export const buildReportReason = (reason: PublicationReportReason): ReportingReasonInputParams => {
+  switch (reason) {
+    case PublicationReportReason.VIOLENCE:
+      return {
+        illegalReason: {
+          reason: PublicationReportingReason.Illegal,
+          subreason: PublicationReportingIllegalSubreason.Violence,
+        },
+      };
+    case PublicationReportReason.SELF_HARM:
+      return {
+        illegalReason: {
+          reason: PublicationReportingReason.Illegal,
+          subreason: PublicationReportingIllegalSubreason.ThreatIndividual,
+        },
+      };
+    case PublicationReportReason.DIRECT_THREAT:
+      return {
+        illegalReason: {
+          reason: PublicationReportingReason.Illegal,
+          subreason: PublicationReportingIllegalSubreason.DirectThreat,
+        },
+      };
+    case PublicationReportReason.HARASSMENT:
+    case PublicationReportReason.HATE_SPEECH:
+      return {
+        illegalReason: {
+          reason: PublicationReportingReason.Illegal,
+          subreason: PublicationReportingIllegalSubreason.HumanAbuse,
+        },
+      };
+    case PublicationReportReason.ANIMAL_ABUSE:
+      return {
+        illegalReason: {
+          reason: PublicationReportingReason.Illegal,
+          subreason: PublicationReportingIllegalSubreason.AnimalAbuse,
+        },
+      };
+    case PublicationReportReason.SCAM:
+    case PublicationReportReason.UNAUTHORIZED_SALE:
+      return {
+        fraudReason: {
+          reason: PublicationReportingReason.Fraud,
+          subreason: PublicationReportingFraudSubreason.Scam,
+        },
+      };
+    case PublicationReportReason.IMPERSONATION:
+      return {
+        fraudReason: {
+          reason: PublicationReportingReason.Fraud,
+          subreason: PublicationReportingFraudSubreason.Impersonation,
+        },
+      };
+    case PublicationReportReason.NUDITY:
+      return {
+        sensitiveReason: {
+          reason: PublicationReportingReason.Sensitive,
+          subreason: PublicationReportingSensitiveSubreason.Nsfw,
+        },
+      };
+    case PublicationReportReason.OFFENSIVE:
+      return {
+        sensitiveReason: {
+          reason: PublicationReportingReason.Sensitive,
+          subreason: PublicationReportingSensitiveSubreason.Offensive,
+        },
+      };
+    case PublicationReportReason.MISLEADING:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.Misleading,
+        },
+      };
+    case PublicationReportReason.MISUSE_HASHTAGS:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.MisuseHashtags,
+        },
+      };
+    case PublicationReportReason.UNRELATED:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.Unrelated,
+        },
+      };
+    case PublicationReportReason.REPETITIVE:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.Repetitive,
+        },
+      };
+    case PublicationReportReason.FAKE_ENGAGEMENT:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.FakeEngagement,
+        },
+      };
+    case PublicationReportReason.MANIPULATION_ALGO:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.ManipulationAlgo,
+        },
+      };
+    case PublicationReportReason.SOMETHING_ELSE:
+      return {
+        spamReason: {
+          reason: PublicationReportingReason.Spam,
+          subreason: PublicationReportingSpamSubreason.SomethingElse,
+        },
+      };
+    default:
+      assertNever(reason, `Unknown report type`);
+  }
+};

--- a/packages/client/src/publication/index.ts
+++ b/packages/client/src/publication/index.ts
@@ -1,3 +1,5 @@
+export { PublicationReportReason } from './helpers/buildReportReason';
+
 export * from './Publication';
 export {
   PublicationMetadataDisplayTypes,

--- a/packages/client/src/revenue/graphql/revenue.generated.ts
+++ b/packages/client/src/revenue/graphql/revenue.generated.ts
@@ -9,6 +9,9 @@ import {
   MirrorFragment,
   CommentFragment,
   WalletFragment,
+  Eip712TypedDataDomainFragment,
+  RelayerResultFragment,
+  RelayErrorFragment,
 } from '../../graphql/fragments.generated';
 import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
@@ -22,6 +25,9 @@ import {
   MirrorFragmentDoc,
   CommentFragmentDoc,
   WalletFragmentDoc,
+  Eip712TypedDataDomainFragmentDoc,
+  RelayerResultFragmentDoc,
+  RelayErrorFragmentDoc,
 } from '../../graphql/fragments.generated';
 export type ProfilePublicationRevenueQueryVariables = Types.Exact<{
   request: Types.ProfilePublicationRevenueQueryRequest;


### PR DESCRIPTION
```
- [x] [Q] client.publication.stats(request)
- [x] [AM] client.publication.createPostTypedData(request)
- [x] [AM] client.publication.createPostViaDispatcher(request)

- [x] [AM] client.publication.createCommentTypedData(request)
- [x] [AM] client.publication.createCommentViaDispatcher(request)

- [x] [AM] client.publication.createMirrorTypedData(request)
- [x] [AM] client.publication.createMirrorViaDispatcher(request)

- [x] [AM] client.publication.createCollectTypedData(request)

- [x] [AM] client.publication.hide({ publicationId })
- [x] [M] client.publication.createAttachMediaData(request)

- [x] [AM] client.publication.report(request)
- [x] [H] client.publication.buildReportReason(PublicationReportReason)
```