### PR TITLE
feat: wires Active Profile ID as `observerId` in the remaining hooks

### DIFF
--- a/examples/web-wagmi/src/profiles/UseCreateProfile.tsx
+++ b/examples/web-wagmi/src/profiles/UseCreateProfile.tsx
@@ -1,5 +1,7 @@
-import { useActiveWallet, useCreateProfile, useProfilesOwnedByMe } from '@lens-protocol/react';
+import { useCreateProfile, useProfilesOwnedByMe } from '@lens-protocol/react';
 
+import { UnauthenticatedFallback } from '../components/UnauthenticatedFallback';
+import { WhenLoggedInWithProfile } from '../components/auth/auth';
 import { never } from '../utils';
 import { ProfileCard } from './components/ProfileCard';
 
@@ -20,25 +22,24 @@ function OwnedProfiles() {
   );
 }
 
-export function UseCreateProfile() {
+function CreateProfileForm() {
   const { execute: create, error, isPending } = useCreateProfile();
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget);
-    const handle = (formData.get('handle') as string) ?? never();
-    await create(handle);
-  };
+    const form = event.currentTarget;
 
-  const activeWallet = useActiveWallet();
+    const formData = new FormData(form);
+    const handle = (formData.get('handle') as string) ?? never();
+
+    await create(handle);
+
+    form.reset();
+  };
 
   return (
     <div>
-      <h1>
-        <code>useCreateProfile</code>
-      </h1>
-
       <form onSubmit={onSubmit}>
         <fieldset>
           <label>
@@ -62,7 +63,20 @@ export function UseCreateProfile() {
         {error && <p>{error.message}</p>}
       </form>
 
-      {activeWallet.data && <OwnedProfiles />}
+      <OwnedProfiles />
+    </div>
+  );
+}
+
+export function UseCreateProfile() {
+  return (
+    <div>
+      <h1>
+        <code>useCreateProfile</code>
+      </h1>
+
+      <WhenLoggedInWithProfile>{() => <CreateProfileForm />}</WhenLoggedInWithProfile>
+      <UnauthenticatedFallback message="Log in to create new profiles" />
     </div>
   );
 }

--- a/examples/web-wagmi/src/revenue/UsePublicationRevenue.tsx
+++ b/examples/web-wagmi/src/revenue/UsePublicationRevenue.tsx
@@ -1,39 +1,30 @@
-import { usePublication, usePublicationRevenue } from '@lens-protocol/react';
+import { usePublicationRevenue } from '@lens-protocol/react';
 
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
-import { PublicationCard } from '../publications/components/PublicationCard';
-import { RevenueCard } from './components/RevenueCard';
+import { PublicationRevenueCard } from './components/PublicationRevenueCard';
 
 const publicationId = '0x4f90-0x02';
 
 export function UsePublicationRevenue() {
   const {
     data: publicationRevenue,
-    error: revenueError,
-    loading: publicationRevenueLoading,
+    error,
+    loading,
   } = usePublicationRevenue({
     publicationId,
   });
-  const {
-    data: publication,
-    error: publicationError,
-    loading: publicationLoading,
-  } = usePublication({ publicationId });
 
-  if (publicationRevenueLoading || publicationLoading) return <Loading />;
+  if (loading) return <Loading />;
 
-  if (revenueError) return <ErrorMessage error={revenueError} />;
-  if (publicationError) return <ErrorMessage error={publicationError} />;
+  if (error) return <ErrorMessage error={error} />;
 
   return (
     <div>
       <h1>
         <code>usePublicationRevenue</code>
       </h1>
-      <PublicationCard publication={publication} />
-      <h2>Revenue</h2>
-      <RevenueCard revenue={publicationRevenue} />
+      <PublicationRevenueCard publicationRevenue={publicationRevenue} />
     </div>
   );
 }

--- a/packages/api-bindings/src/graphql/__helpers__/fragments.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/fragments.ts
@@ -47,7 +47,6 @@ import {
   RelayErrorFragment,
   RelayErrorReasons,
   RevenueAggregateFragment,
-  RevenueFragment,
   RootCriterionFragment,
   ScalarOperator,
   WalletFragment,
@@ -396,18 +395,6 @@ export function mockPublicationRevenueFragment({
   return {
     __typename: 'PublicationRevenue',
     publication: publication,
-    revenue: mockRevenueAggregateFragment(amount),
-  };
-}
-
-export function mockRevenueFragment({
-  amount,
-}: {
-  publication?: CommentFragment | PostFragment | MirrorFragment;
-  amount?: Amount<Erc20>;
-} = {}): RevenueFragment {
-  return {
-    __typename: 'PublicationRevenue',
     revenue: mockRevenueAggregateFragment(amount),
   };
 }

--- a/packages/api-bindings/src/graphql/__helpers__/queries.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/queries.ts
@@ -69,7 +69,6 @@ import {
   PublicationsDocument,
   PublicationsQuery,
   PublicationsQueryVariables,
-  RevenueFragment,
   SearchProfilesDocument,
   SearchProfilesQueryVariables,
   SearchPublicationsDocument,
@@ -445,7 +444,7 @@ export function createExplorePublicationsQueryMockedResponse(args: {
 
 export function createPublicationRevenueQueryMockedResponse(args: {
   variables: PublicationRevenueQueryVariables;
-  revenue: RevenueFragment | null;
+  revenue: PublicationRevenueFragment | null;
 }): MockedResponse<PublicationRevenueQuery> {
   return {
     request: {

--- a/packages/api-bindings/src/graphql/__helpers__/queries.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/queries.ts
@@ -370,7 +370,7 @@ export function createPublicationQueryMockedResponse({
 
 export function createPublicationsQueryMockedResponse(args: {
   variables: PublicationsQueryVariables;
-  publications: Array<CommentFragment | PostFragment>;
+  publications: Array<AnyPublicationFragment>;
 }): MockedResponse<PublicationsQuery> {
   return {
     request: {

--- a/packages/api-bindings/src/graphql/__helpers__/queries.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/queries.ts
@@ -608,7 +608,7 @@ export function createProfilesWhoMirroredPublicationMockedResponse(args: {
 
 export function createSearchPublicationsQueryMockedResponse(args: {
   variables: SearchPublicationsQueryVariables;
-  items: Array<CommentFragment | PostFragment>;
+  items: Array<ContentPublicationFragment>;
 }): MockedResponse<SearchPublicationsQuery> {
   return {
     request: {

--- a/packages/api-bindings/src/graphql/__helpers__/queries.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/queries.ts
@@ -2,7 +2,12 @@ import { MockedResponse } from '@apollo/client/testing';
 import { AppId } from '@lens-protocol/domain/entities';
 import { Erc20 } from '@lens-protocol/shared-kernel';
 
-import { ContentPublicationFragment, SearchProfilesQuery, SearchPublicationsQuery } from '..';
+import {
+  AnyPublicationFragment,
+  ContentPublicationFragment,
+  SearchProfilesQuery,
+  SearchPublicationsQuery,
+} from '..';
 import {
   CommentFragment,
   CommentWithFirstCommentFragment,
@@ -350,7 +355,7 @@ export function createPublicationQueryMockedResponse({
   result,
 }: {
   variables: PublicationQueryVariables;
-  result: PostFragment | null;
+  result: AnyPublicationFragment | null;
 }): MockedResponse<PublicationQuery> {
   return {
     request: {

--- a/packages/api-bindings/src/graphql/__helpers__/queries.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/queries.ts
@@ -2,7 +2,7 @@ import { MockedResponse } from '@apollo/client/testing';
 import { AppId } from '@lens-protocol/domain/entities';
 import { Erc20 } from '@lens-protocol/shared-kernel';
 
-import { SearchProfilesQuery, SearchPublicationsQuery } from '..';
+import { ContentPublicationFragment, SearchProfilesQuery, SearchPublicationsQuery } from '..';
 import {
   CommentFragment,
   CommentWithFirstCommentFragment,
@@ -482,7 +482,7 @@ export function createProfilePublicationRevenueQueryMockedResponse(args: {
 
 export function createProfilePublicationsForSaleQueryMockedResponse(args: {
   variables: ProfilePublicationsForSaleQueryVariables;
-  items: PostFragment[];
+  items: ContentPublicationFragment[];
 }): MockedResponse<ProfilePublicationsForSaleQuery> {
   return {
     request: {

--- a/packages/api-bindings/src/graphql/revenue.graphql
+++ b/packages/api-bindings/src/graphql/revenue.graphql
@@ -23,19 +23,18 @@ fragment PublicationRevenue on PublicationRevenue {
     }
   }
 
-  ...Revenue
-}
-
-fragment Revenue on PublicationRevenue {
-  __typename
   revenue {
     ...RevenueAggregate
   }
 }
 
-query PublicationRevenue($request: PublicationRevenueQueryRequest!) {
-  result: publicationRevenue(request: $request) {
-    ...Revenue
+query PublicationRevenue(
+  $publicationId: InternalPublicationId!
+  $observerId: ProfileId
+  $sources: [Sources!]!
+) {
+  result: publicationRevenue(request: { publicationId: $publicationId }) {
+    ...PublicationRevenue
   }
 }
 

--- a/packages/react/src/profile/__tests__/useProfile.spec.ts
+++ b/packages/react/src/profile/__tests__/useProfile.spec.ts
@@ -5,7 +5,6 @@ import {
   mockProfileFragment,
   mockSources,
 } from '@lens-protocol/api-bindings/mocks';
-import { Profile } from '@lens-protocol/domain/entities';
 import { mockProfile, mockProfileId } from '@lens-protocol/domain/mocks';
 import { waitFor } from '@testing-library/react';
 
@@ -36,10 +35,7 @@ describe(`Given the ${useProfile.name} hook`, () => {
     simulateAppReady();
   });
 
-  describe.each<{
-    activeProfileValue: Profile | null;
-    precondition: string;
-  }>([
+  describe.each([
     {
       precondition: 'and NO Active Profile set',
       activeProfileValue: null,

--- a/packages/react/src/publication/__tests__/useProfilePublicationsForSale.spec.ts
+++ b/packages/react/src/publication/__tests__/useProfilePublicationsForSale.spec.ts
@@ -1,52 +1,97 @@
-import { PostFragment } from '@lens-protocol/api-bindings';
+import { ContentPublicationFragment } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockPostFragment,
-  mockProfileFragment,
   createProfilePublicationsForSaleQueryMockedResponse,
   mockSources,
 } from '@lens-protocol/api-bindings/mocks';
+import { ProfileId } from '@lens-protocol/domain/entities';
+import { mockProfile, mockProfileId } from '@lens-protocol/domain/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
-import { useProfilePublicationsForSale } from '../useProfilePublicationsForSale';
+import { simulateAppReady } from '../../lifecycle/adapters/__helpers__/simulate';
+import { activeProfileIdentifierVar } from '../../profile/adapters/ActiveProfilePresenter';
+import {
+  useProfilePublicationsForSale,
+  UseProfilePublicationsForSaleArgs,
+} from '../useProfilePublicationsForSale';
 
-const sources = mockSources();
+function setupTestScenario({
+  expectedObserverId,
+  result,
+  ...args
+}: UseProfilePublicationsForSaleArgs & {
+  expectedObserverId?: ProfileId;
+  result: ContentPublicationFragment[];
+}) {
+  const sources = mockSources();
+
+  return renderHookWithMocks(() => useProfilePublicationsForSale(args), {
+    mocks: {
+      sources,
+      apolloClient: createMockApolloClientWithMultipleResponses([
+        createProfilePublicationsForSaleQueryMockedResponse({
+          variables: {
+            ...args,
+            limit: 10,
+            sources,
+            observerId: expectedObserverId ?? null,
+          },
+          items: result,
+        }),
+      ]),
+    },
+  });
+}
 
 describe(`Given the ${useProfilePublicationsForSale.name} hook`, () => {
-  const profile = mockProfileFragment();
-  const observer = mockProfileFragment();
-  const mockPublication: PostFragment = mockPostFragment();
+  const profileId = mockProfileId();
+  const publications = [mockPostFragment()];
+
+  beforeAll(() => {
+    simulateAppReady();
+  });
 
   describe('when the query returns data successfully', () => {
     it('should return publications', async () => {
-      const { result } = renderHookWithMocks(
-        () =>
-          useProfilePublicationsForSale({
-            profileId: profile.id,
-            observerId: observer.id,
-          }),
-        {
-          mocks: {
-            sources,
-            apolloClient: createMockApolloClientWithMultipleResponses([
-              createProfilePublicationsForSaleQueryMockedResponse({
-                variables: {
-                  profileId: profile.id,
-                  observerId: observer.id,
-                  limit: 10,
-                  sources,
-                },
-                items: [mockPublication],
-              }),
-            ]),
-          },
-        },
-      );
+      const { result } = setupTestScenario({ profileId, result: publications });
 
       await waitFor(() => expect(result.current.loading).toBeFalsy());
+      expect(result.current.data).toEqual(publications);
+    });
+  });
 
-      expect(result.current.data).toEqual([mockPublication]);
+  describe('when there is an Active Profile defined', () => {
+    const activeProfile = mockProfile();
+
+    beforeAll(() => {
+      activeProfileIdentifierVar(activeProfile);
+    });
+
+    it('should use the Active Profile Id as the "observerId"', async () => {
+      const { result } = setupTestScenario({
+        profileId,
+        result: publications,
+        expectedObserverId: activeProfile.id,
+      });
+
+      await waitFor(() => expect(result.current.loading).toBeFalsy());
+      expect(result.current.data).toEqual(publications);
+    });
+
+    it('should always allow to specify the "observerId" on a per-call basis', async () => {
+      const observerId = mockProfileId();
+
+      const { result } = setupTestScenario({
+        profileId,
+        observerId,
+        result: publications,
+        expectedObserverId: observerId,
+      });
+
+      await waitFor(() => expect(result.current.loading).toBeFalsy());
+      expect(result.current.data).toEqual(publications);
     });
   });
 });

--- a/packages/react/src/publication/__tests__/usePublication.spec.ts
+++ b/packages/react/src/publication/__tests__/usePublication.spec.ts
@@ -15,8 +15,6 @@ import { simulateAppReady } from '../../lifecycle/adapters/__helpers__/simulate'
 import { activeProfileIdentifierVar } from '../../profile/adapters/ActiveProfilePresenter';
 import { usePublication, UsePublicationArgs } from '../usePublication';
 
-const sources = mockSources();
-
 function setupTestScenario({
   expectedObserverId,
   result,
@@ -27,6 +25,8 @@ function setupTestScenario({
   expectedObserverId?: ProfileId;
   result: AnyPublicationFragment | null;
 }) {
+  const sources = mockSources();
+
   return renderHookWithMocks(() => usePublication(args), {
     mocks: {
       sources,

--- a/packages/react/src/publication/__tests__/usePublication.spec.ts
+++ b/packages/react/src/publication/__tests__/usePublication.spec.ts
@@ -1,76 +1,110 @@
-import { PostFragment } from '@lens-protocol/api-bindings';
+import { AnyPublicationFragment } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   mockPostFragment,
   createPublicationQueryMockedResponse,
   mockSources,
 } from '@lens-protocol/api-bindings/mocks';
+import { Profile, ProfileId, PublicationId } from '@lens-protocol/domain/entities';
+import { mockProfile, mockProfileId } from '@lens-protocol/domain/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { NotFoundError } from '../../NotFoundError';
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
-import { usePublication } from '../usePublication';
+import { simulateAppReady } from '../../lifecycle/adapters/__helpers__/simulate';
+import { activeProfileIdentifierVar } from '../../profile/adapters/ActiveProfilePresenter';
+import { usePublication, UsePublicationArgs } from '../usePublication';
 
 const sources = mockSources();
 
-describe(`Given the ${usePublication.name} hook`, () => {
-  const mockPublication: PostFragment = mockPostFragment();
-
-  describe('when the query returns data successfully', () => {
-    it('should settle with the publication data', async () => {
-      const { result } = renderHookWithMocks(
-        () =>
-          usePublication({
-            publicationId: mockPublication.id,
-          }),
-        {
-          mocks: {
+function setupTestScenario({
+  expectedObserverId,
+  result,
+  ...args
+}: UsePublicationArgs & {
+  publicationId: PublicationId;
+  observerId?: ProfileId;
+  expectedObserverId?: ProfileId;
+  result: AnyPublicationFragment | null;
+}) {
+  return renderHookWithMocks(() => usePublication(args), {
+    mocks: {
+      sources,
+      apolloClient: createMockApolloClientWithMultipleResponses([
+        createPublicationQueryMockedResponse({
+          variables: {
+            ...args,
             sources,
-            apolloClient: createMockApolloClientWithMultipleResponses([
-              createPublicationQueryMockedResponse({
-                variables: {
-                  publicationId: mockPublication.id,
-                  sources,
-                },
-                result: mockPublication,
-              }),
-            ]),
+            observerId: expectedObserverId ?? null,
           },
-        },
-      );
+          result,
+        }),
+      ]),
+    },
+  });
+}
 
-      await waitFor(() => expect(result.current.loading).toBeFalsy());
+describe(`Given the ${usePublication.name} hook`, () => {
+  const publication = mockPostFragment();
 
-      expect(result.current.data).toEqual(mockPublication);
-    });
+  beforeAll(() => {
+    simulateAppReady();
   });
 
-  describe('when the query returns null', () => {
-    it(`should settle with a ${NotFoundError.name} state`, async () => {
-      const { result } = renderHookWithMocks(
-        () =>
-          usePublication({
-            publicationId: mockPublication.id,
-          }),
-        {
-          mocks: {
-            sources,
-            apolloClient: createMockApolloClientWithMultipleResponses([
-              createPublicationQueryMockedResponse({
-                variables: {
-                  publicationId: mockPublication.id,
-                  sources,
-                },
-                result: null,
-              }),
-            ]),
-          },
-        },
-      );
+  describe.each<{
+    activeProfileValue: Profile | null;
+    precondition: string;
+  }>([
+    {
+      precondition: 'and NO Active Profile set',
+      activeProfileValue: null,
+    },
+    {
+      precondition: 'and an Active Profile set',
+      activeProfileValue: mockProfile(),
+    },
+  ])('$precondition', ({ activeProfileValue }) => {
+    beforeAll(() => {
+      activeProfileIdentifierVar(activeProfileValue);
+    });
 
-      await waitFor(() => expect(result.current.loading).toBeFalsy());
+    describe('when the query returns data successfully', () => {
+      it('should settle with the publication data', async () => {
+        const { result } = setupTestScenario({
+          publicationId: publication.id,
+          expectedObserverId: activeProfileValue?.id,
+          result: publication,
+        });
 
-      expect(result.current.error).toBeInstanceOf(NotFoundError);
+        await waitFor(() => expect(result.current.loading).toBeFalsy());
+        expect(result.current.data).toEqual(publication);
+      });
+
+      it('should allow to specify the "observerId" on a per-call basis', async () => {
+        const observerId = mockProfileId();
+        const { result } = setupTestScenario({
+          publicationId: publication.id,
+          observerId,
+          expectedObserverId: observerId,
+          result: publication,
+        });
+
+        await waitFor(() => expect(result.current.loading).toBeFalsy());
+        expect(result.current.data).toEqual(publication);
+      });
+    });
+
+    describe('when the query returns null', () => {
+      it(`should settle with a ${NotFoundError.name} state`, async () => {
+        const { result } = setupTestScenario({
+          publicationId: publication.id,
+          expectedObserverId: activeProfileValue?.id,
+          result: null,
+        });
+
+        await waitFor(() => expect(result.current.loading).toBeFalsy());
+        expect(result.current.error).toBeInstanceOf(NotFoundError);
+      });
     });
   });
 });

--- a/packages/react/src/publication/__tests__/useWhoMirroredPublication.spec.ts
+++ b/packages/react/src/publication/__tests__/useWhoMirroredPublication.spec.ts
@@ -1,52 +1,95 @@
+import { ProfileFragment } from '@lens-protocol/api-bindings';
 import {
   createMockApolloClientWithMultipleResponses,
   createProfilesWhoMirroredPublicationMockedResponse,
-  mockPostFragment,
   mockProfileFragment,
   mockSources,
 } from '@lens-protocol/api-bindings/mocks';
+import { ProfileId } from '@lens-protocol/domain/entities';
+import { mockProfile, mockProfileId, mockPublicationId } from '@lens-protocol/domain/mocks';
 import { waitFor } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
-import { useWhoMirroredPublication } from '../useWhoMirroredPublication';
+import { simulateAppReady } from '../../lifecycle/adapters/__helpers__/simulate';
+import { activeProfileIdentifierVar } from '../../profile/adapters/ActiveProfilePresenter';
+import {
+  useWhoMirroredPublication,
+  UseWhoMirroredPublicationArgs,
+} from '../useWhoMirroredPublication';
 
-const sources = mockSources();
+function setupTestScenario({
+  expectedObserverId,
+  result,
+  ...args
+}: UseWhoMirroredPublicationArgs & { expectedObserverId?: ProfileId; result: ProfileFragment[] }) {
+  const sources = mockSources();
+
+  return renderHookWithMocks(() => useWhoMirroredPublication(args), {
+    mocks: {
+      sources,
+      apolloClient: createMockApolloClientWithMultipleResponses([
+        createProfilesWhoMirroredPublicationMockedResponse({
+          variables: {
+            ...args,
+            observerId: expectedObserverId ?? null,
+            limit: 10,
+            sources,
+          },
+          items: result,
+        }),
+      ]),
+    },
+  });
+}
 
 describe(`Given the ${useWhoMirroredPublication.name} hook`, () => {
-  const observer = mockProfileFragment();
-  const publication = mockPostFragment();
+  const publicationId = mockPublicationId();
+  const profiles = [mockProfileFragment()];
 
-  const mockProfiles = [mockProfileFragment()];
+  beforeAll(() => {
+    simulateAppReady();
+  });
 
   describe('when the query returns data successfully', () => {
     it('should return profiles that mirrored the queried publication', async () => {
-      const { result } = renderHookWithMocks(
-        () =>
-          useWhoMirroredPublication({
-            publicationId: publication.id,
-            observerId: observer.id,
-          }),
-        {
-          mocks: {
-            sources,
-            apolloClient: createMockApolloClientWithMultipleResponses([
-              createProfilesWhoMirroredPublicationMockedResponse({
-                variables: {
-                  publicationId: publication.id,
-                  observerId: observer.id,
-                  limit: 10,
-                  sources,
-                },
-                items: mockProfiles,
-              }),
-            ]),
-          },
-        },
-      );
+      const { result } = setupTestScenario({ publicationId, result: profiles });
 
       await waitFor(() => expect(result.current.loading).toBeFalsy());
 
-      expect(result.current.data).toEqual(mockProfiles);
+      expect(result.current.data).toEqual(profiles);
+    });
+  });
+
+  describe('when there is an Active Profile defined', () => {
+    const activeProfile = mockProfile();
+
+    beforeAll(() => {
+      activeProfileIdentifierVar(activeProfile);
+    });
+
+    it('should use the Active Profile Id as the "observerId"', async () => {
+      const { result } = setupTestScenario({
+        publicationId,
+        result: profiles,
+        expectedObserverId: activeProfile.id,
+      });
+
+      await waitFor(() => expect(result.current.loading).toBeFalsy());
+      expect(result.current.data).toEqual(profiles);
+    });
+
+    it('should always allow to specify the "observerId" on a per-call basis', async () => {
+      const observerId = mockProfileId();
+
+      const { result } = setupTestScenario({
+        publicationId,
+        result: profiles,
+        observerId,
+        expectedObserverId: observerId,
+      });
+
+      await waitFor(() => expect(result.current.loading).toBeFalsy());
+      expect(result.current.data).toEqual(profiles);
     });
   });
 });

--- a/packages/react/src/publication/useComments.ts
+++ b/packages/react/src/publication/useComments.ts
@@ -1,33 +1,40 @@
 import { useCommentsQuery, CommentWithFirstCommentFragment } from '@lens-protocol/api-bindings';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
+import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 import { createPublicationMetadataFilters, PublicationMetadataFilters } from './filters';
 
-type UseCommentsArgs = PaginatedArgs<{
-  commentsOf: string;
-  observerId?: string;
-  metadataFilter?: PublicationMetadataFilters;
-}>;
+export type UseCommentsArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    commentsOf: string;
+    metadataFilter?: PublicationMetadataFilters;
+  }>
+>;
 
 export function useComments({
   metadataFilter,
   commentsOf,
-  limit,
+  limit = DEFAULT_PAGINATED_QUERY_LIMIT,
   observerId,
 }: UseCommentsArgs): PaginatedReadResult<CommentWithFirstCommentFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
   return usePaginatedReadResult(
-    useCommentsQuery({
-      variables: {
-        metadata: createPublicationMetadataFilters(metadataFilter),
-        commentsOf,
-        limit: limit ?? 10,
-        observerId,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    useCommentsQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            metadata: createPublicationMetadataFilters(metadataFilter),
+            commentsOf,
+            limit,
+            observerId,
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/publication/useProfilePublicationsForSale.ts
+++ b/packages/react/src/publication/useProfilePublicationsForSale.ts
@@ -2,32 +2,39 @@ import {
   AnyPublicationFragment,
   useProfilePublicationsForSaleQuery,
 } from '@lens-protocol/api-bindings';
+import { ProfileId } from '@lens-protocol/domain/entities';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 
-type UseProfilePublicationsForSaleArgs = PaginatedArgs<{
-  profileId: string;
-  observerId?: string;
-}>;
+export type UseProfilePublicationsForSaleArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    profileId: ProfileId;
+  }>
+>;
 
 export function useProfilePublicationsForSale({
   profileId,
   observerId,
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
 }: UseProfilePublicationsForSaleArgs): PaginatedReadResult<AnyPublicationFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
   return usePaginatedReadResult(
-    useProfilePublicationsForSaleQuery({
-      variables: {
-        profileId,
-        observerId,
-        limit,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    useProfilePublicationsForSaleQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            profileId,
+            observerId,
+            limit,
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/publication/usePublication.ts
+++ b/packages/react/src/publication/usePublication.ts
@@ -3,31 +3,36 @@ import {
   UnspecifiedError,
   usePublicationQuery,
 } from '@lens-protocol/api-bindings';
+import { PublicationId } from '@lens-protocol/domain/entities';
 
 import { NotFoundError } from '../NotFoundError';
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { ReadResult, useReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 
-type UsePublicationArgs = {
-  publicationId: string;
-  observerId?: string;
-};
+export type UsePublicationArgs = SubjectiveArgs<{
+  publicationId: PublicationId;
+}>;
 
 export function usePublication({
   publicationId,
   observerId,
 }: UsePublicationArgs): ReadResult<AnyPublicationFragment, NotFoundError | UnspecifiedError> {
-  const { apolloClient, sources } = useSharedDependencies();
-
   const { data, error, loading } = useReadResult(
-    usePublicationQuery({
-      variables: {
-        publicationId,
-        observerId,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    usePublicationQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            publicationId,
+            observerId,
+          }),
+        }),
+      ),
+    ),
   );
 
   if (loading) {

--- a/packages/react/src/publication/usePublications.ts
+++ b/packages/react/src/publication/usePublications.ts
@@ -1,34 +1,41 @@
 import { AnyPublicationFragment, usePublicationsQuery } from '@lens-protocol/api-bindings';
+import { ProfileId } from '@lens-protocol/domain/entities';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 import { createPublicationMetadataFilters, PublicationMetadataFilters } from './filters';
 
-type UsePublicationArgs = PaginatedArgs<{
-  metadataFilter?: PublicationMetadataFilters;
-  profileId: string;
-  observerId?: string;
-}>;
+export type UsePublicationsArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    metadataFilter?: PublicationMetadataFilters;
+    profileId: ProfileId;
+  }>
+>;
 
 export function usePublications({
   profileId,
   metadataFilter,
   observerId,
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
-}: UsePublicationArgs): PaginatedReadResult<AnyPublicationFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
+}: UsePublicationsArgs): PaginatedReadResult<AnyPublicationFragment[]> {
   return usePaginatedReadResult(
-    usePublicationsQuery({
-      variables: {
-        profileId,
-        observerId,
-        limit,
-        metadata: createPublicationMetadataFilters(metadataFilter),
-        sources,
-      },
-      client: apolloClient,
-    }),
+    usePublicationsQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            profileId,
+            observerId,
+            limit,
+            metadata: createPublicationMetadataFilters(metadataFilter),
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/publication/useSearchPublications.ts
+++ b/packages/react/src/publication/useSearchPublications.ts
@@ -4,32 +4,38 @@ import {
   useSearchPublicationsQuery,
 } from '@lens-protocol/api-bindings';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 
-type UseSearchPublicationsArgs = PaginatedArgs<{
-  query: string;
-  limit?: number;
-  observerId?: string;
-}>;
+export type UseSearchPublicationsArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    query: string;
+    limit?: number;
+  }>
+>;
 
 export function useSearchPublications({
   query,
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
   observerId,
 }: UseSearchPublicationsArgs): PaginatedReadResult<(PostFragment | CommentFragment)[]> {
-  const { sources, apolloClient } = useSharedDependencies();
-
   return usePaginatedReadResult(
-    useSearchPublicationsQuery({
-      variables: {
-        query,
-        sources,
-        limit,
-        observerId,
-      },
-      client: apolloClient,
-    }),
+    useSearchPublicationsQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            query,
+            limit,
+            observerId,
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/publication/useWhoCollectedPublication.ts
+++ b/packages/react/src/publication/useWhoCollectedPublication.ts
@@ -1,28 +1,32 @@
 import { useWhoCollectedPublicationQuery, WalletFragment } from '@lens-protocol/api-bindings';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedReadResult, PaginatedArgs, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 
-type UseWhoCollectedPublicationArgs = PaginatedArgs<{
-  publicationId: string;
-  observerId?: string;
-}>;
+export type UseWhoCollectedPublicationArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    publicationId: string;
+  }>
+>;
 
-export function useWhoCollectedPublication(
-  args: UseWhoCollectedPublicationArgs,
-): PaginatedReadResult<WalletFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
+export function useWhoCollectedPublication({
+  limit = DEFAULT_PAGINATED_QUERY_LIMIT,
+  observerId,
+  publicationId,
+}: UseWhoCollectedPublicationArgs): PaginatedReadResult<WalletFragment[]> {
   return usePaginatedReadResult(
-    useWhoCollectedPublicationQuery({
-      variables: {
-        limit: args.limit ?? DEFAULT_PAGINATED_QUERY_LIMIT,
-        publicationId: args.publicationId,
-        observerId: args.observerId,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    useWhoCollectedPublicationQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({ limit, publicationId, observerId }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/publication/useWhoCollectedPublication.ts
+++ b/packages/react/src/publication/useWhoCollectedPublication.ts
@@ -1,4 +1,5 @@
 import { useWhoCollectedPublicationQuery, WalletFragment } from '@lens-protocol/api-bindings';
+import { PublicationId } from '@lens-protocol/domain/entities';
 
 import {
   SubjectiveArgs,
@@ -11,7 +12,7 @@ import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 
 export type UseWhoCollectedPublicationArgs = PaginatedArgs<
   SubjectiveArgs<{
-    publicationId: string;
+    publicationId: PublicationId;
   }>
 >;
 

--- a/packages/react/src/publication/useWhoMirroredPublication.ts
+++ b/packages/react/src/publication/useWhoMirroredPublication.ts
@@ -2,33 +2,40 @@ import {
   ProfileFragment,
   useGetAllProfilesByWhoMirroredPublicationQuery,
 } from '@lens-protocol/api-bindings';
+import { PublicationId } from '@lens-protocol/domain/entities';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 
-type UseWhoMirroredPublicationArgs = PaginatedArgs<{
-  limit?: number;
-  observerId?: string;
-  publicationId: string;
-}>;
+export type UseWhoMirroredPublicationArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    limit?: number;
+    publicationId: PublicationId;
+  }>
+>;
 
 export function useWhoMirroredPublication({
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
   publicationId,
   observerId,
 }: UseWhoMirroredPublicationArgs): PaginatedReadResult<ProfileFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
   return usePaginatedReadResult(
-    useGetAllProfilesByWhoMirroredPublicationQuery({
-      variables: {
-        publicationId,
-        observerId,
-        limit,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    useGetAllProfilesByWhoMirroredPublicationQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            publicationId,
+            observerId,
+            limit,
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/publication/useWhoReacted.ts
+++ b/packages/react/src/publication/useWhoReacted.ts
@@ -2,29 +2,36 @@ import {
   WhoReactedResultFragment,
   useWhoReactedPublicationQuery,
 } from '@lens-protocol/api-bindings';
+import { PublicationId } from '@lens-protocol/domain/entities';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedReadResult, PaginatedArgs, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 
-type UseWhoReactedArgs = PaginatedArgs<{
-  publicationId: string;
-  observerId?: string;
-}>;
+export type UseWhoReactedArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    publicationId: PublicationId;
+  }>
+>;
 
 export function useWhoReacted(
   args: UseWhoReactedArgs,
 ): PaginatedReadResult<WhoReactedResultFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
   return usePaginatedReadResult(
-    useWhoReactedPublicationQuery({
-      variables: {
-        publicationId: args.publicationId,
-        observerId: args?.observerId,
-        limit: args?.limit ?? 10,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    useWhoReactedPublicationQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            publicationId: args.publicationId,
+            observerId: args?.observerId,
+            limit: args?.limit ?? 10,
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/revenue/useProfileFollowRevenue.ts
+++ b/packages/react/src/revenue/useProfileFollowRevenue.ts
@@ -4,25 +4,24 @@ import {
 } from '@lens-protocol/api-bindings';
 import { ProfileId } from '@lens-protocol/domain/entities';
 
+import { useLensApolloClient } from '../helpers/arguments';
 import { ReadResult, useReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 
-type UseProfileFollowRevenueArgs = {
+export type UseProfileFollowRevenueArgs = {
   profileId: ProfileId;
 };
 
 export function useProfileFollowRevenue({
   profileId,
 }: UseProfileFollowRevenueArgs): ReadResult<RevenueAggregateFragment[]> {
-  const { apolloClient } = useSharedDependencies();
-
   const { data, error, loading } = useReadResult(
-    useProfileFollowRevenueQuery({
-      variables: {
-        profileId,
-      },
-      client: apolloClient,
-    }),
+    useProfileFollowRevenueQuery(
+      useLensApolloClient({
+        variables: {
+          profileId,
+        },
+      }),
+    ),
   );
 
   if (loading) {

--- a/packages/react/src/revenue/useProfilePublicationRevenue.ts
+++ b/packages/react/src/revenue/useProfilePublicationRevenue.ts
@@ -3,16 +3,23 @@ import {
   PublicationTypes,
   useProfilePublicationRevenueQuery,
 } from '@lens-protocol/api-bindings';
+import { ProfileId } from '@lens-protocol/domain/entities';
 
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { PaginatedArgs, PaginatedReadResult, usePaginatedReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 import { DEFAULT_PAGINATED_QUERY_LIMIT } from '../utils';
 
-type UseProfilePublicationRevenueArgs = PaginatedArgs<{
-  profileId: string;
-  observerId?: string;
-  publicationTypes?: PublicationTypes[];
-}>;
+export type UseProfilePublicationRevenueArgs = PaginatedArgs<
+  SubjectiveArgs<{
+    profileId: ProfileId;
+    publicationTypes?: PublicationTypes[];
+  }>
+>;
 
 export function useProfilePublicationRevenue({
   profileId,
@@ -20,18 +27,18 @@ export function useProfilePublicationRevenue({
   limit = DEFAULT_PAGINATED_QUERY_LIMIT,
   publicationTypes,
 }: UseProfilePublicationRevenueArgs): PaginatedReadResult<PublicationRevenueFragment[]> {
-  const { apolloClient, sources } = useSharedDependencies();
-
   return usePaginatedReadResult(
-    useProfilePublicationRevenueQuery({
-      variables: {
-        limit,
-        publicationTypes,
-        observerId,
-        profileId,
-        sources,
-      },
-      client: apolloClient,
-    }),
+    useProfilePublicationRevenueQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            limit,
+            publicationTypes,
+            observerId,
+            profileId,
+          }),
+        }),
+      ),
+    ),
   );
 }

--- a/packages/react/src/revenue/usePublicationRevenue.ts
+++ b/packages/react/src/revenue/usePublicationRevenue.ts
@@ -1,30 +1,40 @@
 import {
   UnspecifiedError,
-  RevenueAggregateFragment,
+  PublicationRevenueFragment,
   usePublicationRevenueQuery,
 } from '@lens-protocol/api-bindings';
 
 import { NotFoundError } from '../NotFoundError';
+import {
+  SubjectiveArgs,
+  useActiveProfileAsDefaultObserver,
+  useConfigSourcesVariable,
+  useLensApolloClient,
+} from '../helpers/arguments';
 import { ReadResult, useReadResult } from '../helpers/reads';
-import { useSharedDependencies } from '../shared';
 
-type UsePublicationRevenueArgs = {
+export type UsePublicationRevenueArgs = SubjectiveArgs<{
   publicationId: string;
-};
+}>;
 
 export function usePublicationRevenue({
   publicationId,
+  observerId,
 }: UsePublicationRevenueArgs): ReadResult<
-  RevenueAggregateFragment,
+  PublicationRevenueFragment,
   NotFoundError | UnspecifiedError
 > {
-  const { apolloClient } = useSharedDependencies();
-
   const { data, error, loading } = useReadResult(
-    usePublicationRevenueQuery({
-      variables: { request: { publicationId } },
-      client: apolloClient,
-    }),
+    usePublicationRevenueQuery(
+      useLensApolloClient(
+        useActiveProfileAsDefaultObserver({
+          variables: useConfigSourcesVariable({
+            publicationId,
+            observerId,
+          }),
+        }),
+      ),
+    ),
   );
 
   if (loading) {
@@ -52,7 +62,7 @@ export function usePublicationRevenue({
   }
 
   return {
-    data: data.revenue,
+    data,
     error: undefined,
     loading: false,
   };


### PR DESCRIPTION
### In this PR:

Following the approach used in the previous PR this PR covers the following hooks:
- `usePublicationRevenue`
- `useProfilePublicationRevenue`
- `useWhoReacted`
- `useWhoMirroredPublication`
- `useWhoCollectedPublication`
- `useSearchPublications`
- `usePublications`
- `usePublication`
- `useProfilePublicationsForSale`
- `useExplorePublications`
- `useComments`

It also refactors `useProfileFollowRevenue` to use new hook helpers.