### PR TITLE
chore: update changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,17 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@lens-protocol/*"]],
+  "fixed": [
+    [
+      "@lens-protocol/api-bindings",
+      "@lens-protocol/blockchain-bindings",
+      "@lens-protocol/domain",
+      "@lens-protocol/react",
+      "@lens-protocol/storage",
+      "@lens-protocol/wagmi",
+      "@lens-protocol/shared-kernel"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ _Note: Because this command assumes that the last commit is the release commit, 
 git push --follow-tags
 ```
 
+7. It's important that the last commit, from which the release was made and the git tags are associated with, is correctly merged to the `main` branch. Use `"Create a merge commit"` option when merging the release branch to the `main`.
+
 ## License
 
 Lens SDK is [MIT licensed](./LICENSE)


### PR DESCRIPTION
I'm not really happy or just confused with how `changesets` work, as it always bumps major versions even if I requested only minor ones. anyway, with this PR I'm excluding `client` and other packages we don't publish from the changeset versioning to make it a bit easier for the person who prepares the release.

wdyt?  