### PR TITLE
feat: makes `ProfileId` type more strict

### DIFF
--- a/examples/web-wagmi/src/profiles/UseActiveProfileSwitch.tsx
+++ b/examples/web-wagmi/src/profiles/UseActiveProfileSwitch.tsx
@@ -3,6 +3,7 @@ import {
   useProfilesOwnedBy,
   Profile,
   useActiveProfileSwitch,
+  ProfileId,
 } from '@lens-protocol/react-web';
 import { useState } from 'react';
 
@@ -17,7 +18,7 @@ type ProfilesSwitcherProps = {
 
 function ProfilesSwitcher({ address, current }: ProfilesSwitcherProps) {
   const { execute: switchProfile, isPending } = useActiveProfileSwitch();
-  const [selected, setSelected] = useState<string>(current.id);
+  const [selected, setSelected] = useState<ProfileId>(current.id);
   const { data, error, loading } = useProfilesOwnedBy({ address, limit: 50 });
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/examples/web-wagmi/src/profiles/UseMutualFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/UseMutualFollowers.tsx
@@ -1,4 +1,4 @@
-import { useMutualFollowers, useProfile, Profile } from '@lens-protocol/react-web';
+import { useMutualFollowers, useProfile, Profile, ProfileId } from '@lens-protocol/react-web';
 import { useState } from 'react';
 
 import { ErrorMessage } from '../components/error/ErrorMessage';
@@ -6,8 +6,8 @@ import { SmallProfileCard } from './components/ProfileCard';
 import { ProfileSelector } from './components/ProfileSelector';
 
 type ViewMutualFollowersProps = {
-  profileToCompareOne: string;
-  profileToCompareTwo: string;
+  profileToCompareOne: ProfileId;
+  profileToCompareTwo: ProfileId;
 };
 
 function ViewMutualFollowers({

--- a/examples/web-wagmi/src/profiles/components/ProfileFollowers.tsx
+++ b/examples/web-wagmi/src/profiles/components/ProfileFollowers.tsx
@@ -1,4 +1,4 @@
-import { useProfileFollowers } from '@lens-protocol/react-web';
+import { ProfileId, useProfileFollowers } from '@lens-protocol/react-web';
 
 import { ErrorMessage } from '../../components/error/ErrorMessage';
 import { Loading } from '../../components/loading/Loading';
@@ -6,7 +6,7 @@ import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
 import { ProfileCard } from './ProfileCard';
 
 type ProfileFollowersProps = {
-  profileId: string;
+  profileId: ProfileId;
 };
 
 export function ProfileFollowers({ profileId }: ProfileFollowersProps) {

--- a/examples/web-wagmi/src/publications/UseCreatePost.tsx
+++ b/examples/web-wagmi/src/publications/UseCreatePost.tsx
@@ -1,4 +1,4 @@
-import { useFeed, useRecentPosts } from '@lens-protocol/react-web';
+import { ProfileId, useFeed, useRecentPosts } from '@lens-protocol/react-web';
 
 import { UnauthenticatedFallback } from '../components/UnauthenticatedFallback';
 import { WhenLoggedInWithProfile } from '../components/auth';
@@ -9,7 +9,7 @@ import { PostComposer } from './components/PostComposer';
 import { PublicationCard } from './components/PublicationCard';
 
 type TimelineProps = {
-  profileId: string;
+  profileId: ProfileId;
 };
 
 export function Timeline({ profileId }: TimelineProps) {

--- a/examples/web-wagmi/src/publications/UseReaction.tsx
+++ b/examples/web-wagmi/src/publications/UseReaction.tsx
@@ -5,6 +5,7 @@ import {
   usePublication,
   useReaction,
   isMirrorPublication,
+  ProfileId,
 } from '@lens-protocol/react-web';
 
 import { UnauthenticatedFallback } from '../components/UnauthenticatedFallback';
@@ -16,7 +17,7 @@ import { PublicationCard } from './components/PublicationCard';
 
 type ReactionButtonProps = {
   publication: ContentPublication;
-  profileId: string;
+  profileId: ProfileId;
   reactionType: ReactionType;
 };
 

--- a/packages/api-bindings/src/graphql/__helpers__/mutations.ts
+++ b/packages/api-bindings/src/graphql/__helpers__/mutations.ts
@@ -1,7 +1,7 @@
 import { MockedResponse } from '@apollo/client/testing';
 import { faker } from '@faker-js/faker';
 import { Nonce } from '@lens-protocol/domain/entities';
-import { mockNonce } from '@lens-protocol/domain/mocks';
+import { mockNonce, mockProfileId } from '@lens-protocol/domain/mocks';
 import { mockEthereumAddress } from '@lens-protocol/shared-kernel/mocks';
 
 import { createGraphQLValidationError } from '../../apollo/__helpers__/mocks';
@@ -186,11 +186,11 @@ export function mockCreateCommentTypedDataData({
       domain: mockEIP712TypedDataDomain(),
       value: {
         __typename: 'CreateCommentEIP712TypedDataValue',
-        profileIdPointed: '',
+        profileIdPointed: mockProfileId(),
         pubIdPointed: '',
         nonce,
         deadline: 1644303500,
-        profileId: '0x0132',
+        profileId: mockProfileId(),
         contentURI: 'ipfs://QmR5V6fwKWzoa9gevmYaQ11eMQsAahsjfWPz1rCoNJjN1K.json',
         collectModule: '0xd6072BB2ABc0a9d1331c7d0B83AE6C47f2Cb86A3',
         collectModuleInitData: '0x',
@@ -277,7 +277,7 @@ export function mockCreateFollowTypedDataData({
         __typename: 'CreateFollowEIP712TypedDataValue',
         nonce,
         deadline: '0',
-        profileIds: [faker.datatype.uuid()],
+        profileIds: [mockProfileId()],
         datas: ['0x00'],
       },
     }),
@@ -299,7 +299,7 @@ export function mockCreateSetProfileMetadataTypedDataData({
         __typename: 'CreateSetProfileMetadataURIEIP712TypedDataValue',
         nonce,
         deadline: '0',
-        profileId: faker.datatype.uuid(),
+        profileId: mockProfileId(),
         metadata: faker.internet.url(),
       },
     }),
@@ -357,7 +357,7 @@ export function mockCreateSetFollowModuleTypedDataData({
         __typename: 'CreateSetFollowModuleEIP712TypedDataValue',
         nonce,
         deadline: '0',
-        profileId: faker.datatype.uuid(),
+        profileId: mockProfileId(),
         followModule: mockEthereumAddress(),
         followModuleInitData: '0x00',
       },
@@ -422,7 +422,7 @@ export function mockCreateSetDispatcherTypedDataData({
         __typename: 'CreateSetDispatcherEIP712TypedDataValue',
         nonce,
         deadline: '0',
-        profileId: faker.datatype.uuid(),
+        profileId: mockProfileId(),
         dispatcher: faker.datatype.uuid(),
       },
     }),
@@ -577,7 +577,7 @@ export function mockCreateCollectTypedDataData({
         __typename: 'CreateCollectEIP712TypedDataValue',
         nonce,
         deadline: '0',
-        profileId: faker.datatype.uuid(),
+        profileId: mockProfileId(),
         pubId: faker.datatype.uuid(),
         data: ['0x00'],
       },

--- a/packages/api-bindings/src/graphql/hooks.ts
+++ b/packages/api-bindings/src/graphql/hooks.ts
@@ -10,1180 +10,1229 @@ import gql from 'graphql-tag';
 import * as Operations from './operations';
 const defaultOptions = {} as const;
 export const FragmentPublicationStats = /*#__PURE__*/ gql`
-    fragment PublicationStats on PublicationStats {
-  __typename
-  totalAmountOfMirrors
-  totalUpvotes
-  totalDownvotes
-  totalAmountOfCollects
-  totalAmountOfComments
-  commentsCount: commentsTotal(forSources: $sources)
-}
-    `;
+  fragment PublicationStats on PublicationStats {
+    __typename
+    totalAmountOfMirrors
+    totalUpvotes
+    totalDownvotes
+    totalAmountOfCollects
+    totalAmountOfComments
+    commentsCount: commentsTotal(forSources: $sources)
+  }
+`;
 export const FragmentMedia = /*#__PURE__*/ gql`
-    fragment Media on Media {
-  __typename
-  altTag
-  cover
-  mimeType
-  url
-}
-    `;
+  fragment Media on Media {
+    __typename
+    altTag
+    cover
+    mimeType
+    url
+  }
+`;
 export const FragmentMediaSet = /*#__PURE__*/ gql`
-    fragment MediaSet on MediaSet {
-  __typename
-  original {
-    ...Media
-  }
-}
-    ${FragmentMedia}`;
-export const FragmentMetadataAttributeOutput = /*#__PURE__*/ gql`
-    fragment MetadataAttributeOutput on MetadataAttributeOutput {
-  __typename
-  traitType
-  value
-}
-    `;
-export const FragmentNftOwnershipOutput = /*#__PURE__*/ gql`
-    fragment NftOwnershipOutput on NftOwnershipOutput {
-  __typename
-  contractAddress
-  chainID
-  contractType
-  tokenIds
-}
-    `;
-export const FragmentErc20OwnershipOutput = /*#__PURE__*/ gql`
-    fragment Erc20OwnershipOutput on Erc20OwnershipOutput {
-  __typename
-  amount
-  chainID
-  condition
-  contractAddress
-  decimals
-  name
-  symbol
-}
-    `;
-export const FragmentEoaOwnershipOutput = /*#__PURE__*/ gql`
-    fragment EoaOwnershipOutput on EoaOwnershipOutput {
-  __typename
-  address
-}
-    `;
-export const FragmentProfileOwnershipOutput = /*#__PURE__*/ gql`
-    fragment ProfileOwnershipOutput on ProfileOwnershipOutput {
-  __typename
-  profileId
-}
-    `;
-export const FragmentFollowConditionOutput = /*#__PURE__*/ gql`
-    fragment FollowConditionOutput on FollowConditionOutput {
-  __typename
-  profileId
-}
-    `;
-export const FragmentCollectConditionOutput = /*#__PURE__*/ gql`
-    fragment CollectConditionOutput on CollectConditionOutput {
-  __typename
-  publicationId
-  thisPublication
-}
-    `;
-export const FragmentLeafConditionOutput = /*#__PURE__*/ gql`
-    fragment LeafConditionOutput on AccessConditionOutput {
-  __typename
-  nft {
-    ...NftOwnershipOutput
-  }
-  token {
-    ...Erc20OwnershipOutput
-  }
-  eoa {
-    ...EoaOwnershipOutput
-  }
-  profile {
-    ...ProfileOwnershipOutput
-  }
-  follow {
-    ...FollowConditionOutput
-  }
-  collect {
-    ...CollectConditionOutput
-  }
-}
-    ${FragmentNftOwnershipOutput}
-${FragmentErc20OwnershipOutput}
-${FragmentEoaOwnershipOutput}
-${FragmentProfileOwnershipOutput}
-${FragmentFollowConditionOutput}
-${FragmentCollectConditionOutput}`;
-export const FragmentOrConditionOutput = /*#__PURE__*/ gql`
-    fragment OrConditionOutput on OrConditionOutput {
-  __typename
-  criteria {
-    ...LeafConditionOutput
-  }
-}
-    ${FragmentLeafConditionOutput}`;
-export const FragmentAndConditionOutput = /*#__PURE__*/ gql`
-    fragment AndConditionOutput on AndConditionOutput {
-  __typename
-  criteria {
-    ...LeafConditionOutput
-  }
-}
-    ${FragmentLeafConditionOutput}`;
-export const FragmentAnyConditionOutput = /*#__PURE__*/ gql`
-    fragment AnyConditionOutput on AccessConditionOutput {
-  __typename
-  ...LeafConditionOutput
-  or {
-    ...OrConditionOutput
-  }
-  and {
-    ...AndConditionOutput
-  }
-}
-    ${FragmentLeafConditionOutput}
-${FragmentOrConditionOutput}
-${FragmentAndConditionOutput}`;
-export const FragmentRootConditionOutput = /*#__PURE__*/ gql`
-    fragment RootConditionOutput on AccessConditionOutput {
-  __typename
-  or {
-    criteria {
-      ...AnyConditionOutput
+  fragment MediaSet on MediaSet {
+    __typename
+    original {
+      ...Media
     }
   }
-}
-    ${FragmentAnyConditionOutput}`;
+  ${FragmentMedia}
+`;
+export const FragmentMetadataAttributeOutput = /*#__PURE__*/ gql`
+  fragment MetadataAttributeOutput on MetadataAttributeOutput {
+    __typename
+    traitType
+    value
+  }
+`;
+export const FragmentNftOwnershipOutput = /*#__PURE__*/ gql`
+  fragment NftOwnershipOutput on NftOwnershipOutput {
+    __typename
+    contractAddress
+    chainID
+    contractType
+    tokenIds
+  }
+`;
+export const FragmentErc20OwnershipOutput = /*#__PURE__*/ gql`
+  fragment Erc20OwnershipOutput on Erc20OwnershipOutput {
+    __typename
+    amount
+    chainID
+    condition
+    contractAddress
+    decimals
+    name
+    symbol
+  }
+`;
+export const FragmentEoaOwnershipOutput = /*#__PURE__*/ gql`
+  fragment EoaOwnershipOutput on EoaOwnershipOutput {
+    __typename
+    address
+  }
+`;
+export const FragmentProfileOwnershipOutput = /*#__PURE__*/ gql`
+  fragment ProfileOwnershipOutput on ProfileOwnershipOutput {
+    __typename
+    profileId
+  }
+`;
+export const FragmentFollowConditionOutput = /*#__PURE__*/ gql`
+  fragment FollowConditionOutput on FollowConditionOutput {
+    __typename
+    profileId
+  }
+`;
+export const FragmentCollectConditionOutput = /*#__PURE__*/ gql`
+  fragment CollectConditionOutput on CollectConditionOutput {
+    __typename
+    publicationId
+    thisPublication
+  }
+`;
+export const FragmentLeafConditionOutput = /*#__PURE__*/ gql`
+  fragment LeafConditionOutput on AccessConditionOutput {
+    __typename
+    nft {
+      ...NftOwnershipOutput
+    }
+    token {
+      ...Erc20OwnershipOutput
+    }
+    eoa {
+      ...EoaOwnershipOutput
+    }
+    profile {
+      ...ProfileOwnershipOutput
+    }
+    follow {
+      ...FollowConditionOutput
+    }
+    collect {
+      ...CollectConditionOutput
+    }
+  }
+  ${FragmentNftOwnershipOutput}
+  ${FragmentErc20OwnershipOutput}
+  ${FragmentEoaOwnershipOutput}
+  ${FragmentProfileOwnershipOutput}
+  ${FragmentFollowConditionOutput}
+  ${FragmentCollectConditionOutput}
+`;
+export const FragmentOrConditionOutput = /*#__PURE__*/ gql`
+  fragment OrConditionOutput on OrConditionOutput {
+    __typename
+    criteria {
+      ...LeafConditionOutput
+    }
+  }
+  ${FragmentLeafConditionOutput}
+`;
+export const FragmentAndConditionOutput = /*#__PURE__*/ gql`
+  fragment AndConditionOutput on AndConditionOutput {
+    __typename
+    criteria {
+      ...LeafConditionOutput
+    }
+  }
+  ${FragmentLeafConditionOutput}
+`;
+export const FragmentAnyConditionOutput = /*#__PURE__*/ gql`
+  fragment AnyConditionOutput on AccessConditionOutput {
+    __typename
+    ...LeafConditionOutput
+    or {
+      ...OrConditionOutput
+    }
+    and {
+      ...AndConditionOutput
+    }
+  }
+  ${FragmentLeafConditionOutput}
+  ${FragmentOrConditionOutput}
+  ${FragmentAndConditionOutput}
+`;
+export const FragmentRootConditionOutput = /*#__PURE__*/ gql`
+  fragment RootConditionOutput on AccessConditionOutput {
+    __typename
+    or {
+      criteria {
+        ...AnyConditionOutput
+      }
+    }
+  }
+  ${FragmentAnyConditionOutput}
+`;
 export const FragmentEncryptedMedia = /*#__PURE__*/ gql`
-    fragment EncryptedMedia on EncryptedMedia {
-  __typename
-  altTag
-  cover
-  mimeType
-  url
-}
-    `;
+  fragment EncryptedMedia on EncryptedMedia {
+    __typename
+    altTag
+    cover
+    mimeType
+    url
+  }
+`;
 export const FragmentEncryptedFieldsOutput = /*#__PURE__*/ gql`
-    fragment EncryptedFieldsOutput on EncryptedFieldsOutput {
-  __typename
-  animation_url
-  content
-  external_url
-  image
-  media {
+  fragment EncryptedFieldsOutput on EncryptedFieldsOutput {
+    __typename
+    animation_url
+    content
+    external_url
+    image
+    media {
+      original {
+        ...EncryptedMedia
+      }
+    }
+  }
+  ${FragmentEncryptedMedia}
+`;
+export const FragmentEncryptionParamsOutput = /*#__PURE__*/ gql`
+  fragment EncryptionParamsOutput on EncryptionParamsOutput {
+    __typename
+    accessCondition {
+      ...RootConditionOutput
+    }
+    encryptionProvider
+    encryptedFields {
+      ...EncryptedFieldsOutput
+    }
+    providerSpecificParams {
+      encryptionKey
+    }
+  }
+  ${FragmentRootConditionOutput}
+  ${FragmentEncryptedFieldsOutput}
+`;
+export const FragmentMetadataOutput = /*#__PURE__*/ gql`
+  fragment MetadataOutput on MetadataOutput {
+    __typename
+    animatedUrl
+    name
+    description
+    mainContentFocus
+    content
+    image
+    media {
+      ...MediaSet
+    }
+    attributes {
+      ...MetadataAttributeOutput
+    }
+    encryptionParams {
+      ...EncryptionParamsOutput
+    }
+  }
+  ${FragmentMediaSet}
+  ${FragmentMetadataAttributeOutput}
+  ${FragmentEncryptionParamsOutput}
+`;
+export const FragmentNftImage = /*#__PURE__*/ gql`
+  fragment NftImage on NftImage {
+    __typename
+    contractAddress
+    tokenId
+    uri
+    verified
+  }
+`;
+export const FragmentProfileStats = /*#__PURE__*/ gql`
+  fragment ProfileStats on ProfileStats {
+    __typename
+    totalCollects
+    totalComments
+    totalFollowers
+    totalFollowing
+    totalMirrors
+    totalPosts
+    totalPublications
+    commentsCount: commentsTotal(forSources: $sources)
+    postsCount: postsTotal(forSources: $sources)
+    mirrorsCount: mirrorsTotal(forSources: $sources)
+  }
+`;
+export const FragmentErc20Fields = /*#__PURE__*/ gql`
+  fragment Erc20Fields on Erc20 {
+    __typename
+    name
+    symbol
+    decimals
+    address
+  }
+`;
+export const FragmentModuleFeeAmount = /*#__PURE__*/ gql`
+  fragment ModuleFeeAmount on ModuleFeeAmount {
+    __typename
+    asset {
+      ...Erc20Fields
+    }
+    value
+  }
+  ${FragmentErc20Fields}
+`;
+export const FragmentFeeFollowModuleSettings = /*#__PURE__*/ gql`
+  fragment FeeFollowModuleSettings on FeeFollowModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    contractAddress
+    recipient
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentProfileFollowModuleSettings = /*#__PURE__*/ gql`
+  fragment ProfileFollowModuleSettings on ProfileFollowModuleSettings {
+    __typename
+    contractAddress
+  }
+`;
+export const FragmentRevertFollowModuleSettings = /*#__PURE__*/ gql`
+  fragment RevertFollowModuleSettings on RevertFollowModuleSettings {
+    __typename
+    contractAddress
+  }
+`;
+export const FragmentUnknownFollowModuleSettings = /*#__PURE__*/ gql`
+  fragment UnknownFollowModuleSettings on UnknownFollowModuleSettings {
+    __typename
+    contractAddress
+  }
+`;
+export const FragmentAttribute = /*#__PURE__*/ gql`
+  fragment Attribute on Attribute {
+    __typename
+    displayType
+    key
+    value
+  }
+`;
+export const FragmentProfile = /*#__PURE__*/ gql`
+  fragment Profile on Profile {
+    __typename
+    id
+    name
+    bio
+    handle
+    ownedBy
+    picture {
+      ... on NftImage {
+        ...NftImage
+      }
+      ... on MediaSet {
+        ...MediaSet
+      }
+    }
+    coverPicture {
+      ... on NftImage {
+        ...NftImage
+      }
+      ... on MediaSet {
+        ...MediaSet
+      }
+    }
+    stats {
+      ...ProfileStats
+    }
+    followModule {
+      ... on FeeFollowModuleSettings {
+        ...FeeFollowModuleSettings
+      }
+      ... on ProfileFollowModuleSettings {
+        ...ProfileFollowModuleSettings
+      }
+      ... on RevertFollowModuleSettings {
+        ...RevertFollowModuleSettings
+      }
+      ... on UnknownFollowModuleSettings {
+        ...UnknownFollowModuleSettings
+      }
+    }
+    followPolicy @client
+    __attributes: attributes {
+      ...Attribute
+    }
+    attributes: attributesMap @client
+    dispatcher {
+      address
+      canUseRelay
+    }
+    onChainIdentity {
+      proofOfHumanity
+      ens {
+        name
+      }
+      sybilDotOrg {
+        verified
+        source {
+          twitter {
+            handle
+          }
+        }
+      }
+      worldcoin {
+        isHuman
+      }
+    }
+    isFollowedByMe
+    isFollowingObserver: isFollowing(who: $observerId)
+    followStatus @client
+    ownedByMe @client
+  }
+  ${FragmentNftImage}
+  ${FragmentMediaSet}
+  ${FragmentProfileStats}
+  ${FragmentFeeFollowModuleSettings}
+  ${FragmentProfileFollowModuleSettings}
+  ${FragmentRevertFollowModuleSettings}
+  ${FragmentUnknownFollowModuleSettings}
+  ${FragmentAttribute}
+`;
+export const FragmentWallet = /*#__PURE__*/ gql`
+  fragment Wallet on Wallet {
+    __typename
+    address
+    defaultProfile {
+      ...Profile
+    }
+  }
+  ${FragmentProfile}
+`;
+export const FragmentAaveFeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment AaveFeeCollectModuleSettings on AaveFeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    collectLimitOptional: collectLimit
+    contractAddress
+    followerOnly
+    endTimestampOptional: endTimestamp
+    recipient
+    referralFee
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentErc4626FeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment Erc4626FeeCollectModuleSettings on ERC4626FeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    collectLimitOptional: collectLimit
+    contractAddress
+    followerOnly
+    endTimestampOptional: endTimestamp
+    recipient
+    referralFee
+    vault
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentMultirecipientFeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment MultirecipientFeeCollectModuleSettings on MultirecipientFeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    collectLimitOptional: collectLimit
+    contractAddress
+    followerOnly
+    endTimestampOptional: endTimestamp
+    recipients {
+      recipient
+      split
+    }
+    referralFee
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentUnknownCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment UnknownCollectModuleSettings on UnknownCollectModuleSettings {
+    __typename
+  }
+`;
+export const FragmentFreeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment FreeCollectModuleSettings on FreeCollectModuleSettings {
+    __typename
+    contractAddress
+    followerOnly
+  }
+`;
+export const FragmentFeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment FeeCollectModuleSettings on FeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    contractAddress
+    followerOnly
+    recipient
+    referralFee
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentLimitedFeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment LimitedFeeCollectModuleSettings on LimitedFeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    collectLimit
+    contractAddress
+    followerOnly
+    recipient
+    referralFee
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentLimitedTimedFeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment LimitedTimedFeeCollectModuleSettings on LimitedTimedFeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    collectLimit
+    contractAddress
+    followerOnly
+    endTimestamp
+    recipient
+    referralFee
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentRevertCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment RevertCollectModuleSettings on RevertCollectModuleSettings {
+    __typename
+    contractAddress
+  }
+`;
+export const FragmentTimedFeeCollectModuleSettings = /*#__PURE__*/ gql`
+  fragment TimedFeeCollectModuleSettings on TimedFeeCollectModuleSettings {
+    __typename
+    amount {
+      ...ModuleFeeAmount
+    }
+    contractAddress
+    followerOnly
+    endTimestamp
+    recipient
+    referralFee
+  }
+  ${FragmentModuleFeeAmount}
+`;
+export const FragmentFollowOnlyReferenceModuleSettings = /*#__PURE__*/ gql`
+  fragment FollowOnlyReferenceModuleSettings on FollowOnlyReferenceModuleSettings {
+    __typename
+    contractAddress
+  }
+`;
+export const FragmentDegreesOfSeparationReferenceModuleSettings = /*#__PURE__*/ gql`
+  fragment DegreesOfSeparationReferenceModuleSettings on DegreesOfSeparationReferenceModuleSettings {
+    __typename
+    contractAddress
+    commentsRestricted
+    degreesOfSeparation
+    mirrorsRestricted
+  }
+`;
+export const FragmentUnknownReferenceModuleSettings = /*#__PURE__*/ gql`
+  fragment UnknownReferenceModuleSettings on UnknownReferenceModuleSettings {
+    __typename
+    contractAddress
+    referenceModuleReturnData
+  }
+`;
+export const FragmentCommentBase = /*#__PURE__*/ gql`
+  fragment CommentBase on Comment {
+    __typename
+    id
+    stats {
+      ...PublicationStats
+    }
+    metadata {
+      ...MetadataOutput
+    }
+    profile {
+      ...Profile
+    }
+    collectedBy {
+      ...Wallet
+    }
+    collectModule {
+      ... on AaveFeeCollectModuleSettings {
+        ...AaveFeeCollectModuleSettings
+      }
+      ... on ERC4626FeeCollectModuleSettings {
+        ...Erc4626FeeCollectModuleSettings
+      }
+      ... on MultirecipientFeeCollectModuleSettings {
+        ...MultirecipientFeeCollectModuleSettings
+      }
+      ... on UnknownCollectModuleSettings {
+        ...UnknownCollectModuleSettings
+      }
+      ... on FreeCollectModuleSettings {
+        ...FreeCollectModuleSettings
+      }
+      ... on FeeCollectModuleSettings {
+        ...FeeCollectModuleSettings
+      }
+      ... on LimitedFeeCollectModuleSettings {
+        ...LimitedFeeCollectModuleSettings
+      }
+      ... on LimitedTimedFeeCollectModuleSettings {
+        ...LimitedTimedFeeCollectModuleSettings
+      }
+      ... on RevertCollectModuleSettings {
+        ...RevertCollectModuleSettings
+      }
+      ... on TimedFeeCollectModuleSettings {
+        ...TimedFeeCollectModuleSettings
+      }
+    }
+    collectNftAddress
+    referenceModule {
+      ... on FollowOnlyReferenceModuleSettings {
+        ...FollowOnlyReferenceModuleSettings
+      }
+      ... on DegreesOfSeparationReferenceModuleSettings {
+        ...DegreesOfSeparationReferenceModuleSettings
+      }
+      ... on UnknownReferenceModuleSettings {
+        ...UnknownReferenceModuleSettings
+      }
+    }
+    createdAt
+    hidden
+    isGated
+    reaction(request: { profileId: $observerId })
+    hasCollectedByMe(isFinalisedOnChain: true)
+    canComment(profileId: $observerId) {
+      result
+    }
+    canMirror(profileId: $observerId) {
+      result
+    }
+    canObserverDecrypt: canDecrypt(profileId: $observerId) {
+      result
+      reasons
+    }
+    mirrors(by: $observerId)
+    hasOptimisticCollectedByMe @client
+    isOptimisticMirroredByMe @client
+    collectPolicy @client
+    referencePolicy @client
+    decryptionCriteria @client
+  }
+  ${FragmentPublicationStats}
+  ${FragmentMetadataOutput}
+  ${FragmentProfile}
+  ${FragmentWallet}
+  ${FragmentAaveFeeCollectModuleSettings}
+  ${FragmentErc4626FeeCollectModuleSettings}
+  ${FragmentMultirecipientFeeCollectModuleSettings}
+  ${FragmentUnknownCollectModuleSettings}
+  ${FragmentFreeCollectModuleSettings}
+  ${FragmentFeeCollectModuleSettings}
+  ${FragmentLimitedFeeCollectModuleSettings}
+  ${FragmentLimitedTimedFeeCollectModuleSettings}
+  ${FragmentRevertCollectModuleSettings}
+  ${FragmentTimedFeeCollectModuleSettings}
+  ${FragmentFollowOnlyReferenceModuleSettings}
+  ${FragmentDegreesOfSeparationReferenceModuleSettings}
+  ${FragmentUnknownReferenceModuleSettings}
+`;
+export const FragmentPost = /*#__PURE__*/ gql`
+  fragment Post on Post {
+    __typename
+    id
+    stats {
+      ...PublicationStats
+    }
+    metadata {
+      ...MetadataOutput
+    }
+    profile {
+      ...Profile
+    }
+    collectedBy {
+      ...Wallet
+    }
+    collectModule {
+      ... on AaveFeeCollectModuleSettings {
+        ...AaveFeeCollectModuleSettings
+      }
+      ... on ERC4626FeeCollectModuleSettings {
+        ...Erc4626FeeCollectModuleSettings
+      }
+      ... on MultirecipientFeeCollectModuleSettings {
+        ...MultirecipientFeeCollectModuleSettings
+      }
+      ... on UnknownCollectModuleSettings {
+        ...UnknownCollectModuleSettings
+      }
+      ... on FreeCollectModuleSettings {
+        ...FreeCollectModuleSettings
+      }
+      ... on FeeCollectModuleSettings {
+        ...FeeCollectModuleSettings
+      }
+      ... on LimitedFeeCollectModuleSettings {
+        ...LimitedFeeCollectModuleSettings
+      }
+      ... on LimitedTimedFeeCollectModuleSettings {
+        ...LimitedTimedFeeCollectModuleSettings
+      }
+      ... on RevertCollectModuleSettings {
+        ...RevertCollectModuleSettings
+      }
+      ... on TimedFeeCollectModuleSettings {
+        ...TimedFeeCollectModuleSettings
+      }
+    }
+    collectNftAddress
+    referenceModule {
+      ... on FollowOnlyReferenceModuleSettings {
+        ...FollowOnlyReferenceModuleSettings
+      }
+      ... on DegreesOfSeparationReferenceModuleSettings {
+        ...DegreesOfSeparationReferenceModuleSettings
+      }
+      ... on UnknownReferenceModuleSettings {
+        ...UnknownReferenceModuleSettings
+      }
+    }
+    createdAt
+    hidden
+    isGated
+    reaction(request: { profileId: $observerId })
+    hasCollectedByMe(isFinalisedOnChain: true)
+    canComment(profileId: $observerId) {
+      result
+    }
+    canMirror(profileId: $observerId) {
+      result
+    }
+    mirrors(by: $observerId)
+    canObserverDecrypt: canDecrypt(profileId: $observerId) {
+      result
+      reasons
+    }
+    hasOptimisticCollectedByMe @client
+    isOptimisticMirroredByMe @client
+    collectPolicy @client
+    referencePolicy @client
+    decryptionCriteria @client
+  }
+  ${FragmentPublicationStats}
+  ${FragmentMetadataOutput}
+  ${FragmentProfile}
+  ${FragmentWallet}
+  ${FragmentAaveFeeCollectModuleSettings}
+  ${FragmentErc4626FeeCollectModuleSettings}
+  ${FragmentMultirecipientFeeCollectModuleSettings}
+  ${FragmentUnknownCollectModuleSettings}
+  ${FragmentFreeCollectModuleSettings}
+  ${FragmentFeeCollectModuleSettings}
+  ${FragmentLimitedFeeCollectModuleSettings}
+  ${FragmentLimitedTimedFeeCollectModuleSettings}
+  ${FragmentRevertCollectModuleSettings}
+  ${FragmentTimedFeeCollectModuleSettings}
+  ${FragmentFollowOnlyReferenceModuleSettings}
+  ${FragmentDegreesOfSeparationReferenceModuleSettings}
+  ${FragmentUnknownReferenceModuleSettings}
+`;
+export const FragmentMirrorBase = /*#__PURE__*/ gql`
+  fragment MirrorBase on Mirror {
+    __typename
+    id
+    createdAt
+    profile {
+      ...Profile
+    }
+    hidden
+  }
+  ${FragmentProfile}
+`;
+export const FragmentComment = /*#__PURE__*/ gql`
+  fragment Comment on Comment {
+    __typename
+    ...CommentBase
+    commentOn {
+      ... on Post {
+        ...Post
+      }
+      ... on Mirror {
+        ...MirrorBase
+      }
+      ... on Comment {
+        ...CommentBase
+      }
+    }
+    mainPost {
+      ... on Post {
+        ...Post
+      }
+      ... on Mirror {
+        ...MirrorBase
+      }
+    }
+  }
+  ${FragmentCommentBase}
+  ${FragmentPost}
+  ${FragmentMirrorBase}
+`;
+export const FragmentCommentWithFirstComment = /*#__PURE__*/ gql`
+  fragment CommentWithFirstComment on Comment {
+    __typename
+    ...Comment
+    firstComment {
+      ...Comment
+    }
+  }
+  ${FragmentComment}
+`;
+export const FragmentCommonPaginatedResultInfo = /*#__PURE__*/ gql`
+  fragment CommonPaginatedResultInfo on PaginatedResultInfo {
+    __typename
+    prev
+    next
+    totalCount
+  }
+`;
+export const FragmentPendingPost = /*#__PURE__*/ gql`
+  fragment PendingPost on PendingPost {
+    __typename
+    id
+    content
+    media {
+      ...Media
+    }
+    profile {
+      ...Profile
+    }
+    locale
+    mainContentFocus
+  }
+  ${FragmentMedia}
+  ${FragmentProfile}
+`;
+export const FragmentEip712TypedDataDomain = /*#__PURE__*/ gql`
+  fragment EIP712TypedDataDomain on EIP712TypedDataDomain {
+    __typename
+    name
+    chainId
+    version
+    verifyingContract
+  }
+`;
+export const FragmentElectedMirror = /*#__PURE__*/ gql`
+  fragment ElectedMirror on ElectedMirror {
+    __typename
+    mirrorId
+    profile {
+      ...Profile
+    }
+    timestamp
+  }
+  ${FragmentProfile}
+`;
+export const FragmentMirrorEvent = /*#__PURE__*/ gql`
+  fragment MirrorEvent on MirrorEvent {
+    __typename
+    profile {
+      ...Profile
+    }
+    timestamp
+  }
+  ${FragmentProfile}
+`;
+export const FragmentCollectedEvent = /*#__PURE__*/ gql`
+  fragment CollectedEvent on CollectedEvent {
+    __typename
+    profile {
+      ...Profile
+    }
+    timestamp
+  }
+  ${FragmentProfile}
+`;
+export const FragmentReactionEvent = /*#__PURE__*/ gql`
+  fragment ReactionEvent on ReactionEvent {
+    __typename
+    profile {
+      ...Profile
+    }
+    reaction
+    timestamp
+  }
+  ${FragmentProfile}
+`;
+export const FragmentFeedItem = /*#__PURE__*/ gql`
+  fragment FeedItem on FeedItem {
+    __typename
+    root {
+      ... on Post {
+        ...Post
+      }
+      ... on Comment {
+        ...Comment
+      }
+    }
+    comments {
+      ...Comment
+    }
+    electedMirror {
+      ...ElectedMirror
+    }
+    mirrors {
+      ...MirrorEvent
+    }
+    collects {
+      ...CollectedEvent
+    }
+    reactions {
+      ...ReactionEvent
+    }
+  }
+  ${FragmentPost}
+  ${FragmentComment}
+  ${FragmentElectedMirror}
+  ${FragmentMirrorEvent}
+  ${FragmentCollectedEvent}
+  ${FragmentReactionEvent}
+`;
+export const FragmentEncryptedMediaSet = /*#__PURE__*/ gql`
+  fragment EncryptedMediaSet on EncryptedMediaSet {
+    __typename
     original {
       ...EncryptedMedia
     }
   }
-}
-    ${FragmentEncryptedMedia}`;
-export const FragmentEncryptionParamsOutput = /*#__PURE__*/ gql`
-    fragment EncryptionParamsOutput on EncryptionParamsOutput {
-  __typename
-  accessCondition {
-    ...RootConditionOutput
+  ${FragmentEncryptedMedia}
+`;
+export const FragmentModuleInfo = /*#__PURE__*/ gql`
+  fragment ModuleInfo on ModuleInfo {
+    __typename
+    name
+    type
   }
-  encryptionProvider
-  encryptedFields {
-    ...EncryptedFieldsOutput
-  }
-  providerSpecificParams {
-    encryptionKey
-  }
-}
-    ${FragmentRootConditionOutput}
-${FragmentEncryptedFieldsOutput}`;
-export const FragmentMetadataOutput = /*#__PURE__*/ gql`
-    fragment MetadataOutput on MetadataOutput {
-  __typename
-  animatedUrl
-  name
-  description
-  mainContentFocus
-  content
-  image
-  media {
-    ...MediaSet
-  }
-  attributes {
-    ...MetadataAttributeOutput
-  }
-  encryptionParams {
-    ...EncryptionParamsOutput
-  }
-}
-    ${FragmentMediaSet}
-${FragmentMetadataAttributeOutput}
-${FragmentEncryptionParamsOutput}`;
-export const FragmentNftImage = /*#__PURE__*/ gql`
-    fragment NftImage on NftImage {
-  __typename
-  contractAddress
-  tokenId
-  uri
-  verified
-}
-    `;
-export const FragmentProfileStats = /*#__PURE__*/ gql`
-    fragment ProfileStats on ProfileStats {
-  __typename
-  totalCollects
-  totalComments
-  totalFollowers
-  totalFollowing
-  totalMirrors
-  totalPosts
-  totalPublications
-  commentsCount: commentsTotal(forSources: $sources)
-  postsCount: postsTotal(forSources: $sources)
-  mirrorsCount: mirrorsTotal(forSources: $sources)
-}
-    `;
-export const FragmentErc20Fields = /*#__PURE__*/ gql`
-    fragment Erc20Fields on Erc20 {
-  __typename
-  name
-  symbol
-  decimals
-  address
-}
-    `;
-export const FragmentModuleFeeAmount = /*#__PURE__*/ gql`
-    fragment ModuleFeeAmount on ModuleFeeAmount {
-  __typename
-  asset {
-    ...Erc20Fields
-  }
-  value
-}
-    ${FragmentErc20Fields}`;
-export const FragmentFeeFollowModuleSettings = /*#__PURE__*/ gql`
-    fragment FeeFollowModuleSettings on FeeFollowModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  contractAddress
-  recipient
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentProfileFollowModuleSettings = /*#__PURE__*/ gql`
-    fragment ProfileFollowModuleSettings on ProfileFollowModuleSettings {
-  __typename
-  contractAddress
-}
-    `;
-export const FragmentRevertFollowModuleSettings = /*#__PURE__*/ gql`
-    fragment RevertFollowModuleSettings on RevertFollowModuleSettings {
-  __typename
-  contractAddress
-}
-    `;
-export const FragmentUnknownFollowModuleSettings = /*#__PURE__*/ gql`
-    fragment UnknownFollowModuleSettings on UnknownFollowModuleSettings {
-  __typename
-  contractAddress
-}
-    `;
-export const FragmentAttribute = /*#__PURE__*/ gql`
-    fragment Attribute on Attribute {
-  __typename
-  displayType
-  key
-  value
-}
-    `;
-export const FragmentProfile = /*#__PURE__*/ gql`
-    fragment Profile on Profile {
-  __typename
-  id
-  name
-  bio
-  handle
-  ownedBy
-  picture {
-    ... on NftImage {
-      ...NftImage
+`;
+export const FragmentEnabledModule = /*#__PURE__*/ gql`
+  fragment EnabledModule on EnabledModule {
+    __typename
+    moduleName
+    contractAddress
+    inputParams {
+      ...ModuleInfo
     }
-    ... on MediaSet {
-      ...MediaSet
+    redeemParams {
+      ...ModuleInfo
+    }
+    returnDataParams: returnDataParms {
+      ...ModuleInfo
     }
   }
-  coverPicture {
-    ... on NftImage {
-      ...NftImage
+  ${FragmentModuleInfo}
+`;
+export const FragmentEnabledModules = /*#__PURE__*/ gql`
+  fragment EnabledModules on EnabledModules {
+    __typename
+    collectModules {
+      ...EnabledModule
     }
-    ... on MediaSet {
-      ...MediaSet
+    followModules {
+      ...EnabledModule
     }
-  }
-  stats {
-    ...ProfileStats
-  }
-  followModule {
-    ... on FeeFollowModuleSettings {
-      ...FeeFollowModuleSettings
-    }
-    ... on ProfileFollowModuleSettings {
-      ...ProfileFollowModuleSettings
-    }
-    ... on RevertFollowModuleSettings {
-      ...RevertFollowModuleSettings
-    }
-    ... on UnknownFollowModuleSettings {
-      ...UnknownFollowModuleSettings
+    referenceModules {
+      ...EnabledModule
     }
   }
-  followPolicy @client
-  __attributes: attributes {
-    ...Attribute
-  }
-  attributes: attributesMap @client
-  dispatcher {
-    address
-    canUseRelay
-  }
-  onChainIdentity {
-    proofOfHumanity
-    ens {
-      name
+  ${FragmentEnabledModule}
+`;
+export const FragmentNewFollowerNotification = /*#__PURE__*/ gql`
+  fragment NewFollowerNotification on NewFollowerNotification {
+    __typename
+    notificationId
+    createdAt
+    isFollowedByMe
+    wallet {
+      ...Wallet
     }
-    sybilDotOrg {
-      verified
-      source {
-        twitter {
-          handle
-        }
+  }
+  ${FragmentWallet}
+`;
+export const FragmentMirror = /*#__PURE__*/ gql`
+  fragment Mirror on Mirror {
+    __typename
+    ...MirrorBase
+    mirrorOf {
+      ... on Post {
+        ...Post
+      }
+      ... on Comment {
+        ...Comment
       }
     }
-    worldcoin {
-      isHuman
-    }
   }
-  isFollowedByMe
-  isFollowingObserver: isFollowing(who: $observerId)
-  followStatus @client
-  ownedByMe @client
-}
-    ${FragmentNftImage}
-${FragmentMediaSet}
-${FragmentProfileStats}
-${FragmentFeeFollowModuleSettings}
-${FragmentProfileFollowModuleSettings}
-${FragmentRevertFollowModuleSettings}
-${FragmentUnknownFollowModuleSettings}
-${FragmentAttribute}`;
-export const FragmentWallet = /*#__PURE__*/ gql`
-    fragment Wallet on Wallet {
-  __typename
-  address
-  defaultProfile {
-    ...Profile
-  }
-}
-    ${FragmentProfile}`;
-export const FragmentAaveFeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment AaveFeeCollectModuleSettings on AaveFeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  collectLimitOptional: collectLimit
-  contractAddress
-  followerOnly
-  endTimestampOptional: endTimestamp
-  recipient
-  referralFee
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentErc4626FeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment Erc4626FeeCollectModuleSettings on ERC4626FeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  collectLimitOptional: collectLimit
-  contractAddress
-  followerOnly
-  endTimestampOptional: endTimestamp
-  recipient
-  referralFee
-  vault
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentMultirecipientFeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment MultirecipientFeeCollectModuleSettings on MultirecipientFeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  collectLimitOptional: collectLimit
-  contractAddress
-  followerOnly
-  endTimestampOptional: endTimestamp
-  recipients {
-    recipient
-    split
-  }
-  referralFee
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentUnknownCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment UnknownCollectModuleSettings on UnknownCollectModuleSettings {
-  __typename
-}
-    `;
-export const FragmentFreeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment FreeCollectModuleSettings on FreeCollectModuleSettings {
-  __typename
-  contractAddress
-  followerOnly
-}
-    `;
-export const FragmentFeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment FeeCollectModuleSettings on FeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  contractAddress
-  followerOnly
-  recipient
-  referralFee
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentLimitedFeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment LimitedFeeCollectModuleSettings on LimitedFeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  collectLimit
-  contractAddress
-  followerOnly
-  recipient
-  referralFee
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentLimitedTimedFeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment LimitedTimedFeeCollectModuleSettings on LimitedTimedFeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  collectLimit
-  contractAddress
-  followerOnly
-  endTimestamp
-  recipient
-  referralFee
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentRevertCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment RevertCollectModuleSettings on RevertCollectModuleSettings {
-  __typename
-  contractAddress
-}
-    `;
-export const FragmentTimedFeeCollectModuleSettings = /*#__PURE__*/ gql`
-    fragment TimedFeeCollectModuleSettings on TimedFeeCollectModuleSettings {
-  __typename
-  amount {
-    ...ModuleFeeAmount
-  }
-  contractAddress
-  followerOnly
-  endTimestamp
-  recipient
-  referralFee
-}
-    ${FragmentModuleFeeAmount}`;
-export const FragmentFollowOnlyReferenceModuleSettings = /*#__PURE__*/ gql`
-    fragment FollowOnlyReferenceModuleSettings on FollowOnlyReferenceModuleSettings {
-  __typename
-  contractAddress
-}
-    `;
-export const FragmentDegreesOfSeparationReferenceModuleSettings = /*#__PURE__*/ gql`
-    fragment DegreesOfSeparationReferenceModuleSettings on DegreesOfSeparationReferenceModuleSettings {
-  __typename
-  contractAddress
-  commentsRestricted
-  degreesOfSeparation
-  mirrorsRestricted
-}
-    `;
-export const FragmentUnknownReferenceModuleSettings = /*#__PURE__*/ gql`
-    fragment UnknownReferenceModuleSettings on UnknownReferenceModuleSettings {
-  __typename
-  contractAddress
-  referenceModuleReturnData
-}
-    `;
-export const FragmentCommentBase = /*#__PURE__*/ gql`
-    fragment CommentBase on Comment {
-  __typename
-  id
-  stats {
-    ...PublicationStats
-  }
-  metadata {
-    ...MetadataOutput
-  }
-  profile {
-    ...Profile
-  }
-  collectedBy {
-    ...Wallet
-  }
-  collectModule {
-    ... on AaveFeeCollectModuleSettings {
-      ...AaveFeeCollectModuleSettings
-    }
-    ... on ERC4626FeeCollectModuleSettings {
-      ...Erc4626FeeCollectModuleSettings
-    }
-    ... on MultirecipientFeeCollectModuleSettings {
-      ...MultirecipientFeeCollectModuleSettings
-    }
-    ... on UnknownCollectModuleSettings {
-      ...UnknownCollectModuleSettings
-    }
-    ... on FreeCollectModuleSettings {
-      ...FreeCollectModuleSettings
-    }
-    ... on FeeCollectModuleSettings {
-      ...FeeCollectModuleSettings
-    }
-    ... on LimitedFeeCollectModuleSettings {
-      ...LimitedFeeCollectModuleSettings
-    }
-    ... on LimitedTimedFeeCollectModuleSettings {
-      ...LimitedTimedFeeCollectModuleSettings
-    }
-    ... on RevertCollectModuleSettings {
-      ...RevertCollectModuleSettings
-    }
-    ... on TimedFeeCollectModuleSettings {
-      ...TimedFeeCollectModuleSettings
-    }
-  }
-  collectNftAddress
-  referenceModule {
-    ... on FollowOnlyReferenceModuleSettings {
-      ...FollowOnlyReferenceModuleSettings
-    }
-    ... on DegreesOfSeparationReferenceModuleSettings {
-      ...DegreesOfSeparationReferenceModuleSettings
-    }
-    ... on UnknownReferenceModuleSettings {
-      ...UnknownReferenceModuleSettings
-    }
-  }
-  createdAt
-  hidden
-  isGated
-  reaction(request: {profileId: $observerId})
-  hasCollectedByMe(isFinalisedOnChain: true)
-  canComment(profileId: $observerId) {
-    result
-  }
-  canMirror(profileId: $observerId) {
-    result
-  }
-  canObserverDecrypt: canDecrypt(profileId: $observerId) {
-    result
-    reasons
-  }
-  mirrors(by: $observerId)
-  hasOptimisticCollectedByMe @client
-  isOptimisticMirroredByMe @client
-  collectPolicy @client
-  referencePolicy @client
-  decryptionCriteria @client
-}
-    ${FragmentPublicationStats}
-${FragmentMetadataOutput}
-${FragmentProfile}
-${FragmentWallet}
-${FragmentAaveFeeCollectModuleSettings}
-${FragmentErc4626FeeCollectModuleSettings}
-${FragmentMultirecipientFeeCollectModuleSettings}
-${FragmentUnknownCollectModuleSettings}
-${FragmentFreeCollectModuleSettings}
-${FragmentFeeCollectModuleSettings}
-${FragmentLimitedFeeCollectModuleSettings}
-${FragmentLimitedTimedFeeCollectModuleSettings}
-${FragmentRevertCollectModuleSettings}
-${FragmentTimedFeeCollectModuleSettings}
-${FragmentFollowOnlyReferenceModuleSettings}
-${FragmentDegreesOfSeparationReferenceModuleSettings}
-${FragmentUnknownReferenceModuleSettings}`;
-export const FragmentPost = /*#__PURE__*/ gql`
-    fragment Post on Post {
-  __typename
-  id
-  stats {
-    ...PublicationStats
-  }
-  metadata {
-    ...MetadataOutput
-  }
-  profile {
-    ...Profile
-  }
-  collectedBy {
-    ...Wallet
-  }
-  collectModule {
-    ... on AaveFeeCollectModuleSettings {
-      ...AaveFeeCollectModuleSettings
-    }
-    ... on ERC4626FeeCollectModuleSettings {
-      ...Erc4626FeeCollectModuleSettings
-    }
-    ... on MultirecipientFeeCollectModuleSettings {
-      ...MultirecipientFeeCollectModuleSettings
-    }
-    ... on UnknownCollectModuleSettings {
-      ...UnknownCollectModuleSettings
-    }
-    ... on FreeCollectModuleSettings {
-      ...FreeCollectModuleSettings
-    }
-    ... on FeeCollectModuleSettings {
-      ...FeeCollectModuleSettings
-    }
-    ... on LimitedFeeCollectModuleSettings {
-      ...LimitedFeeCollectModuleSettings
-    }
-    ... on LimitedTimedFeeCollectModuleSettings {
-      ...LimitedTimedFeeCollectModuleSettings
-    }
-    ... on RevertCollectModuleSettings {
-      ...RevertCollectModuleSettings
-    }
-    ... on TimedFeeCollectModuleSettings {
-      ...TimedFeeCollectModuleSettings
-    }
-  }
-  collectNftAddress
-  referenceModule {
-    ... on FollowOnlyReferenceModuleSettings {
-      ...FollowOnlyReferenceModuleSettings
-    }
-    ... on DegreesOfSeparationReferenceModuleSettings {
-      ...DegreesOfSeparationReferenceModuleSettings
-    }
-    ... on UnknownReferenceModuleSettings {
-      ...UnknownReferenceModuleSettings
-    }
-  }
-  createdAt
-  hidden
-  isGated
-  reaction(request: {profileId: $observerId})
-  hasCollectedByMe(isFinalisedOnChain: true)
-  canComment(profileId: $observerId) {
-    result
-  }
-  canMirror(profileId: $observerId) {
-    result
-  }
-  mirrors(by: $observerId)
-  canObserverDecrypt: canDecrypt(profileId: $observerId) {
-    result
-    reasons
-  }
-  hasOptimisticCollectedByMe @client
-  isOptimisticMirroredByMe @client
-  collectPolicy @client
-  referencePolicy @client
-  decryptionCriteria @client
-}
-    ${FragmentPublicationStats}
-${FragmentMetadataOutput}
-${FragmentProfile}
-${FragmentWallet}
-${FragmentAaveFeeCollectModuleSettings}
-${FragmentErc4626FeeCollectModuleSettings}
-${FragmentMultirecipientFeeCollectModuleSettings}
-${FragmentUnknownCollectModuleSettings}
-${FragmentFreeCollectModuleSettings}
-${FragmentFeeCollectModuleSettings}
-${FragmentLimitedFeeCollectModuleSettings}
-${FragmentLimitedTimedFeeCollectModuleSettings}
-${FragmentRevertCollectModuleSettings}
-${FragmentTimedFeeCollectModuleSettings}
-${FragmentFollowOnlyReferenceModuleSettings}
-${FragmentDegreesOfSeparationReferenceModuleSettings}
-${FragmentUnknownReferenceModuleSettings}`;
-export const FragmentMirrorBase = /*#__PURE__*/ gql`
-    fragment MirrorBase on Mirror {
-  __typename
-  id
-  createdAt
-  profile {
-    ...Profile
-  }
-  hidden
-}
-    ${FragmentProfile}`;
-export const FragmentComment = /*#__PURE__*/ gql`
-    fragment Comment on Comment {
-  __typename
-  ...CommentBase
-  commentOn {
-    ... on Post {
-      ...Post
-    }
-    ... on Mirror {
-      ...MirrorBase
-    }
-    ... on Comment {
-      ...CommentBase
-    }
-  }
-  mainPost {
-    ... on Post {
-      ...Post
-    }
-    ... on Mirror {
-      ...MirrorBase
-    }
-  }
-}
-    ${FragmentCommentBase}
-${FragmentPost}
-${FragmentMirrorBase}`;
-export const FragmentCommentWithFirstComment = /*#__PURE__*/ gql`
-    fragment CommentWithFirstComment on Comment {
-  __typename
-  ...Comment
-  firstComment {
-    ...Comment
-  }
-}
-    ${FragmentComment}`;
-export const FragmentCommonPaginatedResultInfo = /*#__PURE__*/ gql`
-    fragment CommonPaginatedResultInfo on PaginatedResultInfo {
-  __typename
-  prev
-  next
-  totalCount
-}
-    `;
-export const FragmentPendingPost = /*#__PURE__*/ gql`
-    fragment PendingPost on PendingPost {
-  __typename
-  id
-  content
-  media {
-    ...Media
-  }
-  profile {
-    ...Profile
-  }
-  locale
-  mainContentFocus
-}
-    ${FragmentMedia}
-${FragmentProfile}`;
-export const FragmentEip712TypedDataDomain = /*#__PURE__*/ gql`
-    fragment EIP712TypedDataDomain on EIP712TypedDataDomain {
-  __typename
-  name
-  chainId
-  version
-  verifyingContract
-}
-    `;
-export const FragmentElectedMirror = /*#__PURE__*/ gql`
-    fragment ElectedMirror on ElectedMirror {
-  __typename
-  mirrorId
-  profile {
-    ...Profile
-  }
-  timestamp
-}
-    ${FragmentProfile}`;
-export const FragmentMirrorEvent = /*#__PURE__*/ gql`
-    fragment MirrorEvent on MirrorEvent {
-  __typename
-  profile {
-    ...Profile
-  }
-  timestamp
-}
-    ${FragmentProfile}`;
-export const FragmentCollectedEvent = /*#__PURE__*/ gql`
-    fragment CollectedEvent on CollectedEvent {
-  __typename
-  profile {
-    ...Profile
-  }
-  timestamp
-}
-    ${FragmentProfile}`;
-export const FragmentReactionEvent = /*#__PURE__*/ gql`
-    fragment ReactionEvent on ReactionEvent {
-  __typename
-  profile {
-    ...Profile
-  }
-  reaction
-  timestamp
-}
-    ${FragmentProfile}`;
-export const FragmentFeedItem = /*#__PURE__*/ gql`
-    fragment FeedItem on FeedItem {
-  __typename
-  root {
-    ... on Post {
-      ...Post
-    }
-    ... on Comment {
-      ...Comment
-    }
-  }
-  comments {
-    ...Comment
-  }
-  electedMirror {
-    ...ElectedMirror
-  }
-  mirrors {
-    ...MirrorEvent
-  }
-  collects {
-    ...CollectedEvent
-  }
-  reactions {
-    ...ReactionEvent
-  }
-}
-    ${FragmentPost}
-${FragmentComment}
-${FragmentElectedMirror}
-${FragmentMirrorEvent}
-${FragmentCollectedEvent}
-${FragmentReactionEvent}`;
-export const FragmentEncryptedMediaSet = /*#__PURE__*/ gql`
-    fragment EncryptedMediaSet on EncryptedMediaSet {
-  __typename
-  original {
-    ...EncryptedMedia
-  }
-}
-    ${FragmentEncryptedMedia}`;
-export const FragmentModuleInfo = /*#__PURE__*/ gql`
-    fragment ModuleInfo on ModuleInfo {
-  __typename
-  name
-  type
-}
-    `;
-export const FragmentEnabledModule = /*#__PURE__*/ gql`
-    fragment EnabledModule on EnabledModule {
-  __typename
-  moduleName
-  contractAddress
-  inputParams {
-    ...ModuleInfo
-  }
-  redeemParams {
-    ...ModuleInfo
-  }
-  returnDataParams: returnDataParms {
-    ...ModuleInfo
-  }
-}
-    ${FragmentModuleInfo}`;
-export const FragmentEnabledModules = /*#__PURE__*/ gql`
-    fragment EnabledModules on EnabledModules {
-  __typename
-  collectModules {
-    ...EnabledModule
-  }
-  followModules {
-    ...EnabledModule
-  }
-  referenceModules {
-    ...EnabledModule
-  }
-}
-    ${FragmentEnabledModule}`;
-export const FragmentNewFollowerNotification = /*#__PURE__*/ gql`
-    fragment NewFollowerNotification on NewFollowerNotification {
-  __typename
-  notificationId
-  createdAt
-  isFollowedByMe
-  wallet {
-    ...Wallet
-  }
-}
-    ${FragmentWallet}`;
-export const FragmentMirror = /*#__PURE__*/ gql`
-    fragment Mirror on Mirror {
-  __typename
-  ...MirrorBase
-  mirrorOf {
-    ... on Post {
-      ...Post
-    }
-    ... on Comment {
-      ...Comment
-    }
-  }
-}
-    ${FragmentMirrorBase}
-${FragmentPost}
-${FragmentComment}`;
+  ${FragmentMirrorBase}
+  ${FragmentPost}
+  ${FragmentComment}
+`;
 export const FragmentNewCollectNotification = /*#__PURE__*/ gql`
-    fragment NewCollectNotification on NewCollectNotification {
-  __typename
-  notificationId
-  createdAt
-  wallet {
-    ...Wallet
+  fragment NewCollectNotification on NewCollectNotification {
+    __typename
+    notificationId
+    createdAt
+    wallet {
+      ...Wallet
+    }
+    collectedPublication {
+      ... on Post {
+        ...Post
+      }
+      ... on Mirror {
+        ...Mirror
+      }
+      ... on Comment {
+        ...Comment
+      }
+    }
   }
-  collectedPublication {
-    ... on Post {
-      ...Post
-    }
-    ... on Mirror {
-      ...Mirror
-    }
-    ... on Comment {
-      ...Comment
-    }
-  }
-}
-    ${FragmentWallet}
-${FragmentPost}
-${FragmentMirror}
-${FragmentComment}`;
+  ${FragmentWallet}
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentComment}
+`;
 export const FragmentNewMirrorNotification = /*#__PURE__*/ gql`
-    fragment NewMirrorNotification on NewMirrorNotification {
-  __typename
-  notificationId
-  createdAt
-  profile {
-    ...Profile
-  }
-  publication {
-    ... on Post {
-      ...Post
+  fragment NewMirrorNotification on NewMirrorNotification {
+    __typename
+    notificationId
+    createdAt
+    profile {
+      ...Profile
     }
-    ... on Comment {
-      ...Comment
+    publication {
+      ... on Post {
+        ...Post
+      }
+      ... on Comment {
+        ...Comment
+      }
     }
   }
-}
-    ${FragmentProfile}
-${FragmentPost}
-${FragmentComment}`;
+  ${FragmentProfile}
+  ${FragmentPost}
+  ${FragmentComment}
+`;
 export const FragmentNewCommentNotification = /*#__PURE__*/ gql`
-    fragment NewCommentNotification on NewCommentNotification {
-  __typename
-  notificationId
-  createdAt
-  profile {
-    ...Profile
+  fragment NewCommentNotification on NewCommentNotification {
+    __typename
+    notificationId
+    createdAt
+    profile {
+      ...Profile
+    }
+    comment {
+      ...Comment
+    }
   }
-  comment {
-    ...Comment
-  }
-}
-    ${FragmentProfile}
-${FragmentComment}`;
+  ${FragmentProfile}
+  ${FragmentComment}
+`;
 export const FragmentNewMentionNotification = /*#__PURE__*/ gql`
-    fragment NewMentionNotification on NewMentionNotification {
-  __typename
-  notificationId
-  createdAt
-  mentionPublication {
-    ... on Post {
-      ...Post
-    }
-    ... on Comment {
-      ...Comment
+  fragment NewMentionNotification on NewMentionNotification {
+    __typename
+    notificationId
+    createdAt
+    mentionPublication {
+      ... on Post {
+        ...Post
+      }
+      ... on Comment {
+        ...Comment
+      }
     }
   }
-}
-    ${FragmentPost}
-${FragmentComment}`;
+  ${FragmentPost}
+  ${FragmentComment}
+`;
 export const FragmentNewReactionNotification = /*#__PURE__*/ gql`
-    fragment NewReactionNotification on NewReactionNotification {
-  __typename
-  notificationId
-  createdAt
-  profile {
-    ...Profile
+  fragment NewReactionNotification on NewReactionNotification {
+    __typename
+    notificationId
+    createdAt
+    profile {
+      ...Profile
+    }
+    reaction
+    publication {
+      ... on Post {
+        ...Post
+      }
+      ... on Comment {
+        ...Comment
+      }
+      ... on Mirror {
+        ...Mirror
+      }
+    }
   }
-  reaction
-  publication {
-    ... on Post {
-      ...Post
-    }
-    ... on Comment {
-      ...Comment
-    }
-    ... on Mirror {
-      ...Mirror
-    }
-  }
-}
-    ${FragmentProfile}
-${FragmentPost}
-${FragmentComment}
-${FragmentMirror}`;
+  ${FragmentProfile}
+  ${FragmentPost}
+  ${FragmentComment}
+  ${FragmentMirror}
+`;
 export const FragmentFollower = /*#__PURE__*/ gql`
-    fragment Follower on Follower {
-  __typename
-  wallet {
-    ...Wallet
+  fragment Follower on Follower {
+    __typename
+    wallet {
+      ...Wallet
+    }
   }
-}
-    ${FragmentWallet}`;
+  ${FragmentWallet}
+`;
 export const FragmentFollowing = /*#__PURE__*/ gql`
-    fragment Following on Following {
-  __typename
-  profile {
-    ...Profile
+  fragment Following on Following {
+    __typename
+    profile {
+      ...Profile
+    }
   }
-}
-    ${FragmentProfile}`;
+  ${FragmentProfile}
+`;
 export const FragmentProxyActionStatusResult = /*#__PURE__*/ gql`
-    fragment ProxyActionStatusResult on ProxyActionStatusResult {
-  __typename
-  txHash
-  txId
-  status
-}
-    `;
+  fragment ProxyActionStatusResult on ProxyActionStatusResult {
+    __typename
+    txHash
+    txId
+    status
+  }
+`;
 export const FragmentProxyActionError = /*#__PURE__*/ gql`
-    fragment ProxyActionError on ProxyActionError {
-  __typename
-  reason
-  lastKnownTxId
-}
-    `;
+  fragment ProxyActionError on ProxyActionError {
+    __typename
+    reason
+    lastKnownTxId
+  }
+`;
 export const FragmentProxyActionQueued = /*#__PURE__*/ gql`
-    fragment ProxyActionQueued on ProxyActionQueued {
-  __typename
-  queuedAt
-}
-    `;
+  fragment ProxyActionQueued on ProxyActionQueued {
+    __typename
+    queuedAt
+  }
+`;
 export const FragmentWhoReactedResult = /*#__PURE__*/ gql`
-    fragment WhoReactedResult on WhoReactedResult {
-  __typename
-  reactionId
-  reaction
-  reactionAt
-  profile {
-    ...Profile
+  fragment WhoReactedResult on WhoReactedResult {
+    __typename
+    reactionId
+    reaction
+    reactionAt
+    profile {
+      ...Profile
+    }
   }
-}
-    ${FragmentProfile}`;
+  ${FragmentProfile}
+`;
 export const FragmentErc20AmountFields = /*#__PURE__*/ gql`
-    fragment Erc20AmountFields on Erc20Amount {
-  __typename
-  asset {
-    ...Erc20Fields
+  fragment Erc20AmountFields on Erc20Amount {
+    __typename
+    asset {
+      ...Erc20Fields
+    }
+    value
   }
-  value
-}
-    ${FragmentErc20Fields}`;
+  ${FragmentErc20Fields}
+`;
 export const FragmentRevenueAggregate = /*#__PURE__*/ gql`
-    fragment RevenueAggregate on RevenueAggregate {
-  __typename
-  __total: total {
-    ...Erc20AmountFields
+  fragment RevenueAggregate on RevenueAggregate {
+    __typename
+    __total: total {
+      ...Erc20AmountFields
+    }
+    totalAmount @client
   }
-  totalAmount @client
-}
-    ${FragmentErc20AmountFields}`;
+  ${FragmentErc20AmountFields}
+`;
 export const FragmentPublicationRevenue = /*#__PURE__*/ gql`
-    fragment PublicationRevenue on PublicationRevenue {
-  __typename
-  publication {
-    ... on Post {
-      ...Post
+  fragment PublicationRevenue on PublicationRevenue {
+    __typename
+    publication {
+      ... on Post {
+        ...Post
+      }
+      ... on Mirror {
+        ...Mirror
+      }
+      ... on Comment {
+        ...Comment
+      }
     }
-    ... on Mirror {
-      ...Mirror
-    }
-    ... on Comment {
-      ...Comment
+    revenue {
+      ...RevenueAggregate
     }
   }
-  revenue {
-    ...RevenueAggregate
-  }
-}
-    ${FragmentPost}
-${FragmentMirror}
-${FragmentComment}
-${FragmentRevenueAggregate}`;
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentComment}
+  ${FragmentRevenueAggregate}
+`;
 export const FragmentProfileFollowRevenue = /*#__PURE__*/ gql`
-    fragment ProfileFollowRevenue on FollowRevenueResult {
-  __typename
-  revenues {
-    ...RevenueAggregate
+  fragment ProfileFollowRevenue on FollowRevenueResult {
+    __typename
+    revenues {
+      ...RevenueAggregate
+    }
   }
-}
-    ${FragmentRevenueAggregate}`;
+  ${FragmentRevenueAggregate}
+`;
 export const FragmentRelayerResult = /*#__PURE__*/ gql`
-    fragment RelayerResult on RelayerResult {
-  __typename
-  txHash
-  txId
-}
-    `;
+  fragment RelayerResult on RelayerResult {
+    __typename
+    txHash
+    txId
+  }
+`;
 export const FragmentRelayError = /*#__PURE__*/ gql`
-    fragment RelayError on RelayError {
-  __typename
-  reason
-}
-    `;
+  fragment RelayError on RelayError {
+    __typename
+    reason
+  }
+`;
 export const FragmentRelayResult = /*#__PURE__*/ gql`
-    fragment RelayResult on RelayResult {
-  ... on RelayerResult {
-    ...RelayerResult
+  fragment RelayResult on RelayResult {
+    ... on RelayerResult {
+      ...RelayerResult
+    }
+    ... on RelayError {
+      ...RelayError
+    }
   }
-  ... on RelayError {
-    ...RelayError
-  }
-}
-    ${FragmentRelayerResult}
-${FragmentRelayError}`;
+  ${FragmentRelayerResult}
+  ${FragmentRelayError}
+`;
 export const FragmentTransactionIndexedResult = /*#__PURE__*/ gql`
-    fragment TransactionIndexedResult on TransactionIndexedResult {
-  __typename
-  indexed
-  txHash
-}
-    `;
-export const FragmentTransactionError = /*#__PURE__*/ gql`
-    fragment TransactionError on TransactionError {
-  __typename
-  reason
-}
-    `;
-export const AuthChallengeDocument = /*#__PURE__*/ gql`
-    query AuthChallenge($address: EthereumAddress!) {
-  result: challenge(request: {address: $address}) {
-    text
+  fragment TransactionIndexedResult on TransactionIndexedResult {
+    __typename
+    indexed
+    txHash
   }
-}
-    `;
+`;
+export const FragmentTransactionError = /*#__PURE__*/ gql`
+  fragment TransactionError on TransactionError {
+    __typename
+    reason
+  }
+`;
+export const AuthChallengeDocument = /*#__PURE__*/ gql`
+  query AuthChallenge($address: EthereumAddress!) {
+    result: challenge(request: { address: $address }) {
+      text
+    }
+  }
+`;
 
 /**
  * __useAuthChallenge__
@@ -1201,26 +1250,48 @@ export const AuthChallengeDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useAuthChallenge(baseOptions: Apollo.QueryHookOptions<Operations.AuthChallengeData, Operations.AuthChallengeVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.AuthChallengeData, Operations.AuthChallengeVariables>(AuthChallengeDocument, options);
-      }
-export function useAuthChallengeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.AuthChallengeData, Operations.AuthChallengeVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.AuthChallengeData, Operations.AuthChallengeVariables>(AuthChallengeDocument, options);
-        }
+export function useAuthChallenge(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.AuthChallengeData,
+    Operations.AuthChallengeVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.AuthChallengeData, Operations.AuthChallengeVariables>(
+    AuthChallengeDocument,
+    options,
+  );
+}
+export function useAuthChallengeLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.AuthChallengeData,
+    Operations.AuthChallengeVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.AuthChallengeData, Operations.AuthChallengeVariables>(
+    AuthChallengeDocument,
+    options,
+  );
+}
 export type AuthChallengeHookResult = ReturnType<typeof useAuthChallenge>;
 export type AuthChallengeLazyQueryHookResult = ReturnType<typeof useAuthChallengeLazyQuery>;
-export type AuthChallengeQueryResult = Apollo.QueryResult<Operations.AuthChallengeData, Operations.AuthChallengeVariables>;
+export type AuthChallengeQueryResult = Apollo.QueryResult<
+  Operations.AuthChallengeData,
+  Operations.AuthChallengeVariables
+>;
 export const AuthAuthenticateDocument = /*#__PURE__*/ gql`
-    mutation AuthAuthenticate($address: EthereumAddress!, $signature: Signature!) {
-  result: authenticate(request: {address: $address, signature: $signature}) {
-    accessToken
-    refreshToken
+  mutation AuthAuthenticate($address: EthereumAddress!, $signature: Signature!) {
+    result: authenticate(request: { address: $address, signature: $signature }) {
+      accessToken
+      refreshToken
+    }
   }
-}
-    `;
-export type AuthAuthenticateMutationFn = Apollo.MutationFunction<Operations.AuthAuthenticateData, Operations.AuthAuthenticateVariables>;
+`;
+export type AuthAuthenticateMutationFn = Apollo.MutationFunction<
+  Operations.AuthAuthenticateData,
+  Operations.AuthAuthenticateVariables
+>;
 
 /**
  * __useAuthAuthenticate__
@@ -1240,22 +1311,36 @@ export type AuthAuthenticateMutationFn = Apollo.MutationFunction<Operations.Auth
  *   },
  * });
  */
-export function useAuthAuthenticate(baseOptions?: Apollo.MutationHookOptions<Operations.AuthAuthenticateData, Operations.AuthAuthenticateVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.AuthAuthenticateData, Operations.AuthAuthenticateVariables>(AuthAuthenticateDocument, options);
-      }
+export function useAuthAuthenticate(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.AuthAuthenticateData,
+    Operations.AuthAuthenticateVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.AuthAuthenticateData, Operations.AuthAuthenticateVariables>(
+    AuthAuthenticateDocument,
+    options,
+  );
+}
 export type AuthAuthenticateHookResult = ReturnType<typeof useAuthAuthenticate>;
 export type AuthAuthenticateMutationResult = Apollo.MutationResult<Operations.AuthAuthenticateData>;
-export type AuthAuthenticateMutationOptions = Apollo.BaseMutationOptions<Operations.AuthAuthenticateData, Operations.AuthAuthenticateVariables>;
+export type AuthAuthenticateMutationOptions = Apollo.BaseMutationOptions<
+  Operations.AuthAuthenticateData,
+  Operations.AuthAuthenticateVariables
+>;
 export const AuthRefreshDocument = /*#__PURE__*/ gql`
-    mutation AuthRefresh($refreshToken: Jwt!) {
-  result: refresh(request: {refreshToken: $refreshToken}) {
-    accessToken
-    refreshToken
+  mutation AuthRefresh($refreshToken: Jwt!) {
+    result: refresh(request: { refreshToken: $refreshToken }) {
+      accessToken
+      refreshToken
+    }
   }
-}
-    `;
-export type AuthRefreshMutationFn = Apollo.MutationFunction<Operations.AuthRefreshData, Operations.AuthRefreshVariables>;
+`;
+export type AuthRefreshMutationFn = Apollo.MutationFunction<
+  Operations.AuthRefreshData,
+  Operations.AuthRefreshVariables
+>;
 
 /**
  * __useAuthRefresh__
@@ -1274,40 +1359,55 @@ export type AuthRefreshMutationFn = Apollo.MutationFunction<Operations.AuthRefre
  *   },
  * });
  */
-export function useAuthRefresh(baseOptions?: Apollo.MutationHookOptions<Operations.AuthRefreshData, Operations.AuthRefreshVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.AuthRefreshData, Operations.AuthRefreshVariables>(AuthRefreshDocument, options);
-      }
+export function useAuthRefresh(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.AuthRefreshData,
+    Operations.AuthRefreshVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.AuthRefreshData, Operations.AuthRefreshVariables>(
+    AuthRefreshDocument,
+    options,
+  );
+}
 export type AuthRefreshHookResult = ReturnType<typeof useAuthRefresh>;
 export type AuthRefreshMutationResult = Apollo.MutationResult<Operations.AuthRefreshData>;
-export type AuthRefreshMutationOptions = Apollo.BaseMutationOptions<Operations.AuthRefreshData, Operations.AuthRefreshVariables>;
+export type AuthRefreshMutationOptions = Apollo.BaseMutationOptions<
+  Operations.AuthRefreshData,
+  Operations.AuthRefreshVariables
+>;
 export const CreateCollectTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateCollectTypedData($request: CreateCollectRequest!, $options: TypedDataOptions) {
-  result: createCollectTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        CollectWithSig {
-          name
-          type
+  mutation CreateCollectTypedData($request: CreateCollectRequest!, $options: TypedDataOptions) {
+    result: createCollectTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          CollectWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        ...EIP712TypedDataDomain
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        pubId
-        data
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          pubId
+          data
+        }
       }
     }
   }
-}
-    ${FragmentEip712TypedDataDomain}`;
-export type CreateCollectTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateCollectTypedDataData, Operations.CreateCollectTypedDataVariables>;
+  ${FragmentEip712TypedDataDomain}
+`;
+export type CreateCollectTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateCollectTypedDataData,
+  Operations.CreateCollectTypedDataVariables
+>;
 
 /**
  * __useCreateCollectTypedData__
@@ -1327,46 +1427,65 @@ export type CreateCollectTypedDataMutationFn = Apollo.MutationFunction<Operation
  *   },
  * });
  */
-export function useCreateCollectTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateCollectTypedDataData, Operations.CreateCollectTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateCollectTypedDataData, Operations.CreateCollectTypedDataVariables>(CreateCollectTypedDataDocument, options);
-      }
+export function useCreateCollectTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateCollectTypedDataData,
+    Operations.CreateCollectTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateCollectTypedDataData,
+    Operations.CreateCollectTypedDataVariables
+  >(CreateCollectTypedDataDocument, options);
+}
 export type CreateCollectTypedDataHookResult = ReturnType<typeof useCreateCollectTypedData>;
-export type CreateCollectTypedDataMutationResult = Apollo.MutationResult<Operations.CreateCollectTypedDataData>;
-export type CreateCollectTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateCollectTypedDataData, Operations.CreateCollectTypedDataVariables>;
+export type CreateCollectTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateCollectTypedDataData>;
+export type CreateCollectTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateCollectTypedDataData,
+  Operations.CreateCollectTypedDataVariables
+>;
 export const CreateCommentTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateCommentTypedData($request: CreatePublicCommentRequest!, $options: TypedDataOptions) {
-  result: createCommentTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        CommentWithSig {
-          name
-          type
+  mutation CreateCommentTypedData(
+    $request: CreatePublicCommentRequest!
+    $options: TypedDataOptions
+  ) {
+    result: createCommentTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          CommentWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        ...EIP712TypedDataDomain
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        contentURI
-        profileIdPointed
-        pubIdPointed
-        collectModule
-        collectModuleInitData
-        referenceModuleData
-        referenceModule
-        referenceModuleInitData
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          contentURI
+          profileIdPointed
+          pubIdPointed
+          collectModule
+          collectModuleInitData
+          referenceModuleData
+          referenceModule
+          referenceModuleInitData
+        }
       }
     }
   }
-}
-    ${FragmentEip712TypedDataDomain}`;
-export type CreateCommentTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateCommentTypedDataData, Operations.CreateCommentTypedDataVariables>;
+  ${FragmentEip712TypedDataDomain}
+`;
+export type CreateCommentTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateCommentTypedDataData,
+  Operations.CreateCommentTypedDataVariables
+>;
 
 /**
  * __useCreateCommentTypedData__
@@ -1386,21 +1505,37 @@ export type CreateCommentTypedDataMutationFn = Apollo.MutationFunction<Operation
  *   },
  * });
  */
-export function useCreateCommentTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateCommentTypedDataData, Operations.CreateCommentTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateCommentTypedDataData, Operations.CreateCommentTypedDataVariables>(CreateCommentTypedDataDocument, options);
-      }
-export type CreateCommentTypedDataHookResult = ReturnType<typeof useCreateCommentTypedData>;
-export type CreateCommentTypedDataMutationResult = Apollo.MutationResult<Operations.CreateCommentTypedDataData>;
-export type CreateCommentTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateCommentTypedDataData, Operations.CreateCommentTypedDataVariables>;
-export const CreateCommentViaDispatcherDocument = /*#__PURE__*/ gql`
-    mutation CreateCommentViaDispatcher($request: CreatePublicCommentRequest!) {
-  result: createCommentViaDispatcher(request: $request) {
-    ...RelayResult
-  }
+export function useCreateCommentTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateCommentTypedDataData,
+    Operations.CreateCommentTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateCommentTypedDataData,
+    Operations.CreateCommentTypedDataVariables
+  >(CreateCommentTypedDataDocument, options);
 }
-    ${FragmentRelayResult}`;
-export type CreateCommentViaDispatcherMutationFn = Apollo.MutationFunction<Operations.CreateCommentViaDispatcherData, Operations.CreateCommentViaDispatcherVariables>;
+export type CreateCommentTypedDataHookResult = ReturnType<typeof useCreateCommentTypedData>;
+export type CreateCommentTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateCommentTypedDataData>;
+export type CreateCommentTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateCommentTypedDataData,
+  Operations.CreateCommentTypedDataVariables
+>;
+export const CreateCommentViaDispatcherDocument = /*#__PURE__*/ gql`
+  mutation CreateCommentViaDispatcher($request: CreatePublicCommentRequest!) {
+    result: createCommentViaDispatcher(request: $request) {
+      ...RelayResult
+    }
+  }
+  ${FragmentRelayResult}
+`;
+export type CreateCommentViaDispatcherMutationFn = Apollo.MutationFunction<
+  Operations.CreateCommentViaDispatcherData,
+  Operations.CreateCommentViaDispatcherVariables
+>;
 
 /**
  * __useCreateCommentViaDispatcher__
@@ -1419,30 +1554,56 @@ export type CreateCommentViaDispatcherMutationFn = Apollo.MutationFunction<Opera
  *   },
  * });
  */
-export function useCreateCommentViaDispatcher(baseOptions?: Apollo.MutationHookOptions<Operations.CreateCommentViaDispatcherData, Operations.CreateCommentViaDispatcherVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateCommentViaDispatcherData, Operations.CreateCommentViaDispatcherVariables>(CreateCommentViaDispatcherDocument, options);
-      }
+export function useCreateCommentViaDispatcher(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateCommentViaDispatcherData,
+    Operations.CreateCommentViaDispatcherVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateCommentViaDispatcherData,
+    Operations.CreateCommentViaDispatcherVariables
+  >(CreateCommentViaDispatcherDocument, options);
+}
 export type CreateCommentViaDispatcherHookResult = ReturnType<typeof useCreateCommentViaDispatcher>;
-export type CreateCommentViaDispatcherMutationResult = Apollo.MutationResult<Operations.CreateCommentViaDispatcherData>;
-export type CreateCommentViaDispatcherMutationOptions = Apollo.BaseMutationOptions<Operations.CreateCommentViaDispatcherData, Operations.CreateCommentViaDispatcherVariables>;
+export type CreateCommentViaDispatcherMutationResult =
+  Apollo.MutationResult<Operations.CreateCommentViaDispatcherData>;
+export type CreateCommentViaDispatcherMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateCommentViaDispatcherData,
+  Operations.CreateCommentViaDispatcherVariables
+>;
 export const CommentsDocument = /*#__PURE__*/ gql`
-    query Comments($observerId: ProfileId, $commentsOf: InternalPublicationId!, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!, $metadata: PublicationMetadataFilters) {
-  result: publications(
-    request: {limit: $limit, cursor: $cursor, commentsOf: $commentsOf, sources: $sources, metadata: $metadata}
+  query Comments(
+    $observerId: ProfileId
+    $commentsOf: InternalPublicationId!
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
+    $metadata: PublicationMetadataFilters
   ) {
-    items {
-      ... on Comment {
-        ...CommentWithFirstComment
+    result: publications(
+      request: {
+        limit: $limit
+        cursor: $cursor
+        commentsOf: $commentsOf
+        sources: $sources
+        metadata: $metadata
       }
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    ) {
+      items {
+        ... on Comment {
+          ...CommentWithFirstComment
+        }
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentCommentWithFirstComment}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentCommentWithFirstComment}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useComments__
@@ -1465,24 +1626,38 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useComments(baseOptions: Apollo.QueryHookOptions<Operations.CommentsData, Operations.CommentsVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.CommentsData, Operations.CommentsVariables>(CommentsDocument, options);
-      }
-export function useCommentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.CommentsData, Operations.CommentsVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.CommentsData, Operations.CommentsVariables>(CommentsDocument, options);
-        }
+export function useComments(
+  baseOptions: Apollo.QueryHookOptions<Operations.CommentsData, Operations.CommentsVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.CommentsData, Operations.CommentsVariables>(
+    CommentsDocument,
+    options,
+  );
+}
+export function useCommentsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<Operations.CommentsData, Operations.CommentsVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.CommentsData, Operations.CommentsVariables>(
+    CommentsDocument,
+    options,
+  );
+}
 export type CommentsHookResult = ReturnType<typeof useComments>;
 export type CommentsLazyQueryHookResult = ReturnType<typeof useCommentsLazyQuery>;
-export type CommentsQueryResult = Apollo.QueryResult<Operations.CommentsData, Operations.CommentsVariables>;
+export type CommentsQueryResult = Apollo.QueryResult<
+  Operations.CommentsData,
+  Operations.CommentsVariables
+>;
 export const EnabledModuleCurrenciesDocument = /*#__PURE__*/ gql`
-    query EnabledModuleCurrencies {
-  result: enabledModuleCurrencies {
-    ...Erc20Fields
+  query EnabledModuleCurrencies {
+    result: enabledModuleCurrencies {
+      ...Erc20Fields
+    }
   }
-}
-    ${FragmentErc20Fields}`;
+  ${FragmentErc20Fields}
+`;
 
 /**
  * __useEnabledModuleCurrencies__
@@ -1499,32 +1674,69 @@ export const EnabledModuleCurrenciesDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useEnabledModuleCurrencies(baseOptions?: Apollo.QueryHookOptions<Operations.EnabledModuleCurrenciesData, Operations.EnabledModuleCurrenciesVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.EnabledModuleCurrenciesData, Operations.EnabledModuleCurrenciesVariables>(EnabledModuleCurrenciesDocument, options);
-      }
-export function useEnabledModuleCurrenciesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.EnabledModuleCurrenciesData, Operations.EnabledModuleCurrenciesVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.EnabledModuleCurrenciesData, Operations.EnabledModuleCurrenciesVariables>(EnabledModuleCurrenciesDocument, options);
-        }
+export function useEnabledModuleCurrencies(
+  baseOptions?: Apollo.QueryHookOptions<
+    Operations.EnabledModuleCurrenciesData,
+    Operations.EnabledModuleCurrenciesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.EnabledModuleCurrenciesData,
+    Operations.EnabledModuleCurrenciesVariables
+  >(EnabledModuleCurrenciesDocument, options);
+}
+export function useEnabledModuleCurrenciesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.EnabledModuleCurrenciesData,
+    Operations.EnabledModuleCurrenciesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.EnabledModuleCurrenciesData,
+    Operations.EnabledModuleCurrenciesVariables
+  >(EnabledModuleCurrenciesDocument, options);
+}
 export type EnabledModuleCurrenciesHookResult = ReturnType<typeof useEnabledModuleCurrencies>;
-export type EnabledModuleCurrenciesLazyQueryHookResult = ReturnType<typeof useEnabledModuleCurrenciesLazyQuery>;
-export type EnabledModuleCurrenciesQueryResult = Apollo.QueryResult<Operations.EnabledModuleCurrenciesData, Operations.EnabledModuleCurrenciesVariables>;
+export type EnabledModuleCurrenciesLazyQueryHookResult = ReturnType<
+  typeof useEnabledModuleCurrenciesLazyQuery
+>;
+export type EnabledModuleCurrenciesQueryResult = Apollo.QueryResult<
+  Operations.EnabledModuleCurrenciesData,
+  Operations.EnabledModuleCurrenciesVariables
+>;
 export const FeedDocument = /*#__PURE__*/ gql`
-    query Feed($profileId: ProfileId!, $restrictEventTypesTo: [FeedEventItemType!], $observerId: ProfileId, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!, $metadata: PublicationMetadataFilters) {
-  result: feed(
-    request: {profileId: $profileId, feedEventItemTypes: $restrictEventTypesTo, limit: $limit, cursor: $cursor, sources: $sources, metadata: $metadata}
+  query Feed(
+    $profileId: ProfileId!
+    $restrictEventTypesTo: [FeedEventItemType!]
+    $observerId: ProfileId
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
+    $metadata: PublicationMetadataFilters
   ) {
-    items {
-      ...FeedItem
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: feed(
+      request: {
+        profileId: $profileId
+        feedEventItemTypes: $restrictEventTypesTo
+        limit: $limit
+        cursor: $cursor
+        sources: $sources
+        metadata: $metadata
+      }
+    ) {
+      items {
+        ...FeedItem
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentFeedItem}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentFeedItem}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useFeed__
@@ -1548,32 +1760,43 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useFeed(baseOptions: Apollo.QueryHookOptions<Operations.FeedData, Operations.FeedVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.FeedData, Operations.FeedVariables>(FeedDocument, options);
-      }
-export function useFeedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.FeedData, Operations.FeedVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.FeedData, Operations.FeedVariables>(FeedDocument, options);
-        }
+export function useFeed(
+  baseOptions: Apollo.QueryHookOptions<Operations.FeedData, Operations.FeedVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.FeedData, Operations.FeedVariables>(FeedDocument, options);
+}
+export function useFeedLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<Operations.FeedData, Operations.FeedVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.FeedData, Operations.FeedVariables>(FeedDocument, options);
+}
 export type FeedHookResult = ReturnType<typeof useFeed>;
 export type FeedLazyQueryHookResult = ReturnType<typeof useFeedLazyQuery>;
 export type FeedQueryResult = Apollo.QueryResult<Operations.FeedData, Operations.FeedVariables>;
 export const ExploreProfilesDocument = /*#__PURE__*/ gql`
-    query ExploreProfiles($sortCriteria: ProfileSortCriteria!, $limit: LimitScalar, $cursor: Cursor, $observerId: ProfileId, $sources: [Sources!]!) {
-  result: exploreProfiles(
-    request: {limit: $limit, cursor: $cursor, sortCriteria: $sortCriteria}
+  query ExploreProfiles(
+    $sortCriteria: ProfileSortCriteria!
+    $limit: LimitScalar
+    $cursor: Cursor
+    $observerId: ProfileId
+    $sources: [Sources!]!
   ) {
-    items {
-      ...Profile
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: exploreProfiles(
+      request: { limit: $limit, cursor: $cursor, sortCriteria: $sortCriteria }
+    ) {
+      items {
+        ...Profile
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentProfile}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentProfile}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useExploreProfiles__
@@ -1595,43 +1818,66 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useExploreProfiles(baseOptions: Apollo.QueryHookOptions<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>(ExploreProfilesDocument, options);
-      }
-export function useExploreProfilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>(ExploreProfilesDocument, options);
-        }
+export function useExploreProfiles(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ExploreProfilesData,
+    Operations.ExploreProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>(
+    ExploreProfilesDocument,
+    options,
+  );
+}
+export function useExploreProfilesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ExploreProfilesData,
+    Operations.ExploreProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>(
+    ExploreProfilesDocument,
+    options,
+  );
+}
 export type ExploreProfilesHookResult = ReturnType<typeof useExploreProfiles>;
 export type ExploreProfilesLazyQueryHookResult = ReturnType<typeof useExploreProfilesLazyQuery>;
-export type ExploreProfilesQueryResult = Apollo.QueryResult<Operations.ExploreProfilesData, Operations.ExploreProfilesVariables>;
+export type ExploreProfilesQueryResult = Apollo.QueryResult<
+  Operations.ExploreProfilesData,
+  Operations.ExploreProfilesVariables
+>;
 export const CreateFollowTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateFollowTypedData($request: FollowRequest!, $options: TypedDataOptions) {
-  result: createFollowTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        FollowWithSig {
-          name
-          type
+  mutation CreateFollowTypedData($request: FollowRequest!, $options: TypedDataOptions) {
+    result: createFollowTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          FollowWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        ...EIP712TypedDataDomain
-      }
-      value {
-        nonce
-        deadline
-        profileIds
-        datas
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileIds
+          datas
+        }
       }
     }
   }
-}
-    ${FragmentEip712TypedDataDomain}`;
-export type CreateFollowTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateFollowTypedDataData, Operations.CreateFollowTypedDataVariables>;
+  ${FragmentEip712TypedDataDomain}
+`;
+export type CreateFollowTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateFollowTypedDataData,
+  Operations.CreateFollowTypedDataVariables
+>;
 
 /**
  * __useCreateFollowTypedData__
@@ -1651,43 +1897,59 @@ export type CreateFollowTypedDataMutationFn = Apollo.MutationFunction<Operations
  *   },
  * });
  */
-export function useCreateFollowTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateFollowTypedDataData, Operations.CreateFollowTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateFollowTypedDataData, Operations.CreateFollowTypedDataVariables>(CreateFollowTypedDataDocument, options);
-      }
+export function useCreateFollowTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateFollowTypedDataData,
+    Operations.CreateFollowTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateFollowTypedDataData,
+    Operations.CreateFollowTypedDataVariables
+  >(CreateFollowTypedDataDocument, options);
+}
 export type CreateFollowTypedDataHookResult = ReturnType<typeof useCreateFollowTypedData>;
-export type CreateFollowTypedDataMutationResult = Apollo.MutationResult<Operations.CreateFollowTypedDataData>;
-export type CreateFollowTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateFollowTypedDataData, Operations.CreateFollowTypedDataVariables>;
+export type CreateFollowTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateFollowTypedDataData>;
+export type CreateFollowTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateFollowTypedDataData,
+  Operations.CreateFollowTypedDataVariables
+>;
 export const CreateMirrorTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateMirrorTypedData($request: CreateMirrorRequest!, $options: TypedDataOptions) {
-  result: createMirrorTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        MirrorWithSig {
-          name
-          type
+  mutation CreateMirrorTypedData($request: CreateMirrorRequest!, $options: TypedDataOptions) {
+    result: createMirrorTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          MirrorWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        ...EIP712TypedDataDomain
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        profileIdPointed
-        pubIdPointed
-        referenceModuleData
-        referenceModule
-        referenceModuleInitData
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          profileIdPointed
+          pubIdPointed
+          referenceModuleData
+          referenceModule
+          referenceModuleInitData
+        }
       }
     }
   }
-}
-    ${FragmentEip712TypedDataDomain}`;
-export type CreateMirrorTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateMirrorTypedDataData, Operations.CreateMirrorTypedDataVariables>;
+  ${FragmentEip712TypedDataDomain}
+`;
+export type CreateMirrorTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateMirrorTypedDataData,
+  Operations.CreateMirrorTypedDataVariables
+>;
 
 /**
  * __useCreateMirrorTypedData__
@@ -1707,21 +1969,37 @@ export type CreateMirrorTypedDataMutationFn = Apollo.MutationFunction<Operations
  *   },
  * });
  */
-export function useCreateMirrorTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateMirrorTypedDataData, Operations.CreateMirrorTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateMirrorTypedDataData, Operations.CreateMirrorTypedDataVariables>(CreateMirrorTypedDataDocument, options);
-      }
-export type CreateMirrorTypedDataHookResult = ReturnType<typeof useCreateMirrorTypedData>;
-export type CreateMirrorTypedDataMutationResult = Apollo.MutationResult<Operations.CreateMirrorTypedDataData>;
-export type CreateMirrorTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateMirrorTypedDataData, Operations.CreateMirrorTypedDataVariables>;
-export const CreateMirrorViaDispatcherDocument = /*#__PURE__*/ gql`
-    mutation CreateMirrorViaDispatcher($request: CreateMirrorRequest!) {
-  result: createMirrorViaDispatcher(request: $request) {
-    ...RelayResult
-  }
+export function useCreateMirrorTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateMirrorTypedDataData,
+    Operations.CreateMirrorTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateMirrorTypedDataData,
+    Operations.CreateMirrorTypedDataVariables
+  >(CreateMirrorTypedDataDocument, options);
 }
-    ${FragmentRelayResult}`;
-export type CreateMirrorViaDispatcherMutationFn = Apollo.MutationFunction<Operations.CreateMirrorViaDispatcherData, Operations.CreateMirrorViaDispatcherVariables>;
+export type CreateMirrorTypedDataHookResult = ReturnType<typeof useCreateMirrorTypedData>;
+export type CreateMirrorTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateMirrorTypedDataData>;
+export type CreateMirrorTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateMirrorTypedDataData,
+  Operations.CreateMirrorTypedDataVariables
+>;
+export const CreateMirrorViaDispatcherDocument = /*#__PURE__*/ gql`
+  mutation CreateMirrorViaDispatcher($request: CreateMirrorRequest!) {
+    result: createMirrorViaDispatcher(request: $request) {
+      ...RelayResult
+    }
+  }
+  ${FragmentRelayResult}
+`;
+export type CreateMirrorViaDispatcherMutationFn = Apollo.MutationFunction<
+  Operations.CreateMirrorViaDispatcherData,
+  Operations.CreateMirrorViaDispatcherVariables
+>;
 
 /**
  * __useCreateMirrorViaDispatcher__
@@ -1740,20 +2018,33 @@ export type CreateMirrorViaDispatcherMutationFn = Apollo.MutationFunction<Operat
  *   },
  * });
  */
-export function useCreateMirrorViaDispatcher(baseOptions?: Apollo.MutationHookOptions<Operations.CreateMirrorViaDispatcherData, Operations.CreateMirrorViaDispatcherVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateMirrorViaDispatcherData, Operations.CreateMirrorViaDispatcherVariables>(CreateMirrorViaDispatcherDocument, options);
-      }
-export type CreateMirrorViaDispatcherHookResult = ReturnType<typeof useCreateMirrorViaDispatcher>;
-export type CreateMirrorViaDispatcherMutationResult = Apollo.MutationResult<Operations.CreateMirrorViaDispatcherData>;
-export type CreateMirrorViaDispatcherMutationOptions = Apollo.BaseMutationOptions<Operations.CreateMirrorViaDispatcherData, Operations.CreateMirrorViaDispatcherVariables>;
-export const EnabledModulesDocument = /*#__PURE__*/ gql`
-    query EnabledModules {
-  result: enabledModules {
-    ...EnabledModules
-  }
+export function useCreateMirrorViaDispatcher(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateMirrorViaDispatcherData,
+    Operations.CreateMirrorViaDispatcherVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateMirrorViaDispatcherData,
+    Operations.CreateMirrorViaDispatcherVariables
+  >(CreateMirrorViaDispatcherDocument, options);
 }
-    ${FragmentEnabledModules}`;
+export type CreateMirrorViaDispatcherHookResult = ReturnType<typeof useCreateMirrorViaDispatcher>;
+export type CreateMirrorViaDispatcherMutationResult =
+  Apollo.MutationResult<Operations.CreateMirrorViaDispatcherData>;
+export type CreateMirrorViaDispatcherMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateMirrorViaDispatcherData,
+  Operations.CreateMirrorViaDispatcherVariables
+>;
+export const EnabledModulesDocument = /*#__PURE__*/ gql`
+  query EnabledModules {
+    result: enabledModules {
+      ...EnabledModules
+    }
+  }
+  ${FragmentEnabledModules}
+`;
 
 /**
  * __useEnabledModules__
@@ -1770,54 +2061,86 @@ export const EnabledModulesDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useEnabledModules(baseOptions?: Apollo.QueryHookOptions<Operations.EnabledModulesData, Operations.EnabledModulesVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.EnabledModulesData, Operations.EnabledModulesVariables>(EnabledModulesDocument, options);
-      }
-export function useEnabledModulesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.EnabledModulesData, Operations.EnabledModulesVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.EnabledModulesData, Operations.EnabledModulesVariables>(EnabledModulesDocument, options);
-        }
+export function useEnabledModules(
+  baseOptions?: Apollo.QueryHookOptions<
+    Operations.EnabledModulesData,
+    Operations.EnabledModulesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.EnabledModulesData, Operations.EnabledModulesVariables>(
+    EnabledModulesDocument,
+    options,
+  );
+}
+export function useEnabledModulesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.EnabledModulesData,
+    Operations.EnabledModulesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.EnabledModulesData, Operations.EnabledModulesVariables>(
+    EnabledModulesDocument,
+    options,
+  );
+}
 export type EnabledModulesHookResult = ReturnType<typeof useEnabledModules>;
 export type EnabledModulesLazyQueryHookResult = ReturnType<typeof useEnabledModulesLazyQuery>;
-export type EnabledModulesQueryResult = Apollo.QueryResult<Operations.EnabledModulesData, Operations.EnabledModulesVariables>;
+export type EnabledModulesQueryResult = Apollo.QueryResult<
+  Operations.EnabledModulesData,
+  Operations.EnabledModulesVariables
+>;
 export const NotificationsDocument = /*#__PURE__*/ gql`
-    query Notifications($observerId: ProfileId!, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!, $notificationTypes: [NotificationTypes!]) {
-  result: notifications(
-    request: {profileId: $observerId, limit: $limit, cursor: $cursor, sources: $sources, notificationTypes: $notificationTypes}
+  query Notifications(
+    $observerId: ProfileId!
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
+    $notificationTypes: [NotificationTypes!]
   ) {
-    items {
-      ... on NewFollowerNotification {
-        ...NewFollowerNotification
+    result: notifications(
+      request: {
+        profileId: $observerId
+        limit: $limit
+        cursor: $cursor
+        sources: $sources
+        notificationTypes: $notificationTypes
       }
-      ... on NewMirrorNotification {
-        ...NewMirrorNotification
+    ) {
+      items {
+        ... on NewFollowerNotification {
+          ...NewFollowerNotification
+        }
+        ... on NewMirrorNotification {
+          ...NewMirrorNotification
+        }
+        ... on NewCollectNotification {
+          ...NewCollectNotification
+        }
+        ... on NewCommentNotification {
+          ...NewCommentNotification
+        }
+        ... on NewMentionNotification {
+          ...NewMentionNotification
+        }
+        ... on NewReactionNotification {
+          ...NewReactionNotification
+        }
       }
-      ... on NewCollectNotification {
-        ...NewCollectNotification
+      pageInfo {
+        ...CommonPaginatedResultInfo
       }
-      ... on NewCommentNotification {
-        ...NewCommentNotification
-      }
-      ... on NewMentionNotification {
-        ...NewMentionNotification
-      }
-      ... on NewReactionNotification {
-        ...NewReactionNotification
-      }
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
     }
   }
-}
-    ${FragmentNewFollowerNotification}
-${FragmentNewMirrorNotification}
-${FragmentNewCollectNotification}
-${FragmentNewCommentNotification}
-${FragmentNewMentionNotification}
-${FragmentNewReactionNotification}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentNewFollowerNotification}
+  ${FragmentNewMirrorNotification}
+  ${FragmentNewCollectNotification}
+  ${FragmentNewCommentNotification}
+  ${FragmentNewMentionNotification}
+  ${FragmentNewReactionNotification}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useNotifications__
@@ -1839,28 +2162,51 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useNotifications(baseOptions: Apollo.QueryHookOptions<Operations.NotificationsData, Operations.NotificationsVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.NotificationsData, Operations.NotificationsVariables>(NotificationsDocument, options);
-      }
-export function useNotificationsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.NotificationsData, Operations.NotificationsVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.NotificationsData, Operations.NotificationsVariables>(NotificationsDocument, options);
-        }
+export function useNotifications(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.NotificationsData,
+    Operations.NotificationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.NotificationsData, Operations.NotificationsVariables>(
+    NotificationsDocument,
+    options,
+  );
+}
+export function useNotificationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.NotificationsData,
+    Operations.NotificationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.NotificationsData, Operations.NotificationsVariables>(
+    NotificationsDocument,
+    options,
+  );
+}
 export type NotificationsHookResult = ReturnType<typeof useNotifications>;
 export type NotificationsLazyQueryHookResult = ReturnType<typeof useNotificationsLazyQuery>;
-export type NotificationsQueryResult = Apollo.QueryResult<Operations.NotificationsData, Operations.NotificationsVariables>;
+export type NotificationsQueryResult = Apollo.QueryResult<
+  Operations.NotificationsData,
+  Operations.NotificationsVariables
+>;
 export const UnreadNotificationCountDocument = /*#__PURE__*/ gql`
-    query UnreadNotificationCount($profileId: ProfileId!, $sources: [Sources!], $notificationTypes: [NotificationTypes!]) {
-  result: notifications(
-    request: {profileId: $profileId, sources: $sources, notificationTypes: $notificationTypes}
+  query UnreadNotificationCount(
+    $profileId: ProfileId!
+    $sources: [Sources!]
+    $notificationTypes: [NotificationTypes!]
   ) {
-    pageInfo {
-      totalCount
+    result: notifications(
+      request: { profileId: $profileId, sources: $sources, notificationTypes: $notificationTypes }
+    ) {
+      pageInfo {
+        totalCount
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useUnreadNotificationCount__
@@ -1880,47 +2226,72 @@ export const UnreadNotificationCountDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useUnreadNotificationCount(baseOptions: Apollo.QueryHookOptions<Operations.UnreadNotificationCountData, Operations.UnreadNotificationCountVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.UnreadNotificationCountData, Operations.UnreadNotificationCountVariables>(UnreadNotificationCountDocument, options);
-      }
-export function useUnreadNotificationCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.UnreadNotificationCountData, Operations.UnreadNotificationCountVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.UnreadNotificationCountData, Operations.UnreadNotificationCountVariables>(UnreadNotificationCountDocument, options);
-        }
+export function useUnreadNotificationCount(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.UnreadNotificationCountData,
+    Operations.UnreadNotificationCountVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.UnreadNotificationCountData,
+    Operations.UnreadNotificationCountVariables
+  >(UnreadNotificationCountDocument, options);
+}
+export function useUnreadNotificationCountLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.UnreadNotificationCountData,
+    Operations.UnreadNotificationCountVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.UnreadNotificationCountData,
+    Operations.UnreadNotificationCountVariables
+  >(UnreadNotificationCountDocument, options);
+}
 export type UnreadNotificationCountHookResult = ReturnType<typeof useUnreadNotificationCount>;
-export type UnreadNotificationCountLazyQueryHookResult = ReturnType<typeof useUnreadNotificationCountLazyQuery>;
-export type UnreadNotificationCountQueryResult = Apollo.QueryResult<Operations.UnreadNotificationCountData, Operations.UnreadNotificationCountVariables>;
+export type UnreadNotificationCountLazyQueryHookResult = ReturnType<
+  typeof useUnreadNotificationCountLazyQuery
+>;
+export type UnreadNotificationCountQueryResult = Apollo.QueryResult<
+  Operations.UnreadNotificationCountData,
+  Operations.UnreadNotificationCountVariables
+>;
 export const CreatePostTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreatePostTypedData($request: CreatePublicPostRequest!, $options: TypedDataOptions) {
-  result: createPostTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        PostWithSig {
-          name
-          type
+  mutation CreatePostTypedData($request: CreatePublicPostRequest!, $options: TypedDataOptions) {
+    result: createPostTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          PostWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        ...EIP712TypedDataDomain
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        contentURI
-        collectModule
-        collectModuleInitData
-        referenceModule
-        referenceModuleInitData
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          contentURI
+          collectModule
+          collectModuleInitData
+          referenceModule
+          referenceModuleInitData
+        }
       }
     }
   }
-}
-    ${FragmentEip712TypedDataDomain}`;
-export type CreatePostTypedDataMutationFn = Apollo.MutationFunction<Operations.CreatePostTypedDataData, Operations.CreatePostTypedDataVariables>;
+  ${FragmentEip712TypedDataDomain}
+`;
+export type CreatePostTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreatePostTypedDataData,
+  Operations.CreatePostTypedDataVariables
+>;
 
 /**
  * __useCreatePostTypedData__
@@ -1940,21 +2311,37 @@ export type CreatePostTypedDataMutationFn = Apollo.MutationFunction<Operations.C
  *   },
  * });
  */
-export function useCreatePostTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreatePostTypedDataData, Operations.CreatePostTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreatePostTypedDataData, Operations.CreatePostTypedDataVariables>(CreatePostTypedDataDocument, options);
-      }
-export type CreatePostTypedDataHookResult = ReturnType<typeof useCreatePostTypedData>;
-export type CreatePostTypedDataMutationResult = Apollo.MutationResult<Operations.CreatePostTypedDataData>;
-export type CreatePostTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreatePostTypedDataData, Operations.CreatePostTypedDataVariables>;
-export const CreatePostViaDispatcherDocument = /*#__PURE__*/ gql`
-    mutation CreatePostViaDispatcher($request: CreatePublicPostRequest!) {
-  result: createPostViaDispatcher(request: $request) {
-    ...RelayResult
-  }
+export function useCreatePostTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreatePostTypedDataData,
+    Operations.CreatePostTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreatePostTypedDataData,
+    Operations.CreatePostTypedDataVariables
+  >(CreatePostTypedDataDocument, options);
 }
-    ${FragmentRelayResult}`;
-export type CreatePostViaDispatcherMutationFn = Apollo.MutationFunction<Operations.CreatePostViaDispatcherData, Operations.CreatePostViaDispatcherVariables>;
+export type CreatePostTypedDataHookResult = ReturnType<typeof useCreatePostTypedData>;
+export type CreatePostTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreatePostTypedDataData>;
+export type CreatePostTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreatePostTypedDataData,
+  Operations.CreatePostTypedDataVariables
+>;
+export const CreatePostViaDispatcherDocument = /*#__PURE__*/ gql`
+  mutation CreatePostViaDispatcher($request: CreatePublicPostRequest!) {
+    result: createPostViaDispatcher(request: $request) {
+      ...RelayResult
+    }
+  }
+  ${FragmentRelayResult}
+`;
+export type CreatePostViaDispatcherMutationFn = Apollo.MutationFunction<
+  Operations.CreatePostViaDispatcherData,
+  Operations.CreatePostViaDispatcherVariables
+>;
 
 /**
  * __useCreatePostViaDispatcher__
@@ -1973,42 +2360,60 @@ export type CreatePostViaDispatcherMutationFn = Apollo.MutationFunction<Operatio
  *   },
  * });
  */
-export function useCreatePostViaDispatcher(baseOptions?: Apollo.MutationHookOptions<Operations.CreatePostViaDispatcherData, Operations.CreatePostViaDispatcherVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreatePostViaDispatcherData, Operations.CreatePostViaDispatcherVariables>(CreatePostViaDispatcherDocument, options);
-      }
+export function useCreatePostViaDispatcher(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreatePostViaDispatcherData,
+    Operations.CreatePostViaDispatcherVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreatePostViaDispatcherData,
+    Operations.CreatePostViaDispatcherVariables
+  >(CreatePostViaDispatcherDocument, options);
+}
 export type CreatePostViaDispatcherHookResult = ReturnType<typeof useCreatePostViaDispatcher>;
-export type CreatePostViaDispatcherMutationResult = Apollo.MutationResult<Operations.CreatePostViaDispatcherData>;
-export type CreatePostViaDispatcherMutationOptions = Apollo.BaseMutationOptions<Operations.CreatePostViaDispatcherData, Operations.CreatePostViaDispatcherVariables>;
+export type CreatePostViaDispatcherMutationResult =
+  Apollo.MutationResult<Operations.CreatePostViaDispatcherData>;
+export type CreatePostViaDispatcherMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreatePostViaDispatcherData,
+  Operations.CreatePostViaDispatcherVariables
+>;
 export const CreateSetDispatcherTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateSetDispatcherTypedData($request: SetDispatcherRequest!, $options: TypedDataOptions) {
-  result: createSetDispatcherTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        SetDispatcherWithSig {
-          name
-          type
+  mutation CreateSetDispatcherTypedData(
+    $request: SetDispatcherRequest!
+    $options: TypedDataOptions
+  ) {
+    result: createSetDispatcherTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          SetDispatcherWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        name
-        chainId
-        version
-        verifyingContract
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        dispatcher
+        domain {
+          name
+          chainId
+          version
+          verifyingContract
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          dispatcher
+        }
       }
     }
   }
-}
-    `;
-export type CreateSetDispatcherTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateSetDispatcherTypedDataData, Operations.CreateSetDispatcherTypedDataVariables>;
+`;
+export type CreateSetDispatcherTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateSetDispatcherTypedDataData,
+  Operations.CreateSetDispatcherTypedDataVariables
+>;
 
 /**
  * __useCreateSetDispatcherTypedData__
@@ -2028,20 +2433,35 @@ export type CreateSetDispatcherTypedDataMutationFn = Apollo.MutationFunction<Ope
  *   },
  * });
  */
-export function useCreateSetDispatcherTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateSetDispatcherTypedDataData, Operations.CreateSetDispatcherTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateSetDispatcherTypedDataData, Operations.CreateSetDispatcherTypedDataVariables>(CreateSetDispatcherTypedDataDocument, options);
-      }
-export type CreateSetDispatcherTypedDataHookResult = ReturnType<typeof useCreateSetDispatcherTypedData>;
-export type CreateSetDispatcherTypedDataMutationResult = Apollo.MutationResult<Operations.CreateSetDispatcherTypedDataData>;
-export type CreateSetDispatcherTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateSetDispatcherTypedDataData, Operations.CreateSetDispatcherTypedDataVariables>;
-export const ProfilesToFollowDocument = /*#__PURE__*/ gql`
-    query ProfilesToFollow($observerId: ProfileId, $sources: [Sources!]!) {
-  result: recommendedProfiles {
-    ...Profile
-  }
+export function useCreateSetDispatcherTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateSetDispatcherTypedDataData,
+    Operations.CreateSetDispatcherTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateSetDispatcherTypedDataData,
+    Operations.CreateSetDispatcherTypedDataVariables
+  >(CreateSetDispatcherTypedDataDocument, options);
 }
-    ${FragmentProfile}`;
+export type CreateSetDispatcherTypedDataHookResult = ReturnType<
+  typeof useCreateSetDispatcherTypedData
+>;
+export type CreateSetDispatcherTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateSetDispatcherTypedDataData>;
+export type CreateSetDispatcherTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateSetDispatcherTypedDataData,
+  Operations.CreateSetDispatcherTypedDataVariables
+>;
+export const ProfilesToFollowDocument = /*#__PURE__*/ gql`
+  query ProfilesToFollow($observerId: ProfileId, $sources: [Sources!]!) {
+    result: recommendedProfiles {
+      ...Profile
+    }
+  }
+  ${FragmentProfile}
+`;
 
 /**
  * __useProfilesToFollow__
@@ -2060,24 +2480,48 @@ export const ProfilesToFollowDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useProfilesToFollow(baseOptions: Apollo.QueryHookOptions<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>(ProfilesToFollowDocument, options);
-      }
-export function useProfilesToFollowLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>(ProfilesToFollowDocument, options);
-        }
+export function useProfilesToFollow(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ProfilesToFollowData,
+    Operations.ProfilesToFollowVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>(
+    ProfilesToFollowDocument,
+    options,
+  );
+}
+export function useProfilesToFollowLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ProfilesToFollowData,
+    Operations.ProfilesToFollowVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>(
+    ProfilesToFollowDocument,
+    options,
+  );
+}
 export type ProfilesToFollowHookResult = ReturnType<typeof useProfilesToFollow>;
 export type ProfilesToFollowLazyQueryHookResult = ReturnType<typeof useProfilesToFollowLazyQuery>;
-export type ProfilesToFollowQueryResult = Apollo.QueryResult<Operations.ProfilesToFollowData, Operations.ProfilesToFollowVariables>;
+export type ProfilesToFollowQueryResult = Apollo.QueryResult<
+  Operations.ProfilesToFollowData,
+  Operations.ProfilesToFollowVariables
+>;
 export const GetProfileDocument = /*#__PURE__*/ gql`
-    query GetProfile($request: SingleProfileQueryRequest!, $observerId: ProfileId, $sources: [Sources!] = []) {
-  result: profile(request: $request) {
-    ...Profile
+  query GetProfile(
+    $request: SingleProfileQueryRequest!
+    $observerId: ProfileId
+    $sources: [Sources!] = []
+  ) {
+    result: profile(request: $request) {
+      ...Profile
+    }
   }
-}
-    ${FragmentProfile}`;
+  ${FragmentProfile}
+`;
 
 /**
  * __useGetProfile__
@@ -2097,32 +2541,65 @@ export const GetProfileDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useGetProfile(baseOptions: Apollo.QueryHookOptions<Operations.GetProfileData, Operations.GetProfileVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.GetProfileData, Operations.GetProfileVariables>(GetProfileDocument, options);
-      }
-export function useGetProfileLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.GetProfileData, Operations.GetProfileVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.GetProfileData, Operations.GetProfileVariables>(GetProfileDocument, options);
-        }
+export function useGetProfile(
+  baseOptions: Apollo.QueryHookOptions<Operations.GetProfileData, Operations.GetProfileVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.GetProfileData, Operations.GetProfileVariables>(
+    GetProfileDocument,
+    options,
+  );
+}
+export function useGetProfileLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.GetProfileData,
+    Operations.GetProfileVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.GetProfileData, Operations.GetProfileVariables>(
+    GetProfileDocument,
+    options,
+  );
+}
 export type GetProfileHookResult = ReturnType<typeof useGetProfile>;
 export type GetProfileLazyQueryHookResult = ReturnType<typeof useGetProfileLazyQuery>;
-export type GetProfileQueryResult = Apollo.QueryResult<Operations.GetProfileData, Operations.GetProfileVariables>;
+export type GetProfileQueryResult = Apollo.QueryResult<
+  Operations.GetProfileData,
+  Operations.GetProfileVariables
+>;
 export const GetAllProfilesDocument = /*#__PURE__*/ gql`
-    query GetAllProfiles($byProfileIds: [ProfileId!], $byHandles: [Handle!], $byOwnerAddresses: [EthereumAddress!], $byWhoMirroredPublicationId: InternalPublicationId, $observerId: ProfileId, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!] = []) {
-  result: profiles(
-    request: {whoMirroredPublicationId: $byWhoMirroredPublicationId, ownedBy: $byOwnerAddresses, profileIds: $byProfileIds, handles: $byHandles, limit: $limit, cursor: $cursor}
+  query GetAllProfiles(
+    $byProfileIds: [ProfileId!]
+    $byHandles: [Handle!]
+    $byOwnerAddresses: [EthereumAddress!]
+    $byWhoMirroredPublicationId: InternalPublicationId
+    $observerId: ProfileId
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!] = []
   ) {
-    items {
-      ...Profile
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: profiles(
+      request: {
+        whoMirroredPublicationId: $byWhoMirroredPublicationId
+        ownedBy: $byOwnerAddresses
+        profileIds: $byProfileIds
+        handles: $byHandles
+        limit: $limit
+        cursor: $cursor
+      }
+    ) {
+      items {
+        ...Profile
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentProfile}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentProfile}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useGetAllProfiles__
@@ -2147,25 +2624,48 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useGetAllProfiles(baseOptions: Apollo.QueryHookOptions<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>(GetAllProfilesDocument, options);
-      }
-export function useGetAllProfilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>(GetAllProfilesDocument, options);
-        }
+export function useGetAllProfiles(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.GetAllProfilesData,
+    Operations.GetAllProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>(
+    GetAllProfilesDocument,
+    options,
+  );
+}
+export function useGetAllProfilesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.GetAllProfilesData,
+    Operations.GetAllProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>(
+    GetAllProfilesDocument,
+    options,
+  );
+}
 export type GetAllProfilesHookResult = ReturnType<typeof useGetAllProfiles>;
 export type GetAllProfilesLazyQueryHookResult = ReturnType<typeof useGetAllProfilesLazyQuery>;
-export type GetAllProfilesQueryResult = Apollo.QueryResult<Operations.GetAllProfilesData, Operations.GetAllProfilesVariables>;
+export type GetAllProfilesQueryResult = Apollo.QueryResult<
+  Operations.GetAllProfilesData,
+  Operations.GetAllProfilesVariables
+>;
 export const CreateProfileDocument = /*#__PURE__*/ gql`
-    mutation CreateProfile($request: CreateProfileRequest!) {
-  result: createProfile(request: $request) {
-    ...RelayResult
+  mutation CreateProfile($request: CreateProfileRequest!) {
+    result: createProfile(request: $request) {
+      ...RelayResult
+    }
   }
-}
-    ${FragmentRelayResult}`;
-export type CreateProfileMutationFn = Apollo.MutationFunction<Operations.CreateProfileData, Operations.CreateProfileVariables>;
+  ${FragmentRelayResult}
+`;
+export type CreateProfileMutationFn = Apollo.MutationFunction<
+  Operations.CreateProfileData,
+  Operations.CreateProfileVariables
+>;
 
 /**
  * __useCreateProfile__
@@ -2184,28 +2684,51 @@ export type CreateProfileMutationFn = Apollo.MutationFunction<Operations.CreateP
  *   },
  * });
  */
-export function useCreateProfile(baseOptions?: Apollo.MutationHookOptions<Operations.CreateProfileData, Operations.CreateProfileVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateProfileData, Operations.CreateProfileVariables>(CreateProfileDocument, options);
-      }
+export function useCreateProfile(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateProfileData,
+    Operations.CreateProfileVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.CreateProfileData, Operations.CreateProfileVariables>(
+    CreateProfileDocument,
+    options,
+  );
+}
 export type CreateProfileHookResult = ReturnType<typeof useCreateProfile>;
 export type CreateProfileMutationResult = Apollo.MutationResult<Operations.CreateProfileData>;
-export type CreateProfileMutationOptions = Apollo.BaseMutationOptions<Operations.CreateProfileData, Operations.CreateProfileVariables>;
+export type CreateProfileMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateProfileData,
+  Operations.CreateProfileVariables
+>;
 export const MutualFollowersProfilesDocument = /*#__PURE__*/ gql`
-    query MutualFollowersProfiles($observerId: ProfileId!, $viewingProfileId: ProfileId!, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!) {
-  result: mutualFollowersProfiles(
-    request: {yourProfileId: $observerId, viewingProfileId: $viewingProfileId, limit: $limit, cursor: $cursor}
+  query MutualFollowersProfiles(
+    $observerId: ProfileId!
+    $viewingProfileId: ProfileId!
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
   ) {
-    items {
-      ...Profile
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: mutualFollowersProfiles(
+      request: {
+        yourProfileId: $observerId
+        viewingProfileId: $viewingProfileId
+        limit: $limit
+        cursor: $cursor
+      }
+    ) {
+      items {
+        ...Profile
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentProfile}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentProfile}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useMutualFollowersProfiles__
@@ -2227,47 +2750,74 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useMutualFollowersProfiles(baseOptions: Apollo.QueryHookOptions<Operations.MutualFollowersProfilesData, Operations.MutualFollowersProfilesVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.MutualFollowersProfilesData, Operations.MutualFollowersProfilesVariables>(MutualFollowersProfilesDocument, options);
-      }
-export function useMutualFollowersProfilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.MutualFollowersProfilesData, Operations.MutualFollowersProfilesVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.MutualFollowersProfilesData, Operations.MutualFollowersProfilesVariables>(MutualFollowersProfilesDocument, options);
-        }
+export function useMutualFollowersProfiles(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.MutualFollowersProfilesData,
+    Operations.MutualFollowersProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.MutualFollowersProfilesData,
+    Operations.MutualFollowersProfilesVariables
+  >(MutualFollowersProfilesDocument, options);
+}
+export function useMutualFollowersProfilesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.MutualFollowersProfilesData,
+    Operations.MutualFollowersProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.MutualFollowersProfilesData,
+    Operations.MutualFollowersProfilesVariables
+  >(MutualFollowersProfilesDocument, options);
+}
 export type MutualFollowersProfilesHookResult = ReturnType<typeof useMutualFollowersProfiles>;
-export type MutualFollowersProfilesLazyQueryHookResult = ReturnType<typeof useMutualFollowersProfilesLazyQuery>;
-export type MutualFollowersProfilesQueryResult = Apollo.QueryResult<Operations.MutualFollowersProfilesData, Operations.MutualFollowersProfilesVariables>;
+export type MutualFollowersProfilesLazyQueryHookResult = ReturnType<
+  typeof useMutualFollowersProfilesLazyQuery
+>;
+export type MutualFollowersProfilesQueryResult = Apollo.QueryResult<
+  Operations.MutualFollowersProfilesData,
+  Operations.MutualFollowersProfilesVariables
+>;
 export const CreateSetFollowModuleTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateSetFollowModuleTypedData($request: CreateSetFollowModuleRequest!, $options: TypedDataOptions) {
-  result: createSetFollowModuleTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        SetFollowModuleWithSig {
-          name
-          type
+  mutation CreateSetFollowModuleTypedData(
+    $request: CreateSetFollowModuleRequest!
+    $options: TypedDataOptions
+  ) {
+    result: createSetFollowModuleTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          SetFollowModuleWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        name
-        chainId
-        version
-        verifyingContract
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        followModule
-        followModuleInitData
+        domain {
+          name
+          chainId
+          version
+          verifyingContract
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          followModule
+          followModuleInitData
+        }
       }
     }
   }
-}
-    `;
-export type CreateSetFollowModuleTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateSetFollowModuleTypedDataData, Operations.CreateSetFollowModuleTypedDataVariables>;
+`;
+export type CreateSetFollowModuleTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateSetFollowModuleTypedDataData,
+  Operations.CreateSetFollowModuleTypedDataVariables
+>;
 
 /**
  * __useCreateSetFollowModuleTypedData__
@@ -2287,42 +2837,62 @@ export type CreateSetFollowModuleTypedDataMutationFn = Apollo.MutationFunction<O
  *   },
  * });
  */
-export function useCreateSetFollowModuleTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateSetFollowModuleTypedDataData, Operations.CreateSetFollowModuleTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateSetFollowModuleTypedDataData, Operations.CreateSetFollowModuleTypedDataVariables>(CreateSetFollowModuleTypedDataDocument, options);
-      }
-export type CreateSetFollowModuleTypedDataHookResult = ReturnType<typeof useCreateSetFollowModuleTypedData>;
-export type CreateSetFollowModuleTypedDataMutationResult = Apollo.MutationResult<Operations.CreateSetFollowModuleTypedDataData>;
-export type CreateSetFollowModuleTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateSetFollowModuleTypedDataData, Operations.CreateSetFollowModuleTypedDataVariables>;
+export function useCreateSetFollowModuleTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateSetFollowModuleTypedDataData,
+    Operations.CreateSetFollowModuleTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateSetFollowModuleTypedDataData,
+    Operations.CreateSetFollowModuleTypedDataVariables
+  >(CreateSetFollowModuleTypedDataDocument, options);
+}
+export type CreateSetFollowModuleTypedDataHookResult = ReturnType<
+  typeof useCreateSetFollowModuleTypedData
+>;
+export type CreateSetFollowModuleTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateSetFollowModuleTypedDataData>;
+export type CreateSetFollowModuleTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateSetFollowModuleTypedDataData,
+  Operations.CreateSetFollowModuleTypedDataVariables
+>;
 export const CreateSetProfileImageUriTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateSetProfileImageURITypedData($request: UpdateProfileImageRequest!, $options: TypedDataOptions) {
-  result: createSetProfileImageURITypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        SetProfileImageURIWithSig {
-          name
-          type
+  mutation CreateSetProfileImageURITypedData(
+    $request: UpdateProfileImageRequest!
+    $options: TypedDataOptions
+  ) {
+    result: createSetProfileImageURITypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          SetProfileImageURIWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        name
-        chainId
-        version
-        verifyingContract
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        imageURI
+        domain {
+          name
+          chainId
+          version
+          verifyingContract
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          imageURI
+        }
       }
     }
   }
-}
-    `;
-export type CreateSetProfileImageUriTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateSetProfileImageUriTypedDataData, Operations.CreateSetProfileImageUriTypedDataVariables>;
+`;
+export type CreateSetProfileImageUriTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateSetProfileImageUriTypedDataData,
+  Operations.CreateSetProfileImageUriTypedDataVariables
+>;
 
 /**
  * __useCreateSetProfileImageUriTypedData__
@@ -2342,21 +2912,39 @@ export type CreateSetProfileImageUriTypedDataMutationFn = Apollo.MutationFunctio
  *   },
  * });
  */
-export function useCreateSetProfileImageUriTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateSetProfileImageUriTypedDataData, Operations.CreateSetProfileImageUriTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateSetProfileImageUriTypedDataData, Operations.CreateSetProfileImageUriTypedDataVariables>(CreateSetProfileImageUriTypedDataDocument, options);
-      }
-export type CreateSetProfileImageUriTypedDataHookResult = ReturnType<typeof useCreateSetProfileImageUriTypedData>;
-export type CreateSetProfileImageUriTypedDataMutationResult = Apollo.MutationResult<Operations.CreateSetProfileImageUriTypedDataData>;
-export type CreateSetProfileImageUriTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateSetProfileImageUriTypedDataData, Operations.CreateSetProfileImageUriTypedDataVariables>;
-export const CreateSetProfileImageUriViaDispatcherDocument = /*#__PURE__*/ gql`
-    mutation CreateSetProfileImageURIViaDispatcher($request: UpdateProfileImageRequest!) {
-  result: createSetProfileImageURIViaDispatcher(request: $request) {
-    ...RelayResult
-  }
+export function useCreateSetProfileImageUriTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateSetProfileImageUriTypedDataData,
+    Operations.CreateSetProfileImageUriTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateSetProfileImageUriTypedDataData,
+    Operations.CreateSetProfileImageUriTypedDataVariables
+  >(CreateSetProfileImageUriTypedDataDocument, options);
 }
-    ${FragmentRelayResult}`;
-export type CreateSetProfileImageUriViaDispatcherMutationFn = Apollo.MutationFunction<Operations.CreateSetProfileImageUriViaDispatcherData, Operations.CreateSetProfileImageUriViaDispatcherVariables>;
+export type CreateSetProfileImageUriTypedDataHookResult = ReturnType<
+  typeof useCreateSetProfileImageUriTypedData
+>;
+export type CreateSetProfileImageUriTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateSetProfileImageUriTypedDataData>;
+export type CreateSetProfileImageUriTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateSetProfileImageUriTypedDataData,
+  Operations.CreateSetProfileImageUriTypedDataVariables
+>;
+export const CreateSetProfileImageUriViaDispatcherDocument = /*#__PURE__*/ gql`
+  mutation CreateSetProfileImageURIViaDispatcher($request: UpdateProfileImageRequest!) {
+    result: createSetProfileImageURIViaDispatcher(request: $request) {
+      ...RelayResult
+    }
+  }
+  ${FragmentRelayResult}
+`;
+export type CreateSetProfileImageUriViaDispatcherMutationFn = Apollo.MutationFunction<
+  Operations.CreateSetProfileImageUriViaDispatcherData,
+  Operations.CreateSetProfileImageUriViaDispatcherVariables
+>;
 
 /**
  * __useCreateSetProfileImageUriViaDispatcher__
@@ -2375,42 +2963,62 @@ export type CreateSetProfileImageUriViaDispatcherMutationFn = Apollo.MutationFun
  *   },
  * });
  */
-export function useCreateSetProfileImageUriViaDispatcher(baseOptions?: Apollo.MutationHookOptions<Operations.CreateSetProfileImageUriViaDispatcherData, Operations.CreateSetProfileImageUriViaDispatcherVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateSetProfileImageUriViaDispatcherData, Operations.CreateSetProfileImageUriViaDispatcherVariables>(CreateSetProfileImageUriViaDispatcherDocument, options);
-      }
-export type CreateSetProfileImageUriViaDispatcherHookResult = ReturnType<typeof useCreateSetProfileImageUriViaDispatcher>;
-export type CreateSetProfileImageUriViaDispatcherMutationResult = Apollo.MutationResult<Operations.CreateSetProfileImageUriViaDispatcherData>;
-export type CreateSetProfileImageUriViaDispatcherMutationOptions = Apollo.BaseMutationOptions<Operations.CreateSetProfileImageUriViaDispatcherData, Operations.CreateSetProfileImageUriViaDispatcherVariables>;
+export function useCreateSetProfileImageUriViaDispatcher(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateSetProfileImageUriViaDispatcherData,
+    Operations.CreateSetProfileImageUriViaDispatcherVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateSetProfileImageUriViaDispatcherData,
+    Operations.CreateSetProfileImageUriViaDispatcherVariables
+  >(CreateSetProfileImageUriViaDispatcherDocument, options);
+}
+export type CreateSetProfileImageUriViaDispatcherHookResult = ReturnType<
+  typeof useCreateSetProfileImageUriViaDispatcher
+>;
+export type CreateSetProfileImageUriViaDispatcherMutationResult =
+  Apollo.MutationResult<Operations.CreateSetProfileImageUriViaDispatcherData>;
+export type CreateSetProfileImageUriViaDispatcherMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateSetProfileImageUriViaDispatcherData,
+  Operations.CreateSetProfileImageUriViaDispatcherVariables
+>;
 export const CreateSetProfileMetadataTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateSetProfileMetadataTypedData($request: CreatePublicSetProfileMetadataURIRequest!, $options: TypedDataOptions) {
-  result: createSetProfileMetadataTypedData(request: $request, options: $options) {
-    id
-    expiresAt
-    typedData {
-      types {
-        SetProfileMetadataURIWithSig {
-          name
-          type
+  mutation CreateSetProfileMetadataTypedData(
+    $request: CreatePublicSetProfileMetadataURIRequest!
+    $options: TypedDataOptions
+  ) {
+    result: createSetProfileMetadataTypedData(request: $request, options: $options) {
+      id
+      expiresAt
+      typedData {
+        types {
+          SetProfileMetadataURIWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        name
-        chainId
-        version
-        verifyingContract
-      }
-      value {
-        nonce
-        deadline
-        profileId
-        metadata
+        domain {
+          name
+          chainId
+          version
+          verifyingContract
+        }
+        value {
+          nonce
+          deadline
+          profileId
+          metadata
+        }
       }
     }
   }
-}
-    `;
-export type CreateSetProfileMetadataTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateSetProfileMetadataTypedDataData, Operations.CreateSetProfileMetadataTypedDataVariables>;
+`;
+export type CreateSetProfileMetadataTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateSetProfileMetadataTypedDataData,
+  Operations.CreateSetProfileMetadataTypedDataVariables
+>;
 
 /**
  * __useCreateSetProfileMetadataTypedData__
@@ -2430,21 +3038,41 @@ export type CreateSetProfileMetadataTypedDataMutationFn = Apollo.MutationFunctio
  *   },
  * });
  */
-export function useCreateSetProfileMetadataTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateSetProfileMetadataTypedDataData, Operations.CreateSetProfileMetadataTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateSetProfileMetadataTypedDataData, Operations.CreateSetProfileMetadataTypedDataVariables>(CreateSetProfileMetadataTypedDataDocument, options);
-      }
-export type CreateSetProfileMetadataTypedDataHookResult = ReturnType<typeof useCreateSetProfileMetadataTypedData>;
-export type CreateSetProfileMetadataTypedDataMutationResult = Apollo.MutationResult<Operations.CreateSetProfileMetadataTypedDataData>;
-export type CreateSetProfileMetadataTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateSetProfileMetadataTypedDataData, Operations.CreateSetProfileMetadataTypedDataVariables>;
-export const CreateSetProfileMetadataViaDispatcherDocument = /*#__PURE__*/ gql`
-    mutation CreateSetProfileMetadataViaDispatcher($request: CreatePublicSetProfileMetadataURIRequest!) {
-  result: createSetProfileMetadataViaDispatcher(request: $request) {
-    ...RelayResult
-  }
+export function useCreateSetProfileMetadataTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateSetProfileMetadataTypedDataData,
+    Operations.CreateSetProfileMetadataTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateSetProfileMetadataTypedDataData,
+    Operations.CreateSetProfileMetadataTypedDataVariables
+  >(CreateSetProfileMetadataTypedDataDocument, options);
 }
-    ${FragmentRelayResult}`;
-export type CreateSetProfileMetadataViaDispatcherMutationFn = Apollo.MutationFunction<Operations.CreateSetProfileMetadataViaDispatcherData, Operations.CreateSetProfileMetadataViaDispatcherVariables>;
+export type CreateSetProfileMetadataTypedDataHookResult = ReturnType<
+  typeof useCreateSetProfileMetadataTypedData
+>;
+export type CreateSetProfileMetadataTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateSetProfileMetadataTypedDataData>;
+export type CreateSetProfileMetadataTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateSetProfileMetadataTypedDataData,
+  Operations.CreateSetProfileMetadataTypedDataVariables
+>;
+export const CreateSetProfileMetadataViaDispatcherDocument = /*#__PURE__*/ gql`
+  mutation CreateSetProfileMetadataViaDispatcher(
+    $request: CreatePublicSetProfileMetadataURIRequest!
+  ) {
+    result: createSetProfileMetadataViaDispatcher(request: $request) {
+      ...RelayResult
+    }
+  }
+  ${FragmentRelayResult}
+`;
+export type CreateSetProfileMetadataViaDispatcherMutationFn = Apollo.MutationFunction<
+  Operations.CreateSetProfileMetadataViaDispatcherData,
+  Operations.CreateSetProfileMetadataViaDispatcherVariables
+>;
 
 /**
  * __useCreateSetProfileMetadataViaDispatcher__
@@ -2463,28 +3091,47 @@ export type CreateSetProfileMetadataViaDispatcherMutationFn = Apollo.MutationFun
  *   },
  * });
  */
-export function useCreateSetProfileMetadataViaDispatcher(baseOptions?: Apollo.MutationHookOptions<Operations.CreateSetProfileMetadataViaDispatcherData, Operations.CreateSetProfileMetadataViaDispatcherVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateSetProfileMetadataViaDispatcherData, Operations.CreateSetProfileMetadataViaDispatcherVariables>(CreateSetProfileMetadataViaDispatcherDocument, options);
-      }
-export type CreateSetProfileMetadataViaDispatcherHookResult = ReturnType<typeof useCreateSetProfileMetadataViaDispatcher>;
-export type CreateSetProfileMetadataViaDispatcherMutationResult = Apollo.MutationResult<Operations.CreateSetProfileMetadataViaDispatcherData>;
-export type CreateSetProfileMetadataViaDispatcherMutationOptions = Apollo.BaseMutationOptions<Operations.CreateSetProfileMetadataViaDispatcherData, Operations.CreateSetProfileMetadataViaDispatcherVariables>;
+export function useCreateSetProfileMetadataViaDispatcher(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateSetProfileMetadataViaDispatcherData,
+    Operations.CreateSetProfileMetadataViaDispatcherVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateSetProfileMetadataViaDispatcherData,
+    Operations.CreateSetProfileMetadataViaDispatcherVariables
+  >(CreateSetProfileMetadataViaDispatcherDocument, options);
+}
+export type CreateSetProfileMetadataViaDispatcherHookResult = ReturnType<
+  typeof useCreateSetProfileMetadataViaDispatcher
+>;
+export type CreateSetProfileMetadataViaDispatcherMutationResult =
+  Apollo.MutationResult<Operations.CreateSetProfileMetadataViaDispatcherData>;
+export type CreateSetProfileMetadataViaDispatcherMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateSetProfileMetadataViaDispatcherData,
+  Operations.CreateSetProfileMetadataViaDispatcherVariables
+>;
 export const ProfileFollowersDocument = /*#__PURE__*/ gql`
-    query ProfileFollowers($profileId: ProfileId!, $limit: LimitScalar!, $cursor: Cursor, $observerId: ProfileId, $sources: [Sources!]!) {
-  result: followers(
-    request: {profileId: $profileId, limit: $limit, cursor: $cursor}
+  query ProfileFollowers(
+    $profileId: ProfileId!
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $observerId: ProfileId
+    $sources: [Sources!]!
   ) {
-    items {
-      ...Follower
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: followers(request: { profileId: $profileId, limit: $limit, cursor: $cursor }) {
+      items {
+        ...Follower
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentFollower}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentFollower}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useProfileFollowers__
@@ -2506,32 +3153,56 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useProfileFollowers(baseOptions: Apollo.QueryHookOptions<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>(ProfileFollowersDocument, options);
-      }
-export function useProfileFollowersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>(ProfileFollowersDocument, options);
-        }
+export function useProfileFollowers(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ProfileFollowersData,
+    Operations.ProfileFollowersVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>(
+    ProfileFollowersDocument,
+    options,
+  );
+}
+export function useProfileFollowersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ProfileFollowersData,
+    Operations.ProfileFollowersVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>(
+    ProfileFollowersDocument,
+    options,
+  );
+}
 export type ProfileFollowersHookResult = ReturnType<typeof useProfileFollowers>;
 export type ProfileFollowersLazyQueryHookResult = ReturnType<typeof useProfileFollowersLazyQuery>;
-export type ProfileFollowersQueryResult = Apollo.QueryResult<Operations.ProfileFollowersData, Operations.ProfileFollowersVariables>;
+export type ProfileFollowersQueryResult = Apollo.QueryResult<
+  Operations.ProfileFollowersData,
+  Operations.ProfileFollowersVariables
+>;
 export const ProfileFollowingDocument = /*#__PURE__*/ gql`
-    query ProfileFollowing($walletAddress: EthereumAddress!, $limit: LimitScalar!, $cursor: Cursor, $observerId: ProfileId, $sources: [Sources!]!) {
-  result: following(
-    request: {address: $walletAddress, limit: $limit, cursor: $cursor}
+  query ProfileFollowing(
+    $walletAddress: EthereumAddress!
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $observerId: ProfileId
+    $sources: [Sources!]!
   ) {
-    items {
-      ...Following
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: following(request: { address: $walletAddress, limit: $limit, cursor: $cursor }) {
+      items {
+        ...Following
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentFollowing}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentFollowing}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useProfileFollowing__
@@ -2553,34 +3224,54 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useProfileFollowing(baseOptions: Apollo.QueryHookOptions<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>(ProfileFollowingDocument, options);
-      }
-export function useProfileFollowingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>(ProfileFollowingDocument, options);
-        }
+export function useProfileFollowing(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ProfileFollowingData,
+    Operations.ProfileFollowingVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>(
+    ProfileFollowingDocument,
+    options,
+  );
+}
+export function useProfileFollowingLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ProfileFollowingData,
+    Operations.ProfileFollowingVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>(
+    ProfileFollowingDocument,
+    options,
+  );
+}
 export type ProfileFollowingHookResult = ReturnType<typeof useProfileFollowing>;
 export type ProfileFollowingLazyQueryHookResult = ReturnType<typeof useProfileFollowingLazyQuery>;
-export type ProfileFollowingQueryResult = Apollo.QueryResult<Operations.ProfileFollowingData, Operations.ProfileFollowingVariables>;
+export type ProfileFollowingQueryResult = Apollo.QueryResult<
+  Operations.ProfileFollowingData,
+  Operations.ProfileFollowingVariables
+>;
 export const ProxyActionStatusDocument = /*#__PURE__*/ gql`
-    query ProxyActionStatus($proxyActionId: ProxyActionId!) {
-  result: proxyActionStatus(proxyActionId: $proxyActionId) {
-    ... on ProxyActionStatusResult {
-      ...ProxyActionStatusResult
-    }
-    ... on ProxyActionError {
-      ...ProxyActionError
-    }
-    ... on ProxyActionQueued {
-      ...ProxyActionQueued
+  query ProxyActionStatus($proxyActionId: ProxyActionId!) {
+    result: proxyActionStatus(proxyActionId: $proxyActionId) {
+      ... on ProxyActionStatusResult {
+        ...ProxyActionStatusResult
+      }
+      ... on ProxyActionError {
+        ...ProxyActionError
+      }
+      ... on ProxyActionQueued {
+        ...ProxyActionQueued
+      }
     }
   }
-}
-    ${FragmentProxyActionStatusResult}
-${FragmentProxyActionError}
-${FragmentProxyActionQueued}`;
+  ${FragmentProxyActionStatusResult}
+  ${FragmentProxyActionError}
+  ${FragmentProxyActionQueued}
+`;
 
 /**
  * __useProxyActionStatus__
@@ -2598,23 +3289,45 @@ ${FragmentProxyActionQueued}`;
  *   },
  * });
  */
-export function useProxyActionStatus(baseOptions: Apollo.QueryHookOptions<Operations.ProxyActionStatusData, Operations.ProxyActionStatusVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ProxyActionStatusData, Operations.ProxyActionStatusVariables>(ProxyActionStatusDocument, options);
-      }
-export function useProxyActionStatusLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ProxyActionStatusData, Operations.ProxyActionStatusVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ProxyActionStatusData, Operations.ProxyActionStatusVariables>(ProxyActionStatusDocument, options);
-        }
+export function useProxyActionStatus(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ProxyActionStatusData,
+    Operations.ProxyActionStatusVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.ProxyActionStatusData, Operations.ProxyActionStatusVariables>(
+    ProxyActionStatusDocument,
+    options,
+  );
+}
+export function useProxyActionStatusLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ProxyActionStatusData,
+    Operations.ProxyActionStatusVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.ProxyActionStatusData,
+    Operations.ProxyActionStatusVariables
+  >(ProxyActionStatusDocument, options);
+}
 export type ProxyActionStatusHookResult = ReturnType<typeof useProxyActionStatus>;
 export type ProxyActionStatusLazyQueryHookResult = ReturnType<typeof useProxyActionStatusLazyQuery>;
-export type ProxyActionStatusQueryResult = Apollo.QueryResult<Operations.ProxyActionStatusData, Operations.ProxyActionStatusVariables>;
+export type ProxyActionStatusQueryResult = Apollo.QueryResult<
+  Operations.ProxyActionStatusData,
+  Operations.ProxyActionStatusVariables
+>;
 export const ProxyActionDocument = /*#__PURE__*/ gql`
-    mutation ProxyAction($request: ProxyActionRequest!) {
-  result: proxyAction(request: $request)
-}
-    `;
-export type ProxyActionMutationFn = Apollo.MutationFunction<Operations.ProxyActionData, Operations.ProxyActionVariables>;
+  mutation ProxyAction($request: ProxyActionRequest!) {
+    result: proxyAction(request: $request)
+  }
+`;
+export type ProxyActionMutationFn = Apollo.MutationFunction<
+  Operations.ProxyActionData,
+  Operations.ProxyActionVariables
+>;
 
 /**
  * __useProxyAction__
@@ -2633,30 +3346,46 @@ export type ProxyActionMutationFn = Apollo.MutationFunction<Operations.ProxyActi
  *   },
  * });
  */
-export function useProxyAction(baseOptions?: Apollo.MutationHookOptions<Operations.ProxyActionData, Operations.ProxyActionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.ProxyActionData, Operations.ProxyActionVariables>(ProxyActionDocument, options);
-      }
+export function useProxyAction(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.ProxyActionData,
+    Operations.ProxyActionVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.ProxyActionData, Operations.ProxyActionVariables>(
+    ProxyActionDocument,
+    options,
+  );
+}
 export type ProxyActionHookResult = ReturnType<typeof useProxyAction>;
 export type ProxyActionMutationResult = Apollo.MutationResult<Operations.ProxyActionData>;
-export type ProxyActionMutationOptions = Apollo.BaseMutationOptions<Operations.ProxyActionData, Operations.ProxyActionVariables>;
+export type ProxyActionMutationOptions = Apollo.BaseMutationOptions<
+  Operations.ProxyActionData,
+  Operations.ProxyActionVariables
+>;
 export const PublicationDocument = /*#__PURE__*/ gql`
-    query Publication($observerId: ProfileId, $publicationId: InternalPublicationId!, $sources: [Sources!]!) {
-  result: publication(request: {publicationId: $publicationId}) {
-    ... on Post {
-      ...Post
-    }
-    ... on Mirror {
-      ...Mirror
-    }
-    ... on Comment {
-      ...Comment
+  query Publication(
+    $observerId: ProfileId
+    $publicationId: InternalPublicationId!
+    $sources: [Sources!]!
+  ) {
+    result: publication(request: { publicationId: $publicationId }) {
+      ... on Post {
+        ...Post
+      }
+      ... on Mirror {
+        ...Mirror
+      }
+      ... on Comment {
+        ...Comment
+      }
     }
   }
-}
-    ${FragmentPost}
-${FragmentMirror}
-${FragmentComment}`;
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentComment}
+`;
 
 /**
  * __usePublication__
@@ -2676,34 +3405,51 @@ ${FragmentComment}`;
  *   },
  * });
  */
-export function usePublication(baseOptions: Apollo.QueryHookOptions<Operations.PublicationData, Operations.PublicationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.PublicationData, Operations.PublicationVariables>(PublicationDocument, options);
-      }
-export function usePublicationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.PublicationData, Operations.PublicationVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.PublicationData, Operations.PublicationVariables>(PublicationDocument, options);
-        }
+export function usePublication(
+  baseOptions: Apollo.QueryHookOptions<Operations.PublicationData, Operations.PublicationVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.PublicationData, Operations.PublicationVariables>(
+    PublicationDocument,
+    options,
+  );
+}
+export function usePublicationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.PublicationData,
+    Operations.PublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.PublicationData, Operations.PublicationVariables>(
+    PublicationDocument,
+    options,
+  );
+}
 export type PublicationHookResult = ReturnType<typeof usePublication>;
 export type PublicationLazyQueryHookResult = ReturnType<typeof usePublicationLazyQuery>;
-export type PublicationQueryResult = Apollo.QueryResult<Operations.PublicationData, Operations.PublicationVariables>;
+export type PublicationQueryResult = Apollo.QueryResult<
+  Operations.PublicationData,
+  Operations.PublicationVariables
+>;
 export const PublicationByTxHashDocument = /*#__PURE__*/ gql`
-    query PublicationByTxHash($observerId: ProfileId, $txHash: TxHash!, $sources: [Sources!]!) {
-  result: publication(request: {txHash: $txHash}) {
-    ... on Post {
-      ...Post
-    }
-    ... on Mirror {
-      ...Mirror
-    }
-    ... on Comment {
-      ...CommentWithFirstComment
+  query PublicationByTxHash($observerId: ProfileId, $txHash: TxHash!, $sources: [Sources!]!) {
+    result: publication(request: { txHash: $txHash }) {
+      ... on Post {
+        ...Post
+      }
+      ... on Mirror {
+        ...Mirror
+      }
+      ... on Comment {
+        ...CommentWithFirstComment
+      }
     }
   }
-}
-    ${FragmentPost}
-${FragmentMirror}
-${FragmentCommentWithFirstComment}`;
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentCommentWithFirstComment}
+`;
 
 /**
  * __usePublicationByTxHash__
@@ -2723,23 +3469,47 @@ ${FragmentCommentWithFirstComment}`;
  *   },
  * });
  */
-export function usePublicationByTxHash(baseOptions: Apollo.QueryHookOptions<Operations.PublicationByTxHashData, Operations.PublicationByTxHashVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.PublicationByTxHashData, Operations.PublicationByTxHashVariables>(PublicationByTxHashDocument, options);
-      }
-export function usePublicationByTxHashLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.PublicationByTxHashData, Operations.PublicationByTxHashVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.PublicationByTxHashData, Operations.PublicationByTxHashVariables>(PublicationByTxHashDocument, options);
-        }
-export type PublicationByTxHashHookResult = ReturnType<typeof usePublicationByTxHash>;
-export type PublicationByTxHashLazyQueryHookResult = ReturnType<typeof usePublicationByTxHashLazyQuery>;
-export type PublicationByTxHashQueryResult = Apollo.QueryResult<Operations.PublicationByTxHashData, Operations.PublicationByTxHashVariables>;
-export const HidePublicationDocument = /*#__PURE__*/ gql`
-    mutation HidePublication($publicationId: InternalPublicationId!) {
-  hidePublication(request: {publicationId: $publicationId})
+export function usePublicationByTxHash(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.PublicationByTxHashData,
+    Operations.PublicationByTxHashVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.PublicationByTxHashData,
+    Operations.PublicationByTxHashVariables
+  >(PublicationByTxHashDocument, options);
 }
-    `;
-export type HidePublicationMutationFn = Apollo.MutationFunction<Operations.HidePublicationData, Operations.HidePublicationVariables>;
+export function usePublicationByTxHashLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.PublicationByTxHashData,
+    Operations.PublicationByTxHashVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.PublicationByTxHashData,
+    Operations.PublicationByTxHashVariables
+  >(PublicationByTxHashDocument, options);
+}
+export type PublicationByTxHashHookResult = ReturnType<typeof usePublicationByTxHash>;
+export type PublicationByTxHashLazyQueryHookResult = ReturnType<
+  typeof usePublicationByTxHashLazyQuery
+>;
+export type PublicationByTxHashQueryResult = Apollo.QueryResult<
+  Operations.PublicationByTxHashData,
+  Operations.PublicationByTxHashVariables
+>;
+export const HidePublicationDocument = /*#__PURE__*/ gql`
+  mutation HidePublication($publicationId: InternalPublicationId!) {
+    hidePublication(request: { publicationId: $publicationId })
+  }
+`;
+export type HidePublicationMutationFn = Apollo.MutationFunction<
+  Operations.HidePublicationData,
+  Operations.HidePublicationVariables
+>;
 
 /**
  * __useHidePublication__
@@ -2758,38 +3528,65 @@ export type HidePublicationMutationFn = Apollo.MutationFunction<Operations.HideP
  *   },
  * });
  */
-export function useHidePublication(baseOptions?: Apollo.MutationHookOptions<Operations.HidePublicationData, Operations.HidePublicationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.HidePublicationData, Operations.HidePublicationVariables>(HidePublicationDocument, options);
-      }
+export function useHidePublication(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.HidePublicationData,
+    Operations.HidePublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.HidePublicationData, Operations.HidePublicationVariables>(
+    HidePublicationDocument,
+    options,
+  );
+}
 export type HidePublicationHookResult = ReturnType<typeof useHidePublication>;
 export type HidePublicationMutationResult = Apollo.MutationResult<Operations.HidePublicationData>;
-export type HidePublicationMutationOptions = Apollo.BaseMutationOptions<Operations.HidePublicationData, Operations.HidePublicationVariables>;
+export type HidePublicationMutationOptions = Apollo.BaseMutationOptions<
+  Operations.HidePublicationData,
+  Operations.HidePublicationVariables
+>;
 export const PublicationsDocument = /*#__PURE__*/ gql`
-    query Publications($profileId: ProfileId!, $observerId: ProfileId, $limit: LimitScalar!, $cursor: Cursor, $publicationTypes: [PublicationTypes!], $sources: [Sources!]!, $metadata: PublicationMetadataFilters) {
-  result: publications(
-    request: {profileId: $profileId, limit: $limit, cursor: $cursor, publicationTypes: $publicationTypes, sources: $sources, metadata: $metadata}
+  query Publications(
+    $profileId: ProfileId!
+    $observerId: ProfileId
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $publicationTypes: [PublicationTypes!]
+    $sources: [Sources!]!
+    $metadata: PublicationMetadataFilters
   ) {
-    items {
-      ... on Post {
-        ...Post
+    result: publications(
+      request: {
+        profileId: $profileId
+        limit: $limit
+        cursor: $cursor
+        publicationTypes: $publicationTypes
+        sources: $sources
+        metadata: $metadata
       }
-      ... on Mirror {
-        ...Mirror
+    ) {
+      items {
+        ... on Post {
+          ...Post
+        }
+        ... on Mirror {
+          ...Mirror
+        }
+        ... on Comment {
+          ...Comment
+        }
       }
-      ... on Comment {
-        ...Comment
+      pageInfo {
+        ...CommonPaginatedResultInfo
       }
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
     }
   }
-}
-    ${FragmentPost}
-${FragmentMirror}
-${FragmentComment}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentComment}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __usePublications__
@@ -2813,42 +3610,81 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function usePublications(baseOptions: Apollo.QueryHookOptions<Operations.PublicationsData, Operations.PublicationsVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.PublicationsData, Operations.PublicationsVariables>(PublicationsDocument, options);
-      }
-export function usePublicationsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.PublicationsData, Operations.PublicationsVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.PublicationsData, Operations.PublicationsVariables>(PublicationsDocument, options);
-        }
+export function usePublications(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.PublicationsData,
+    Operations.PublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.PublicationsData, Operations.PublicationsVariables>(
+    PublicationsDocument,
+    options,
+  );
+}
+export function usePublicationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.PublicationsData,
+    Operations.PublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.PublicationsData, Operations.PublicationsVariables>(
+    PublicationsDocument,
+    options,
+  );
+}
 export type PublicationsHookResult = ReturnType<typeof usePublications>;
 export type PublicationsLazyQueryHookResult = ReturnType<typeof usePublicationsLazyQuery>;
-export type PublicationsQueryResult = Apollo.QueryResult<Operations.PublicationsData, Operations.PublicationsVariables>;
+export type PublicationsQueryResult = Apollo.QueryResult<
+  Operations.PublicationsData,
+  Operations.PublicationsVariables
+>;
 export const ExplorePublicationsDocument = /*#__PURE__*/ gql`
-    query ExplorePublications($cursor: Cursor, $excludeProfileIds: [ProfileId!], $limit: LimitScalar!, $metadata: PublicationMetadataFilters, $observerId: ProfileId, $publicationTypes: [PublicationTypes!], $sortCriteria: PublicationSortCriteria!, $sources: [Sources!]!, $timestamp: TimestampScalar) {
-  result: explorePublications(
-    request: {cursor: $cursor, excludeProfileIds: $excludeProfileIds, limit: $limit, metadata: $metadata, publicationTypes: $publicationTypes, sortCriteria: $sortCriteria, sources: $sources, timestamp: $timestamp}
+  query ExplorePublications(
+    $cursor: Cursor
+    $excludeProfileIds: [ProfileId!]
+    $limit: LimitScalar!
+    $metadata: PublicationMetadataFilters
+    $observerId: ProfileId
+    $publicationTypes: [PublicationTypes!]
+    $sortCriteria: PublicationSortCriteria!
+    $sources: [Sources!]!
+    $timestamp: TimestampScalar
   ) {
-    items {
-      ... on Post {
-        ...Post
+    result: explorePublications(
+      request: {
+        cursor: $cursor
+        excludeProfileIds: $excludeProfileIds
+        limit: $limit
+        metadata: $metadata
+        publicationTypes: $publicationTypes
+        sortCriteria: $sortCriteria
+        sources: $sources
+        timestamp: $timestamp
       }
-      ... on Mirror {
-        ...Mirror
+    ) {
+      items {
+        ... on Post {
+          ...Post
+        }
+        ... on Mirror {
+          ...Mirror
+        }
+        ... on Comment {
+          ...Comment
+        }
       }
-      ... on Comment {
-        ...Comment
+      pageInfo {
+        ...CommonPaginatedResultInfo
       }
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
     }
   }
-}
-    ${FragmentPost}
-${FragmentMirror}
-${FragmentComment}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentComment}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useExplorePublications__
@@ -2874,32 +3710,60 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useExplorePublications(baseOptions: Apollo.QueryHookOptions<Operations.ExplorePublicationsData, Operations.ExplorePublicationsVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ExplorePublicationsData, Operations.ExplorePublicationsVariables>(ExplorePublicationsDocument, options);
-      }
-export function useExplorePublicationsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ExplorePublicationsData, Operations.ExplorePublicationsVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ExplorePublicationsData, Operations.ExplorePublicationsVariables>(ExplorePublicationsDocument, options);
-        }
+export function useExplorePublications(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ExplorePublicationsData,
+    Operations.ExplorePublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.ExplorePublicationsData,
+    Operations.ExplorePublicationsVariables
+  >(ExplorePublicationsDocument, options);
+}
+export function useExplorePublicationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ExplorePublicationsData,
+    Operations.ExplorePublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.ExplorePublicationsData,
+    Operations.ExplorePublicationsVariables
+  >(ExplorePublicationsDocument, options);
+}
 export type ExplorePublicationsHookResult = ReturnType<typeof useExplorePublications>;
-export type ExplorePublicationsLazyQueryHookResult = ReturnType<typeof useExplorePublicationsLazyQuery>;
-export type ExplorePublicationsQueryResult = Apollo.QueryResult<Operations.ExplorePublicationsData, Operations.ExplorePublicationsVariables>;
+export type ExplorePublicationsLazyQueryHookResult = ReturnType<
+  typeof useExplorePublicationsLazyQuery
+>;
+export type ExplorePublicationsQueryResult = Apollo.QueryResult<
+  Operations.ExplorePublicationsData,
+  Operations.ExplorePublicationsVariables
+>;
 export const WhoCollectedPublicationDocument = /*#__PURE__*/ gql`
-    query WhoCollectedPublication($publicationId: InternalPublicationId!, $observerId: ProfileId, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!) {
-  result: whoCollectedPublication(
-    request: {publicationId: $publicationId, limit: $limit, cursor: $cursor}
+  query WhoCollectedPublication(
+    $publicationId: InternalPublicationId!
+    $observerId: ProfileId
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
   ) {
-    items {
-      ...Wallet
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: whoCollectedPublication(
+      request: { publicationId: $publicationId, limit: $limit, cursor: $cursor }
+    ) {
+      items {
+        ...Wallet
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentWallet}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentWallet}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useWhoCollectedPublication__
@@ -2921,38 +3785,66 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useWhoCollectedPublication(baseOptions: Apollo.QueryHookOptions<Operations.WhoCollectedPublicationData, Operations.WhoCollectedPublicationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.WhoCollectedPublicationData, Operations.WhoCollectedPublicationVariables>(WhoCollectedPublicationDocument, options);
-      }
-export function useWhoCollectedPublicationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.WhoCollectedPublicationData, Operations.WhoCollectedPublicationVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.WhoCollectedPublicationData, Operations.WhoCollectedPublicationVariables>(WhoCollectedPublicationDocument, options);
-        }
+export function useWhoCollectedPublication(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.WhoCollectedPublicationData,
+    Operations.WhoCollectedPublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.WhoCollectedPublicationData,
+    Operations.WhoCollectedPublicationVariables
+  >(WhoCollectedPublicationDocument, options);
+}
+export function useWhoCollectedPublicationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.WhoCollectedPublicationData,
+    Operations.WhoCollectedPublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.WhoCollectedPublicationData,
+    Operations.WhoCollectedPublicationVariables
+  >(WhoCollectedPublicationDocument, options);
+}
 export type WhoCollectedPublicationHookResult = ReturnType<typeof useWhoCollectedPublication>;
-export type WhoCollectedPublicationLazyQueryHookResult = ReturnType<typeof useWhoCollectedPublicationLazyQuery>;
-export type WhoCollectedPublicationQueryResult = Apollo.QueryResult<Operations.WhoCollectedPublicationData, Operations.WhoCollectedPublicationVariables>;
+export type WhoCollectedPublicationLazyQueryHookResult = ReturnType<
+  typeof useWhoCollectedPublicationLazyQuery
+>;
+export type WhoCollectedPublicationQueryResult = Apollo.QueryResult<
+  Operations.WhoCollectedPublicationData,
+  Operations.WhoCollectedPublicationVariables
+>;
 export const ProfilePublicationsForSaleDocument = /*#__PURE__*/ gql`
-    query ProfilePublicationsForSale($profileId: ProfileId!, $observerId: ProfileId, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!) {
-  result: profilePublicationsForSale(
-    request: {profileId: $profileId, limit: $limit, cursor: $cursor, sources: $sources}
+  query ProfilePublicationsForSale(
+    $profileId: ProfileId!
+    $observerId: ProfileId
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
   ) {
-    items {
-      ... on Post {
-        ...Post
+    result: profilePublicationsForSale(
+      request: { profileId: $profileId, limit: $limit, cursor: $cursor, sources: $sources }
+    ) {
+      items {
+        ... on Post {
+          ...Post
+        }
+        ... on Comment {
+          ...Comment
+        }
       }
-      ... on Comment {
-        ...Comment
+      pageInfo {
+        ...CommonPaginatedResultInfo
       }
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
     }
   }
-}
-    ${FragmentPost}
-${FragmentComment}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentPost}
+  ${FragmentComment}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useProfilePublicationsForSale__
@@ -2974,25 +3866,53 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useProfilePublicationsForSale(baseOptions: Apollo.QueryHookOptions<Operations.ProfilePublicationsForSaleData, Operations.ProfilePublicationsForSaleVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ProfilePublicationsForSaleData, Operations.ProfilePublicationsForSaleVariables>(ProfilePublicationsForSaleDocument, options);
-      }
-export function useProfilePublicationsForSaleLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ProfilePublicationsForSaleData, Operations.ProfilePublicationsForSaleVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ProfilePublicationsForSaleData, Operations.ProfilePublicationsForSaleVariables>(ProfilePublicationsForSaleDocument, options);
-        }
-export type ProfilePublicationsForSaleHookResult = ReturnType<typeof useProfilePublicationsForSale>;
-export type ProfilePublicationsForSaleLazyQueryHookResult = ReturnType<typeof useProfilePublicationsForSaleLazyQuery>;
-export type ProfilePublicationsForSaleQueryResult = Apollo.QueryResult<Operations.ProfilePublicationsForSaleData, Operations.ProfilePublicationsForSaleVariables>;
-export const AddReactionDocument = /*#__PURE__*/ gql`
-    mutation AddReaction($publicationId: InternalPublicationId!, $reaction: ReactionTypes!, $profileId: ProfileId!) {
-  addReaction(
-    request: {publicationId: $publicationId, reaction: $reaction, profileId: $profileId}
-  )
+export function useProfilePublicationsForSale(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ProfilePublicationsForSaleData,
+    Operations.ProfilePublicationsForSaleVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.ProfilePublicationsForSaleData,
+    Operations.ProfilePublicationsForSaleVariables
+  >(ProfilePublicationsForSaleDocument, options);
 }
-    `;
-export type AddReactionMutationFn = Apollo.MutationFunction<Operations.AddReactionData, Operations.AddReactionVariables>;
+export function useProfilePublicationsForSaleLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ProfilePublicationsForSaleData,
+    Operations.ProfilePublicationsForSaleVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.ProfilePublicationsForSaleData,
+    Operations.ProfilePublicationsForSaleVariables
+  >(ProfilePublicationsForSaleDocument, options);
+}
+export type ProfilePublicationsForSaleHookResult = ReturnType<typeof useProfilePublicationsForSale>;
+export type ProfilePublicationsForSaleLazyQueryHookResult = ReturnType<
+  typeof useProfilePublicationsForSaleLazyQuery
+>;
+export type ProfilePublicationsForSaleQueryResult = Apollo.QueryResult<
+  Operations.ProfilePublicationsForSaleData,
+  Operations.ProfilePublicationsForSaleVariables
+>;
+export const AddReactionDocument = /*#__PURE__*/ gql`
+  mutation AddReaction(
+    $publicationId: InternalPublicationId!
+    $reaction: ReactionTypes!
+    $profileId: ProfileId!
+  ) {
+    addReaction(
+      request: { publicationId: $publicationId, reaction: $reaction, profileId: $profileId }
+    )
+  }
+`;
+export type AddReactionMutationFn = Apollo.MutationFunction<
+  Operations.AddReactionData,
+  Operations.AddReactionVariables
+>;
 
 /**
  * __useAddReaction__
@@ -3013,21 +3933,39 @@ export type AddReactionMutationFn = Apollo.MutationFunction<Operations.AddReacti
  *   },
  * });
  */
-export function useAddReaction(baseOptions?: Apollo.MutationHookOptions<Operations.AddReactionData, Operations.AddReactionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.AddReactionData, Operations.AddReactionVariables>(AddReactionDocument, options);
-      }
+export function useAddReaction(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.AddReactionData,
+    Operations.AddReactionVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.AddReactionData, Operations.AddReactionVariables>(
+    AddReactionDocument,
+    options,
+  );
+}
 export type AddReactionHookResult = ReturnType<typeof useAddReaction>;
 export type AddReactionMutationResult = Apollo.MutationResult<Operations.AddReactionData>;
-export type AddReactionMutationOptions = Apollo.BaseMutationOptions<Operations.AddReactionData, Operations.AddReactionVariables>;
+export type AddReactionMutationOptions = Apollo.BaseMutationOptions<
+  Operations.AddReactionData,
+  Operations.AddReactionVariables
+>;
 export const RemoveReactionDocument = /*#__PURE__*/ gql`
-    mutation RemoveReaction($publicationId: InternalPublicationId!, $reaction: ReactionTypes!, $profileId: ProfileId!) {
-  removeReaction(
-    request: {publicationId: $publicationId, reaction: $reaction, profileId: $profileId}
-  )
-}
-    `;
-export type RemoveReactionMutationFn = Apollo.MutationFunction<Operations.RemoveReactionData, Operations.RemoveReactionVariables>;
+  mutation RemoveReaction(
+    $publicationId: InternalPublicationId!
+    $reaction: ReactionTypes!
+    $profileId: ProfileId!
+  ) {
+    removeReaction(
+      request: { publicationId: $publicationId, reaction: $reaction, profileId: $profileId }
+    )
+  }
+`;
+export type RemoveReactionMutationFn = Apollo.MutationFunction<
+  Operations.RemoveReactionData,
+  Operations.RemoveReactionVariables
+>;
 
 /**
  * __useRemoveReaction__
@@ -3048,28 +3986,46 @@ export type RemoveReactionMutationFn = Apollo.MutationFunction<Operations.Remove
  *   },
  * });
  */
-export function useRemoveReaction(baseOptions?: Apollo.MutationHookOptions<Operations.RemoveReactionData, Operations.RemoveReactionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.RemoveReactionData, Operations.RemoveReactionVariables>(RemoveReactionDocument, options);
-      }
+export function useRemoveReaction(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.RemoveReactionData,
+    Operations.RemoveReactionVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<Operations.RemoveReactionData, Operations.RemoveReactionVariables>(
+    RemoveReactionDocument,
+    options,
+  );
+}
 export type RemoveReactionHookResult = ReturnType<typeof useRemoveReaction>;
 export type RemoveReactionMutationResult = Apollo.MutationResult<Operations.RemoveReactionData>;
-export type RemoveReactionMutationOptions = Apollo.BaseMutationOptions<Operations.RemoveReactionData, Operations.RemoveReactionVariables>;
+export type RemoveReactionMutationOptions = Apollo.BaseMutationOptions<
+  Operations.RemoveReactionData,
+  Operations.RemoveReactionVariables
+>;
 export const WhoReactedPublicationDocument = /*#__PURE__*/ gql`
-    query WhoReactedPublication($limit: LimitScalar, $cursor: Cursor, $publicationId: InternalPublicationId!, $observerId: ProfileId, $sources: [Sources!]!) {
-  result: whoReactedPublication(
-    request: {limit: $limit, cursor: $cursor, publicationId: $publicationId}
+  query WhoReactedPublication(
+    $limit: LimitScalar
+    $cursor: Cursor
+    $publicationId: InternalPublicationId!
+    $observerId: ProfileId
+    $sources: [Sources!]!
   ) {
-    items {
-      ...WhoReactedResult
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: whoReactedPublication(
+      request: { limit: $limit, cursor: $cursor, publicationId: $publicationId }
+    ) {
+      items {
+        ...WhoReactedResult
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentWhoReactedResult}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentWhoReactedResult}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useWhoReactedPublication__
@@ -3091,25 +4047,57 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useWhoReactedPublication(baseOptions: Apollo.QueryHookOptions<Operations.WhoReactedPublicationData, Operations.WhoReactedPublicationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.WhoReactedPublicationData, Operations.WhoReactedPublicationVariables>(WhoReactedPublicationDocument, options);
-      }
-export function useWhoReactedPublicationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.WhoReactedPublicationData, Operations.WhoReactedPublicationVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.WhoReactedPublicationData, Operations.WhoReactedPublicationVariables>(WhoReactedPublicationDocument, options);
-        }
-export type WhoReactedPublicationHookResult = ReturnType<typeof useWhoReactedPublication>;
-export type WhoReactedPublicationLazyQueryHookResult = ReturnType<typeof useWhoReactedPublicationLazyQuery>;
-export type WhoReactedPublicationQueryResult = Apollo.QueryResult<Operations.WhoReactedPublicationData, Operations.WhoReactedPublicationVariables>;
-export const ReportPublicationDocument = /*#__PURE__*/ gql`
-    mutation ReportPublication($publicationId: InternalPublicationId!, $reason: ReportingReasonInputParams!, $additionalComments: String) {
-  reportPublication(
-    request: {publicationId: $publicationId, reason: $reason, additionalComments: $additionalComments}
-  )
+export function useWhoReactedPublication(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.WhoReactedPublicationData,
+    Operations.WhoReactedPublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.WhoReactedPublicationData,
+    Operations.WhoReactedPublicationVariables
+  >(WhoReactedPublicationDocument, options);
 }
-    `;
-export type ReportPublicationMutationFn = Apollo.MutationFunction<Operations.ReportPublicationData, Operations.ReportPublicationVariables>;
+export function useWhoReactedPublicationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.WhoReactedPublicationData,
+    Operations.WhoReactedPublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.WhoReactedPublicationData,
+    Operations.WhoReactedPublicationVariables
+  >(WhoReactedPublicationDocument, options);
+}
+export type WhoReactedPublicationHookResult = ReturnType<typeof useWhoReactedPublication>;
+export type WhoReactedPublicationLazyQueryHookResult = ReturnType<
+  typeof useWhoReactedPublicationLazyQuery
+>;
+export type WhoReactedPublicationQueryResult = Apollo.QueryResult<
+  Operations.WhoReactedPublicationData,
+  Operations.WhoReactedPublicationVariables
+>;
+export const ReportPublicationDocument = /*#__PURE__*/ gql`
+  mutation ReportPublication(
+    $publicationId: InternalPublicationId!
+    $reason: ReportingReasonInputParams!
+    $additionalComments: String
+  ) {
+    reportPublication(
+      request: {
+        publicationId: $publicationId
+        reason: $reason
+        additionalComments: $additionalComments
+      }
+    )
+  }
+`;
+export type ReportPublicationMutationFn = Apollo.MutationFunction<
+  Operations.ReportPublicationData,
+  Operations.ReportPublicationVariables
+>;
 
 /**
  * __useReportPublication__
@@ -3130,20 +4118,37 @@ export type ReportPublicationMutationFn = Apollo.MutationFunction<Operations.Rep
  *   },
  * });
  */
-export function useReportPublication(baseOptions?: Apollo.MutationHookOptions<Operations.ReportPublicationData, Operations.ReportPublicationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.ReportPublicationData, Operations.ReportPublicationVariables>(ReportPublicationDocument, options);
-      }
-export type ReportPublicationHookResult = ReturnType<typeof useReportPublication>;
-export type ReportPublicationMutationResult = Apollo.MutationResult<Operations.ReportPublicationData>;
-export type ReportPublicationMutationOptions = Apollo.BaseMutationOptions<Operations.ReportPublicationData, Operations.ReportPublicationVariables>;
-export const GetPublicationRevenueDocument = /*#__PURE__*/ gql`
-    query GetPublicationRevenue($publicationId: InternalPublicationId!, $observerId: ProfileId, $sources: [Sources!]!) {
-  result: publicationRevenue(request: {publicationId: $publicationId}) {
-    ...PublicationRevenue
-  }
+export function useReportPublication(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.ReportPublicationData,
+    Operations.ReportPublicationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.ReportPublicationData,
+    Operations.ReportPublicationVariables
+  >(ReportPublicationDocument, options);
 }
-    ${FragmentPublicationRevenue}`;
+export type ReportPublicationHookResult = ReturnType<typeof useReportPublication>;
+export type ReportPublicationMutationResult =
+  Apollo.MutationResult<Operations.ReportPublicationData>;
+export type ReportPublicationMutationOptions = Apollo.BaseMutationOptions<
+  Operations.ReportPublicationData,
+  Operations.ReportPublicationVariables
+>;
+export const GetPublicationRevenueDocument = /*#__PURE__*/ gql`
+  query GetPublicationRevenue(
+    $publicationId: InternalPublicationId!
+    $observerId: ProfileId
+    $sources: [Sources!]!
+  ) {
+    result: publicationRevenue(request: { publicationId: $publicationId }) {
+      ...PublicationRevenue
+    }
+  }
+  ${FragmentPublicationRevenue}
+`;
 
 /**
  * __useGetPublicationRevenue__
@@ -3163,32 +4168,67 @@ export const GetPublicationRevenueDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useGetPublicationRevenue(baseOptions: Apollo.QueryHookOptions<Operations.GetPublicationRevenueData, Operations.GetPublicationRevenueVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.GetPublicationRevenueData, Operations.GetPublicationRevenueVariables>(GetPublicationRevenueDocument, options);
-      }
-export function useGetPublicationRevenueLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.GetPublicationRevenueData, Operations.GetPublicationRevenueVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.GetPublicationRevenueData, Operations.GetPublicationRevenueVariables>(GetPublicationRevenueDocument, options);
-        }
+export function useGetPublicationRevenue(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.GetPublicationRevenueData,
+    Operations.GetPublicationRevenueVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.GetPublicationRevenueData,
+    Operations.GetPublicationRevenueVariables
+  >(GetPublicationRevenueDocument, options);
+}
+export function useGetPublicationRevenueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.GetPublicationRevenueData,
+    Operations.GetPublicationRevenueVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.GetPublicationRevenueData,
+    Operations.GetPublicationRevenueVariables
+  >(GetPublicationRevenueDocument, options);
+}
 export type GetPublicationRevenueHookResult = ReturnType<typeof useGetPublicationRevenue>;
-export type GetPublicationRevenueLazyQueryHookResult = ReturnType<typeof useGetPublicationRevenueLazyQuery>;
-export type GetPublicationRevenueQueryResult = Apollo.QueryResult<Operations.GetPublicationRevenueData, Operations.GetPublicationRevenueVariables>;
+export type GetPublicationRevenueLazyQueryHookResult = ReturnType<
+  typeof useGetPublicationRevenueLazyQuery
+>;
+export type GetPublicationRevenueQueryResult = Apollo.QueryResult<
+  Operations.GetPublicationRevenueData,
+  Operations.GetPublicationRevenueVariables
+>;
 export const GetProfilePublicationRevenueDocument = /*#__PURE__*/ gql`
-    query GetProfilePublicationRevenue($profileId: ProfileId!, $observerId: ProfileId, $limit: LimitScalar!, $cursor: Cursor, $publicationTypes: [PublicationTypes!], $sources: [Sources!]!) {
-  result: profilePublicationRevenue(
-    request: {profileId: $profileId, limit: $limit, cursor: $cursor, types: $publicationTypes, sources: $sources}
+  query GetProfilePublicationRevenue(
+    $profileId: ProfileId!
+    $observerId: ProfileId
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $publicationTypes: [PublicationTypes!]
+    $sources: [Sources!]!
   ) {
-    items {
-      ...PublicationRevenue
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
+    result: profilePublicationRevenue(
+      request: {
+        profileId: $profileId
+        limit: $limit
+        cursor: $cursor
+        types: $publicationTypes
+        sources: $sources
+      }
+    ) {
+      items {
+        ...PublicationRevenue
+      }
+      pageInfo {
+        ...CommonPaginatedResultInfo
+      }
     }
   }
-}
-    ${FragmentPublicationRevenue}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentPublicationRevenue}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useGetProfilePublicationRevenue__
@@ -3211,24 +4251,48 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useGetProfilePublicationRevenue(baseOptions: Apollo.QueryHookOptions<Operations.GetProfilePublicationRevenueData, Operations.GetProfilePublicationRevenueVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.GetProfilePublicationRevenueData, Operations.GetProfilePublicationRevenueVariables>(GetProfilePublicationRevenueDocument, options);
-      }
-export function useGetProfilePublicationRevenueLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.GetProfilePublicationRevenueData, Operations.GetProfilePublicationRevenueVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.GetProfilePublicationRevenueData, Operations.GetProfilePublicationRevenueVariables>(GetProfilePublicationRevenueDocument, options);
-        }
-export type GetProfilePublicationRevenueHookResult = ReturnType<typeof useGetProfilePublicationRevenue>;
-export type GetProfilePublicationRevenueLazyQueryHookResult = ReturnType<typeof useGetProfilePublicationRevenueLazyQuery>;
-export type GetProfilePublicationRevenueQueryResult = Apollo.QueryResult<Operations.GetProfilePublicationRevenueData, Operations.GetProfilePublicationRevenueVariables>;
-export const ProfileFollowRevenueDocument = /*#__PURE__*/ gql`
-    query ProfileFollowRevenue($profileId: ProfileId!) {
-  result: profileFollowRevenue(request: {profileId: $profileId}) {
-    ...ProfileFollowRevenue
-  }
+export function useGetProfilePublicationRevenue(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.GetProfilePublicationRevenueData,
+    Operations.GetProfilePublicationRevenueVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.GetProfilePublicationRevenueData,
+    Operations.GetProfilePublicationRevenueVariables
+  >(GetProfilePublicationRevenueDocument, options);
 }
-    ${FragmentProfileFollowRevenue}`;
+export function useGetProfilePublicationRevenueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.GetProfilePublicationRevenueData,
+    Operations.GetProfilePublicationRevenueVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.GetProfilePublicationRevenueData,
+    Operations.GetProfilePublicationRevenueVariables
+  >(GetProfilePublicationRevenueDocument, options);
+}
+export type GetProfilePublicationRevenueHookResult = ReturnType<
+  typeof useGetProfilePublicationRevenue
+>;
+export type GetProfilePublicationRevenueLazyQueryHookResult = ReturnType<
+  typeof useGetProfilePublicationRevenueLazyQuery
+>;
+export type GetProfilePublicationRevenueQueryResult = Apollo.QueryResult<
+  Operations.GetProfilePublicationRevenueData,
+  Operations.GetProfilePublicationRevenueVariables
+>;
+export const ProfileFollowRevenueDocument = /*#__PURE__*/ gql`
+  query ProfileFollowRevenue($profileId: ProfileId!) {
+    result: profileFollowRevenue(request: { profileId: $profileId }) {
+      ...ProfileFollowRevenue
+    }
+  }
+  ${FragmentProfileFollowRevenue}
+`;
 
 /**
  * __useProfileFollowRevenue__
@@ -3246,41 +4310,75 @@ export const ProfileFollowRevenueDocument = /*#__PURE__*/ gql`
  *   },
  * });
  */
-export function useProfileFollowRevenue(baseOptions: Apollo.QueryHookOptions<Operations.ProfileFollowRevenueData, Operations.ProfileFollowRevenueVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.ProfileFollowRevenueData, Operations.ProfileFollowRevenueVariables>(ProfileFollowRevenueDocument, options);
-      }
-export function useProfileFollowRevenueLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.ProfileFollowRevenueData, Operations.ProfileFollowRevenueVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.ProfileFollowRevenueData, Operations.ProfileFollowRevenueVariables>(ProfileFollowRevenueDocument, options);
-        }
+export function useProfileFollowRevenue(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.ProfileFollowRevenueData,
+    Operations.ProfileFollowRevenueVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.ProfileFollowRevenueData,
+    Operations.ProfileFollowRevenueVariables
+  >(ProfileFollowRevenueDocument, options);
+}
+export function useProfileFollowRevenueLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.ProfileFollowRevenueData,
+    Operations.ProfileFollowRevenueVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.ProfileFollowRevenueData,
+    Operations.ProfileFollowRevenueVariables
+  >(ProfileFollowRevenueDocument, options);
+}
 export type ProfileFollowRevenueHookResult = ReturnType<typeof useProfileFollowRevenue>;
-export type ProfileFollowRevenueLazyQueryHookResult = ReturnType<typeof useProfileFollowRevenueLazyQuery>;
-export type ProfileFollowRevenueQueryResult = Apollo.QueryResult<Operations.ProfileFollowRevenueData, Operations.ProfileFollowRevenueVariables>;
+export type ProfileFollowRevenueLazyQueryHookResult = ReturnType<
+  typeof useProfileFollowRevenueLazyQuery
+>;
+export type ProfileFollowRevenueQueryResult = Apollo.QueryResult<
+  Operations.ProfileFollowRevenueData,
+  Operations.ProfileFollowRevenueVariables
+>;
 export const SearchPublicationsDocument = /*#__PURE__*/ gql`
-    query SearchPublications($limit: LimitScalar, $cursor: Cursor, $query: Search!, $sources: [Sources!]!, $observerId: ProfileId) {
-  result: search(
-    request: {query: $query, type: PUBLICATION, limit: $limit, cursor: $cursor, sources: $sources}
+  query SearchPublications(
+    $limit: LimitScalar
+    $cursor: Cursor
+    $query: Search!
+    $sources: [Sources!]!
+    $observerId: ProfileId
   ) {
-    ... on PublicationSearchResult {
-      __typename
-      items {
-        ... on Post {
-          ...Post
-        }
-        ... on Comment {
-          ...Comment
-        }
+    result: search(
+      request: {
+        query: $query
+        type: PUBLICATION
+        limit: $limit
+        cursor: $cursor
+        sources: $sources
       }
-      pageInfo {
-        ...CommonPaginatedResultInfo
+    ) {
+      ... on PublicationSearchResult {
+        __typename
+        items {
+          ... on Post {
+            ...Post
+          }
+          ... on Comment {
+            ...Comment
+          }
+        }
+        pageInfo {
+          ...CommonPaginatedResultInfo
+        }
       }
     }
   }
-}
-    ${FragmentPost}
-${FragmentComment}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentPost}
+  ${FragmentComment}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useSearchPublications__
@@ -3302,35 +4400,61 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useSearchPublications(baseOptions: Apollo.QueryHookOptions<Operations.SearchPublicationsData, Operations.SearchPublicationsVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.SearchPublicationsData, Operations.SearchPublicationsVariables>(SearchPublicationsDocument, options);
-      }
-export function useSearchPublicationsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.SearchPublicationsData, Operations.SearchPublicationsVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.SearchPublicationsData, Operations.SearchPublicationsVariables>(SearchPublicationsDocument, options);
-        }
+export function useSearchPublications(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.SearchPublicationsData,
+    Operations.SearchPublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.SearchPublicationsData, Operations.SearchPublicationsVariables>(
+    SearchPublicationsDocument,
+    options,
+  );
+}
+export function useSearchPublicationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.SearchPublicationsData,
+    Operations.SearchPublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.SearchPublicationsData,
+    Operations.SearchPublicationsVariables
+  >(SearchPublicationsDocument, options);
+}
 export type SearchPublicationsHookResult = ReturnType<typeof useSearchPublications>;
-export type SearchPublicationsLazyQueryHookResult = ReturnType<typeof useSearchPublicationsLazyQuery>;
-export type SearchPublicationsQueryResult = Apollo.QueryResult<Operations.SearchPublicationsData, Operations.SearchPublicationsVariables>;
+export type SearchPublicationsLazyQueryHookResult = ReturnType<
+  typeof useSearchPublicationsLazyQuery
+>;
+export type SearchPublicationsQueryResult = Apollo.QueryResult<
+  Operations.SearchPublicationsData,
+  Operations.SearchPublicationsVariables
+>;
 export const SearchProfilesDocument = /*#__PURE__*/ gql`
-    query SearchProfiles($limit: LimitScalar!, $cursor: Cursor, $query: Search!, $observerId: ProfileId, $sources: [Sources!]!) {
-  result: search(
-    request: {query: $query, type: PROFILE, limit: $limit, cursor: $cursor}
+  query SearchProfiles(
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $query: Search!
+    $observerId: ProfileId
+    $sources: [Sources!]!
   ) {
-    ... on ProfileSearchResult {
-      __typename
-      items {
-        ...Profile
-      }
-      pageInfo {
-        ...CommonPaginatedResultInfo
+    result: search(request: { query: $query, type: PROFILE, limit: $limit, cursor: $cursor }) {
+      ... on ProfileSearchResult {
+        __typename
+        items {
+          ...Profile
+        }
+        pageInfo {
+          ...CommonPaginatedResultInfo
+        }
       }
     }
   }
-}
-    ${FragmentProfile}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentProfile}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useSearchProfiles__
@@ -3352,30 +4476,50 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useSearchProfiles(baseOptions: Apollo.QueryHookOptions<Operations.SearchProfilesData, Operations.SearchProfilesVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.SearchProfilesData, Operations.SearchProfilesVariables>(SearchProfilesDocument, options);
-      }
-export function useSearchProfilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.SearchProfilesData, Operations.SearchProfilesVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.SearchProfilesData, Operations.SearchProfilesVariables>(SearchProfilesDocument, options);
-        }
+export function useSearchProfiles(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.SearchProfilesData,
+    Operations.SearchProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<Operations.SearchProfilesData, Operations.SearchProfilesVariables>(
+    SearchProfilesDocument,
+    options,
+  );
+}
+export function useSearchProfilesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.SearchProfilesData,
+    Operations.SearchProfilesVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<Operations.SearchProfilesData, Operations.SearchProfilesVariables>(
+    SearchProfilesDocument,
+    options,
+  );
+}
 export type SearchProfilesHookResult = ReturnType<typeof useSearchProfiles>;
 export type SearchProfilesLazyQueryHookResult = ReturnType<typeof useSearchProfilesLazyQuery>;
-export type SearchProfilesQueryResult = Apollo.QueryResult<Operations.SearchProfilesData, Operations.SearchProfilesVariables>;
+export type SearchProfilesQueryResult = Apollo.QueryResult<
+  Operations.SearchProfilesData,
+  Operations.SearchProfilesVariables
+>;
 export const HasTxHashBeenIndexedDocument = /*#__PURE__*/ gql`
-    query HasTxHashBeenIndexed($request: HasTxHashBeenIndexedRequest!) {
-  result: hasTxHashBeenIndexed(request: $request) {
-    ... on TransactionIndexedResult {
-      ...TransactionIndexedResult
-    }
-    ... on TransactionError {
-      ...TransactionError
+  query HasTxHashBeenIndexed($request: HasTxHashBeenIndexedRequest!) {
+    result: hasTxHashBeenIndexed(request: $request) {
+      ... on TransactionIndexedResult {
+        ...TransactionIndexedResult
+      }
+      ... on TransactionError {
+        ...TransactionError
+      }
     }
   }
-}
-    ${FragmentTransactionIndexedResult}
-${FragmentTransactionError}`;
+  ${FragmentTransactionIndexedResult}
+  ${FragmentTransactionError}
+`;
 
 /**
  * __useHasTxHashBeenIndexed__
@@ -3393,25 +4537,50 @@ ${FragmentTransactionError}`;
  *   },
  * });
  */
-export function useHasTxHashBeenIndexed(baseOptions: Apollo.QueryHookOptions<Operations.HasTxHashBeenIndexedData, Operations.HasTxHashBeenIndexedVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.HasTxHashBeenIndexedData, Operations.HasTxHashBeenIndexedVariables>(HasTxHashBeenIndexedDocument, options);
-      }
-export function useHasTxHashBeenIndexedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.HasTxHashBeenIndexedData, Operations.HasTxHashBeenIndexedVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.HasTxHashBeenIndexedData, Operations.HasTxHashBeenIndexedVariables>(HasTxHashBeenIndexedDocument, options);
-        }
-export type HasTxHashBeenIndexedHookResult = ReturnType<typeof useHasTxHashBeenIndexed>;
-export type HasTxHashBeenIndexedLazyQueryHookResult = ReturnType<typeof useHasTxHashBeenIndexedLazyQuery>;
-export type HasTxHashBeenIndexedQueryResult = Apollo.QueryResult<Operations.HasTxHashBeenIndexedData, Operations.HasTxHashBeenIndexedVariables>;
-export const BroadcastProtocolCallDocument = /*#__PURE__*/ gql`
-    mutation BroadcastProtocolCall($request: BroadcastRequest!) {
-  result: broadcast(request: $request) {
-    ...RelayResult
-  }
+export function useHasTxHashBeenIndexed(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.HasTxHashBeenIndexedData,
+    Operations.HasTxHashBeenIndexedVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.HasTxHashBeenIndexedData,
+    Operations.HasTxHashBeenIndexedVariables
+  >(HasTxHashBeenIndexedDocument, options);
 }
-    ${FragmentRelayResult}`;
-export type BroadcastProtocolCallMutationFn = Apollo.MutationFunction<Operations.BroadcastProtocolCallData, Operations.BroadcastProtocolCallVariables>;
+export function useHasTxHashBeenIndexedLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.HasTxHashBeenIndexedData,
+    Operations.HasTxHashBeenIndexedVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.HasTxHashBeenIndexedData,
+    Operations.HasTxHashBeenIndexedVariables
+  >(HasTxHashBeenIndexedDocument, options);
+}
+export type HasTxHashBeenIndexedHookResult = ReturnType<typeof useHasTxHashBeenIndexed>;
+export type HasTxHashBeenIndexedLazyQueryHookResult = ReturnType<
+  typeof useHasTxHashBeenIndexedLazyQuery
+>;
+export type HasTxHashBeenIndexedQueryResult = Apollo.QueryResult<
+  Operations.HasTxHashBeenIndexedData,
+  Operations.HasTxHashBeenIndexedVariables
+>;
+export const BroadcastProtocolCallDocument = /*#__PURE__*/ gql`
+  mutation BroadcastProtocolCall($request: BroadcastRequest!) {
+    result: broadcast(request: $request) {
+      ...RelayResult
+    }
+  }
+  ${FragmentRelayResult}
+`;
+export type BroadcastProtocolCallMutationFn = Apollo.MutationFunction<
+  Operations.BroadcastProtocolCallData,
+  Operations.BroadcastProtocolCallVariables
+>;
 
 /**
  * __useBroadcastProtocolCall__
@@ -3430,38 +4599,54 @@ export type BroadcastProtocolCallMutationFn = Apollo.MutationFunction<Operations
  *   },
  * });
  */
-export function useBroadcastProtocolCall(baseOptions?: Apollo.MutationHookOptions<Operations.BroadcastProtocolCallData, Operations.BroadcastProtocolCallVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.BroadcastProtocolCallData, Operations.BroadcastProtocolCallVariables>(BroadcastProtocolCallDocument, options);
-      }
+export function useBroadcastProtocolCall(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.BroadcastProtocolCallData,
+    Operations.BroadcastProtocolCallVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.BroadcastProtocolCallData,
+    Operations.BroadcastProtocolCallVariables
+  >(BroadcastProtocolCallDocument, options);
+}
 export type BroadcastProtocolCallHookResult = ReturnType<typeof useBroadcastProtocolCall>;
-export type BroadcastProtocolCallMutationResult = Apollo.MutationResult<Operations.BroadcastProtocolCallData>;
-export type BroadcastProtocolCallMutationOptions = Apollo.BaseMutationOptions<Operations.BroadcastProtocolCallData, Operations.BroadcastProtocolCallVariables>;
+export type BroadcastProtocolCallMutationResult =
+  Apollo.MutationResult<Operations.BroadcastProtocolCallData>;
+export type BroadcastProtocolCallMutationOptions = Apollo.BaseMutationOptions<
+  Operations.BroadcastProtocolCallData,
+  Operations.BroadcastProtocolCallVariables
+>;
 export const CreateUnfollowTypedDataDocument = /*#__PURE__*/ gql`
-    mutation CreateUnfollowTypedData($request: UnfollowRequest!) {
-  result: createUnfollowTypedData(request: $request) {
-    id
-    expiresAt
-    typedData {
-      types {
-        BurnWithSig {
-          name
-          type
+  mutation CreateUnfollowTypedData($request: UnfollowRequest!) {
+    result: createUnfollowTypedData(request: $request) {
+      id
+      expiresAt
+      typedData {
+        types {
+          BurnWithSig {
+            name
+            type
+          }
         }
-      }
-      domain {
-        ...EIP712TypedDataDomain
-      }
-      value {
-        nonce
-        deadline
-        tokenId
+        domain {
+          ...EIP712TypedDataDomain
+        }
+        value {
+          nonce
+          deadline
+          tokenId
+        }
       }
     }
   }
-}
-    ${FragmentEip712TypedDataDomain}`;
-export type CreateUnfollowTypedDataMutationFn = Apollo.MutationFunction<Operations.CreateUnfollowTypedDataData, Operations.CreateUnfollowTypedDataVariables>;
+  ${FragmentEip712TypedDataDomain}
+`;
+export type CreateUnfollowTypedDataMutationFn = Apollo.MutationFunction<
+  Operations.CreateUnfollowTypedDataData,
+  Operations.CreateUnfollowTypedDataVariables
+>;
 
 /**
  * __useCreateUnfollowTypedData__
@@ -3480,38 +4665,63 @@ export type CreateUnfollowTypedDataMutationFn = Apollo.MutationFunction<Operatio
  *   },
  * });
  */
-export function useCreateUnfollowTypedData(baseOptions?: Apollo.MutationHookOptions<Operations.CreateUnfollowTypedDataData, Operations.CreateUnfollowTypedDataVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Operations.CreateUnfollowTypedDataData, Operations.CreateUnfollowTypedDataVariables>(CreateUnfollowTypedDataDocument, options);
-      }
+export function useCreateUnfollowTypedData(
+  baseOptions?: Apollo.MutationHookOptions<
+    Operations.CreateUnfollowTypedDataData,
+    Operations.CreateUnfollowTypedDataVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    Operations.CreateUnfollowTypedDataData,
+    Operations.CreateUnfollowTypedDataVariables
+  >(CreateUnfollowTypedDataDocument, options);
+}
 export type CreateUnfollowTypedDataHookResult = ReturnType<typeof useCreateUnfollowTypedData>;
-export type CreateUnfollowTypedDataMutationResult = Apollo.MutationResult<Operations.CreateUnfollowTypedDataData>;
-export type CreateUnfollowTypedDataMutationOptions = Apollo.BaseMutationOptions<Operations.CreateUnfollowTypedDataData, Operations.CreateUnfollowTypedDataVariables>;
+export type CreateUnfollowTypedDataMutationResult =
+  Apollo.MutationResult<Operations.CreateUnfollowTypedDataData>;
+export type CreateUnfollowTypedDataMutationOptions = Apollo.BaseMutationOptions<
+  Operations.CreateUnfollowTypedDataData,
+  Operations.CreateUnfollowTypedDataVariables
+>;
 export const WalletCollectedPublicationsDocument = /*#__PURE__*/ gql`
-    query WalletCollectedPublications($observerId: ProfileId, $walletAddress: EthereumAddress!, $limit: LimitScalar!, $cursor: Cursor, $sources: [Sources!]!) {
-  result: publications(
-    request: {collectedBy: $walletAddress, limit: $limit, cursor: $cursor, publicationTypes: [POST, COMMENT], sources: $sources}
+  query WalletCollectedPublications(
+    $observerId: ProfileId
+    $walletAddress: EthereumAddress!
+    $limit: LimitScalar!
+    $cursor: Cursor
+    $sources: [Sources!]!
   ) {
-    items {
-      ... on Post {
-        ...Post
+    result: publications(
+      request: {
+        collectedBy: $walletAddress
+        limit: $limit
+        cursor: $cursor
+        publicationTypes: [POST, COMMENT]
+        sources: $sources
       }
-      ... on Mirror {
-        ...Mirror
+    ) {
+      items {
+        ... on Post {
+          ...Post
+        }
+        ... on Mirror {
+          ...Mirror
+        }
+        ... on Comment {
+          ...Comment
+        }
       }
-      ... on Comment {
-        ...Comment
+      pageInfo {
+        ...CommonPaginatedResultInfo
       }
-    }
-    pageInfo {
-      ...CommonPaginatedResultInfo
     }
   }
-}
-    ${FragmentPost}
-${FragmentMirror}
-${FragmentComment}
-${FragmentCommonPaginatedResultInfo}`;
+  ${FragmentPost}
+  ${FragmentMirror}
+  ${FragmentComment}
+  ${FragmentCommonPaginatedResultInfo}
+`;
 
 /**
  * __useWalletCollectedPublications__
@@ -3533,2221 +4743,3728 @@ ${FragmentCommonPaginatedResultInfo}`;
  *   },
  * });
  */
-export function useWalletCollectedPublications(baseOptions: Apollo.QueryHookOptions<Operations.WalletCollectedPublicationsData, Operations.WalletCollectedPublicationsVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Operations.WalletCollectedPublicationsData, Operations.WalletCollectedPublicationsVariables>(WalletCollectedPublicationsDocument, options);
-      }
-export function useWalletCollectedPublicationsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Operations.WalletCollectedPublicationsData, Operations.WalletCollectedPublicationsVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Operations.WalletCollectedPublicationsData, Operations.WalletCollectedPublicationsVariables>(WalletCollectedPublicationsDocument, options);
-        }
-export type WalletCollectedPublicationsHookResult = ReturnType<typeof useWalletCollectedPublications>;
-export type WalletCollectedPublicationsLazyQueryHookResult = ReturnType<typeof useWalletCollectedPublicationsLazyQuery>;
-export type WalletCollectedPublicationsQueryResult = Apollo.QueryResult<Operations.WalletCollectedPublicationsData, Operations.WalletCollectedPublicationsVariables>;
-export type AaveFeeCollectModuleSettingsKeySpecifier = ('amount' | 'collectLimit' | 'contractAddress' | 'endTimestamp' | 'followerOnly' | 'recipient' | 'referralFee' | 'type' | AaveFeeCollectModuleSettingsKeySpecifier)[];
+export function useWalletCollectedPublications(
+  baseOptions: Apollo.QueryHookOptions<
+    Operations.WalletCollectedPublicationsData,
+    Operations.WalletCollectedPublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Operations.WalletCollectedPublicationsData,
+    Operations.WalletCollectedPublicationsVariables
+  >(WalletCollectedPublicationsDocument, options);
+}
+export function useWalletCollectedPublicationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Operations.WalletCollectedPublicationsData,
+    Operations.WalletCollectedPublicationsVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Operations.WalletCollectedPublicationsData,
+    Operations.WalletCollectedPublicationsVariables
+  >(WalletCollectedPublicationsDocument, options);
+}
+export type WalletCollectedPublicationsHookResult = ReturnType<
+  typeof useWalletCollectedPublications
+>;
+export type WalletCollectedPublicationsLazyQueryHookResult = ReturnType<
+  typeof useWalletCollectedPublicationsLazyQuery
+>;
+export type WalletCollectedPublicationsQueryResult = Apollo.QueryResult<
+  Operations.WalletCollectedPublicationsData,
+  Operations.WalletCollectedPublicationsVariables
+>;
+export type AaveFeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'collectLimit'
+  | 'contractAddress'
+  | 'endTimestamp'
+  | 'followerOnly'
+  | 'recipient'
+  | 'referralFee'
+  | 'type'
+  | AaveFeeCollectModuleSettingsKeySpecifier
+)[];
 export type AaveFeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectLimit?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectLimit?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type AccessConditionOutputKeySpecifier = ('and' | 'collect' | 'eoa' | 'follow' | 'nft' | 'or' | 'profile' | 'token' | AccessConditionOutputKeySpecifier)[];
+export type AccessConditionOutputKeySpecifier = (
+  | 'and'
+  | 'collect'
+  | 'eoa'
+  | 'follow'
+  | 'nft'
+  | 'or'
+  | 'profile'
+  | 'token'
+  | AccessConditionOutputKeySpecifier
+)[];
 export type AccessConditionOutputFieldPolicy = {
-	and?: FieldPolicy<any> | FieldReadFunction<any>,
-	collect?: FieldPolicy<any> | FieldReadFunction<any>,
-	eoa?: FieldPolicy<any> | FieldReadFunction<any>,
-	follow?: FieldPolicy<any> | FieldReadFunction<any>,
-	nft?: FieldPolicy<any> | FieldReadFunction<any>,
-	or?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	token?: FieldPolicy<any> | FieldReadFunction<any>
+  and?: FieldPolicy<any> | FieldReadFunction<any>;
+  collect?: FieldPolicy<any> | FieldReadFunction<any>;
+  eoa?: FieldPolicy<any> | FieldReadFunction<any>;
+  follow?: FieldPolicy<any> | FieldReadFunction<any>;
+  nft?: FieldPolicy<any> | FieldReadFunction<any>;
+  or?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  token?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type AndConditionOutputKeySpecifier = ('criteria' | AndConditionOutputKeySpecifier)[];
 export type AndConditionOutputFieldPolicy = {
-	criteria?: FieldPolicy<any> | FieldReadFunction<any>
+  criteria?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ApprovedAllowanceAmountKeySpecifier = ('allowance' | 'contractAddress' | 'currency' | 'module' | ApprovedAllowanceAmountKeySpecifier)[];
+export type ApprovedAllowanceAmountKeySpecifier = (
+  | 'allowance'
+  | 'contractAddress'
+  | 'currency'
+  | 'module'
+  | ApprovedAllowanceAmountKeySpecifier
+)[];
 export type ApprovedAllowanceAmountFieldPolicy = {
-	allowance?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	currency?: FieldPolicy<any> | FieldReadFunction<any>,
-	module?: FieldPolicy<any> | FieldReadFunction<any>
+  allowance?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  currency?: FieldPolicy<any> | FieldReadFunction<any>;
+  module?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type AttributeKeySpecifier = ('displayType' | 'key' | 'traitType' | 'value' | AttributeKeySpecifier)[];
+export type AttributeKeySpecifier = (
+  | 'displayType'
+  | 'key'
+  | 'traitType'
+  | 'value'
+  | AttributeKeySpecifier
+)[];
 export type AttributeFieldPolicy = {
-	displayType?: FieldPolicy<any> | FieldReadFunction<any>,
-	key?: FieldPolicy<any> | FieldReadFunction<any>,
-	traitType?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  displayType?: FieldPolicy<any> | FieldReadFunction<any>;
+  key?: FieldPolicy<any> | FieldReadFunction<any>;
+  traitType?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type AuthChallengeResultKeySpecifier = ('text' | AuthChallengeResultKeySpecifier)[];
 export type AuthChallengeResultFieldPolicy = {
-	text?: FieldPolicy<any> | FieldReadFunction<any>
+  text?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type AuthenticationResultKeySpecifier = ('accessToken' | 'refreshToken' | AuthenticationResultKeySpecifier)[];
+export type AuthenticationResultKeySpecifier = (
+  | 'accessToken'
+  | 'refreshToken'
+  | AuthenticationResultKeySpecifier
+)[];
 export type AuthenticationResultFieldPolicy = {
-	accessToken?: FieldPolicy<any> | FieldReadFunction<any>,
-	refreshToken?: FieldPolicy<any> | FieldReadFunction<any>
+  accessToken?: FieldPolicy<any> | FieldReadFunction<any>;
+  refreshToken?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CanCommentResponseKeySpecifier = ('result' | CanCommentResponseKeySpecifier)[];
 export type CanCommentResponseFieldPolicy = {
-	result?: FieldPolicy<any> | FieldReadFunction<any>
+  result?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CanDecryptResponseKeySpecifier = ('extraDetails' | 'reasons' | 'result' | CanDecryptResponseKeySpecifier)[];
+export type CanDecryptResponseKeySpecifier = (
+  | 'extraDetails'
+  | 'reasons'
+  | 'result'
+  | CanDecryptResponseKeySpecifier
+)[];
 export type CanDecryptResponseFieldPolicy = {
-	extraDetails?: FieldPolicy<any> | FieldReadFunction<any>,
-	reasons?: FieldPolicy<any> | FieldReadFunction<any>,
-	result?: FieldPolicy<any> | FieldReadFunction<any>
+  extraDetails?: FieldPolicy<any> | FieldReadFunction<any>;
+  reasons?: FieldPolicy<any> | FieldReadFunction<any>;
+  result?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CanMirrorResponseKeySpecifier = ('result' | CanMirrorResponseKeySpecifier)[];
 export type CanMirrorResponseFieldPolicy = {
-	result?: FieldPolicy<any> | FieldReadFunction<any>
+  result?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ClaimableHandlesKeySpecifier = ('canClaimFreeTextHandle' | 'reservedHandles' | ClaimableHandlesKeySpecifier)[];
+export type ClaimableHandlesKeySpecifier = (
+  | 'canClaimFreeTextHandle'
+  | 'reservedHandles'
+  | ClaimableHandlesKeySpecifier
+)[];
 export type ClaimableHandlesFieldPolicy = {
-	canClaimFreeTextHandle?: FieldPolicy<any> | FieldReadFunction<any>,
-	reservedHandles?: FieldPolicy<any> | FieldReadFunction<any>
+  canClaimFreeTextHandle?: FieldPolicy<any> | FieldReadFunction<any>;
+  reservedHandles?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CollectConditionOutputKeySpecifier = ('publicationId' | 'thisPublication' | CollectConditionOutputKeySpecifier)[];
+export type CollectConditionOutputKeySpecifier = (
+  | 'publicationId'
+  | 'thisPublication'
+  | CollectConditionOutputKeySpecifier
+)[];
 export type CollectConditionOutputFieldPolicy = {
-	publicationId?: FieldPolicy<any> | FieldReadFunction<any>,
-	thisPublication?: FieldPolicy<any> | FieldReadFunction<any>
+  publicationId?: FieldPolicy<any> | FieldReadFunction<any>;
+  thisPublication?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type CollectedEventKeySpecifier = ('profile' | 'timestamp' | CollectedEventKeySpecifier)[];
 export type CollectedEventFieldPolicy = {
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	timestamp?: FieldPolicy<any> | FieldReadFunction<any>
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  timestamp?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CommentKeySpecifier = ('appId' | 'canComment' | 'canDecrypt' | 'canMirror' | 'collectModule' | 'collectNftAddress' | 'collectPolicy' | 'collectedBy' | 'commentOn' | 'createdAt' | 'dataAvailabilityProofs' | 'decryptionCriteria' | 'firstComment' | 'hasCollectedByMe' | 'hasOptimisticCollectedByMe' | 'hidden' | 'id' | 'isDataAvailability' | 'isGated' | 'isOptimisticMirroredByMe' | 'mainPost' | 'metadata' | 'mirrors' | 'onChainContentURI' | 'profile' | 'rankingScore' | 'reaction' | 'referenceModule' | 'referencePolicy' | 'stats' | CommentKeySpecifier)[];
+export type CommentKeySpecifier = (
+  | 'appId'
+  | 'canComment'
+  | 'canDecrypt'
+  | 'canMirror'
+  | 'collectModule'
+  | 'collectNftAddress'
+  | 'collectPolicy'
+  | 'collectedBy'
+  | 'commentOn'
+  | 'createdAt'
+  | 'dataAvailabilityProofs'
+  | 'decryptionCriteria'
+  | 'firstComment'
+  | 'hasCollectedByMe'
+  | 'hasOptimisticCollectedByMe'
+  | 'hidden'
+  | 'id'
+  | 'isDataAvailability'
+  | 'isGated'
+  | 'isOptimisticMirroredByMe'
+  | 'mainPost'
+  | 'metadata'
+  | 'mirrors'
+  | 'onChainContentURI'
+  | 'profile'
+  | 'rankingScore'
+  | 'reaction'
+  | 'referenceModule'
+  | 'referencePolicy'
+  | 'stats'
+  | CommentKeySpecifier
+)[];
 export type CommentFieldPolicy = {
-	appId?: FieldPolicy<any> | FieldReadFunction<any>,
-	canComment?: FieldPolicy<any> | FieldReadFunction<any>,
-	canDecrypt?: FieldPolicy<any> | FieldReadFunction<any>,
-	canMirror?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectNftAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectPolicy?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectedBy?: FieldPolicy<any> | FieldReadFunction<any>,
-	commentOn?: FieldPolicy<any> | FieldReadFunction<any>,
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	dataAvailabilityProofs?: FieldPolicy<any> | FieldReadFunction<any>,
-	decryptionCriteria?: FieldPolicy<any> | FieldReadFunction<any>,
-	firstComment?: FieldPolicy<any> | FieldReadFunction<any>,
-	hasCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	hasOptimisticCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	hidden?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	isDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>,
-	isGated?: FieldPolicy<any> | FieldReadFunction<any>,
-	isOptimisticMirroredByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	mainPost?: FieldPolicy<any> | FieldReadFunction<any>,
-	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
-	mirrors?: FieldPolicy<any> | FieldReadFunction<any>,
-	onChainContentURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	rankingScore?: FieldPolicy<any> | FieldReadFunction<any>,
-	reaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	referencePolicy?: FieldPolicy<any> | FieldReadFunction<any>,
-	stats?: FieldPolicy<any> | FieldReadFunction<any>
+  appId?: FieldPolicy<any> | FieldReadFunction<any>;
+  canComment?: FieldPolicy<any> | FieldReadFunction<any>;
+  canDecrypt?: FieldPolicy<any> | FieldReadFunction<any>;
+  canMirror?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectNftAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectPolicy?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectedBy?: FieldPolicy<any> | FieldReadFunction<any>;
+  commentOn?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  dataAvailabilityProofs?: FieldPolicy<any> | FieldReadFunction<any>;
+  decryptionCriteria?: FieldPolicy<any> | FieldReadFunction<any>;
+  firstComment?: FieldPolicy<any> | FieldReadFunction<any>;
+  hasCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  hasOptimisticCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  hidden?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  isDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>;
+  isGated?: FieldPolicy<any> | FieldReadFunction<any>;
+  isOptimisticMirroredByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  mainPost?: FieldPolicy<any> | FieldReadFunction<any>;
+  metadata?: FieldPolicy<any> | FieldReadFunction<any>;
+  mirrors?: FieldPolicy<any> | FieldReadFunction<any>;
+  onChainContentURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  rankingScore?: FieldPolicy<any> | FieldReadFunction<any>;
+  reaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  referencePolicy?: FieldPolicy<any> | FieldReadFunction<any>;
+  stats?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateBurnEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateBurnEIP712TypedDataKeySpecifier)[];
+export type CreateBurnEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateBurnEIP712TypedDataKeySpecifier
+)[];
 export type CreateBurnEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateBurnEIP712TypedDataTypesKeySpecifier = ('BurnWithSig' | CreateBurnEIP712TypedDataTypesKeySpecifier)[];
+export type CreateBurnEIP712TypedDataTypesKeySpecifier = (
+  | 'BurnWithSig'
+  | CreateBurnEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateBurnEIP712TypedDataTypesFieldPolicy = {
-	BurnWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  BurnWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateBurnEIP712TypedDataValueKeySpecifier = ('deadline' | 'nonce' | 'tokenId' | CreateBurnEIP712TypedDataValueKeySpecifier)[];
+export type CreateBurnEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'nonce'
+  | 'tokenId'
+  | CreateBurnEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateBurnEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	tokenId?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  tokenId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateBurnProfileBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateBurnProfileBroadcastItemResultKeySpecifier)[];
+export type CreateBurnProfileBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateBurnProfileBroadcastItemResultKeySpecifier
+)[];
 export type CreateBurnProfileBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCollectBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateCollectBroadcastItemResultKeySpecifier)[];
+export type CreateCollectBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateCollectBroadcastItemResultKeySpecifier
+)[];
 export type CreateCollectBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCollectEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateCollectEIP712TypedDataKeySpecifier)[];
+export type CreateCollectEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateCollectEIP712TypedDataKeySpecifier
+)[];
 export type CreateCollectEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCollectEIP712TypedDataTypesKeySpecifier = ('CollectWithSig' | CreateCollectEIP712TypedDataTypesKeySpecifier)[];
+export type CreateCollectEIP712TypedDataTypesKeySpecifier = (
+  | 'CollectWithSig'
+  | CreateCollectEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateCollectEIP712TypedDataTypesFieldPolicy = {
-	CollectWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  CollectWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCollectEIP712TypedDataValueKeySpecifier = ('data' | 'deadline' | 'nonce' | 'profileId' | 'pubId' | CreateCollectEIP712TypedDataValueKeySpecifier)[];
+export type CreateCollectEIP712TypedDataValueKeySpecifier = (
+  | 'data'
+  | 'deadline'
+  | 'nonce'
+  | 'profileId'
+  | 'pubId'
+  | CreateCollectEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateCollectEIP712TypedDataValueFieldPolicy = {
-	data?: FieldPolicy<any> | FieldReadFunction<any>,
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>,
-	pubId?: FieldPolicy<any> | FieldReadFunction<any>
+  data?: FieldPolicy<any> | FieldReadFunction<any>;
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
+  pubId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCommentBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateCommentBroadcastItemResultKeySpecifier)[];
+export type CreateCommentBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateCommentBroadcastItemResultKeySpecifier
+)[];
 export type CreateCommentBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCommentEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateCommentEIP712TypedDataKeySpecifier)[];
+export type CreateCommentEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateCommentEIP712TypedDataKeySpecifier
+)[];
 export type CreateCommentEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCommentEIP712TypedDataTypesKeySpecifier = ('CommentWithSig' | CreateCommentEIP712TypedDataTypesKeySpecifier)[];
+export type CreateCommentEIP712TypedDataTypesKeySpecifier = (
+  | 'CommentWithSig'
+  | CreateCommentEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateCommentEIP712TypedDataTypesFieldPolicy = {
-	CommentWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  CommentWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateCommentEIP712TypedDataValueKeySpecifier = ('collectModule' | 'collectModuleInitData' | 'contentURI' | 'deadline' | 'nonce' | 'profileId' | 'profileIdPointed' | 'pubIdPointed' | 'referenceModule' | 'referenceModuleData' | 'referenceModuleInitData' | CreateCommentEIP712TypedDataValueKeySpecifier)[];
+export type CreateCommentEIP712TypedDataValueKeySpecifier = (
+  | 'collectModule'
+  | 'collectModuleInitData'
+  | 'contentURI'
+  | 'deadline'
+  | 'nonce'
+  | 'profileId'
+  | 'profileIdPointed'
+  | 'pubIdPointed'
+  | 'referenceModule'
+  | 'referenceModuleData'
+  | 'referenceModuleInitData'
+  | CreateCommentEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateCommentEIP712TypedDataValueFieldPolicy = {
-	collectModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>,
-	contentURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileIdPointed?: FieldPolicy<any> | FieldReadFunction<any>,
-	pubIdPointed?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModuleData?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>
+  collectModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>;
+  contentURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileIdPointed?: FieldPolicy<any> | FieldReadFunction<any>;
+  pubIdPointed?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModuleData?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateDataAvailabilityPublicationResultKeySpecifier = ('dataAvailabilityId' | 'id' | 'proofs' | CreateDataAvailabilityPublicationResultKeySpecifier)[];
+export type CreateDataAvailabilityPublicationResultKeySpecifier = (
+  | 'dataAvailabilityId'
+  | 'id'
+  | 'proofs'
+  | CreateDataAvailabilityPublicationResultKeySpecifier
+)[];
 export type CreateDataAvailabilityPublicationResultFieldPolicy = {
-	dataAvailabilityId?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	proofs?: FieldPolicy<any> | FieldReadFunction<any>
+  dataAvailabilityId?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  proofs?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateFollowBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateFollowBroadcastItemResultKeySpecifier)[];
+export type CreateFollowBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateFollowBroadcastItemResultKeySpecifier
+)[];
 export type CreateFollowBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateFollowEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateFollowEIP712TypedDataKeySpecifier)[];
+export type CreateFollowEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateFollowEIP712TypedDataKeySpecifier
+)[];
 export type CreateFollowEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateFollowEIP712TypedDataTypesKeySpecifier = ('FollowWithSig' | CreateFollowEIP712TypedDataTypesKeySpecifier)[];
+export type CreateFollowEIP712TypedDataTypesKeySpecifier = (
+  | 'FollowWithSig'
+  | CreateFollowEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateFollowEIP712TypedDataTypesFieldPolicy = {
-	FollowWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  FollowWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateFollowEIP712TypedDataValueKeySpecifier = ('datas' | 'deadline' | 'nonce' | 'profileIds' | CreateFollowEIP712TypedDataValueKeySpecifier)[];
+export type CreateFollowEIP712TypedDataValueKeySpecifier = (
+  | 'datas'
+  | 'deadline'
+  | 'nonce'
+  | 'profileIds'
+  | CreateFollowEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateFollowEIP712TypedDataValueFieldPolicy = {
-	datas?: FieldPolicy<any> | FieldReadFunction<any>,
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileIds?: FieldPolicy<any> | FieldReadFunction<any>
+  datas?: FieldPolicy<any> | FieldReadFunction<any>;
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileIds?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateMirrorBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateMirrorBroadcastItemResultKeySpecifier)[];
+export type CreateMirrorBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateMirrorBroadcastItemResultKeySpecifier
+)[];
 export type CreateMirrorBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateMirrorEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateMirrorEIP712TypedDataKeySpecifier)[];
+export type CreateMirrorEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateMirrorEIP712TypedDataKeySpecifier
+)[];
 export type CreateMirrorEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateMirrorEIP712TypedDataTypesKeySpecifier = ('MirrorWithSig' | CreateMirrorEIP712TypedDataTypesKeySpecifier)[];
+export type CreateMirrorEIP712TypedDataTypesKeySpecifier = (
+  | 'MirrorWithSig'
+  | CreateMirrorEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateMirrorEIP712TypedDataTypesFieldPolicy = {
-	MirrorWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  MirrorWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateMirrorEIP712TypedDataValueKeySpecifier = ('deadline' | 'nonce' | 'profileId' | 'profileIdPointed' | 'pubIdPointed' | 'referenceModule' | 'referenceModuleData' | 'referenceModuleInitData' | CreateMirrorEIP712TypedDataValueKeySpecifier)[];
+export type CreateMirrorEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'nonce'
+  | 'profileId'
+  | 'profileIdPointed'
+  | 'pubIdPointed'
+  | 'referenceModule'
+  | 'referenceModuleData'
+  | 'referenceModuleInitData'
+  | CreateMirrorEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateMirrorEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileIdPointed?: FieldPolicy<any> | FieldReadFunction<any>,
-	pubIdPointed?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModuleData?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileIdPointed?: FieldPolicy<any> | FieldReadFunction<any>;
+  pubIdPointed?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModuleData?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreatePostBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreatePostBroadcastItemResultKeySpecifier)[];
+export type CreatePostBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreatePostBroadcastItemResultKeySpecifier
+)[];
 export type CreatePostBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreatePostEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreatePostEIP712TypedDataKeySpecifier)[];
+export type CreatePostEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreatePostEIP712TypedDataKeySpecifier
+)[];
 export type CreatePostEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreatePostEIP712TypedDataTypesKeySpecifier = ('PostWithSig' | CreatePostEIP712TypedDataTypesKeySpecifier)[];
+export type CreatePostEIP712TypedDataTypesKeySpecifier = (
+  | 'PostWithSig'
+  | CreatePostEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreatePostEIP712TypedDataTypesFieldPolicy = {
-	PostWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  PostWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreatePostEIP712TypedDataValueKeySpecifier = ('collectModule' | 'collectModuleInitData' | 'contentURI' | 'deadline' | 'nonce' | 'profileId' | 'referenceModule' | 'referenceModuleInitData' | CreatePostEIP712TypedDataValueKeySpecifier)[];
+export type CreatePostEIP712TypedDataValueKeySpecifier = (
+  | 'collectModule'
+  | 'collectModuleInitData'
+  | 'contentURI'
+  | 'deadline'
+  | 'nonce'
+  | 'profileId'
+  | 'referenceModule'
+  | 'referenceModuleInitData'
+  | CreatePostEIP712TypedDataValueKeySpecifier
+)[];
 export type CreatePostEIP712TypedDataValueFieldPolicy = {
-	collectModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>,
-	contentURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>
+  collectModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>;
+  contentURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetDispatcherBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateSetDispatcherBroadcastItemResultKeySpecifier)[];
+export type CreateSetDispatcherBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateSetDispatcherBroadcastItemResultKeySpecifier
+)[];
 export type CreateSetDispatcherBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetDispatcherEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateSetDispatcherEIP712TypedDataKeySpecifier)[];
+export type CreateSetDispatcherEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateSetDispatcherEIP712TypedDataKeySpecifier
+)[];
 export type CreateSetDispatcherEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetDispatcherEIP712TypedDataTypesKeySpecifier = ('SetDispatcherWithSig' | CreateSetDispatcherEIP712TypedDataTypesKeySpecifier)[];
+export type CreateSetDispatcherEIP712TypedDataTypesKeySpecifier = (
+  | 'SetDispatcherWithSig'
+  | CreateSetDispatcherEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateSetDispatcherEIP712TypedDataTypesFieldPolicy = {
-	SetDispatcherWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  SetDispatcherWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetDispatcherEIP712TypedDataValueKeySpecifier = ('deadline' | 'dispatcher' | 'nonce' | 'profileId' | CreateSetDispatcherEIP712TypedDataValueKeySpecifier)[];
+export type CreateSetDispatcherEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'dispatcher'
+  | 'nonce'
+  | 'profileId'
+  | CreateSetDispatcherEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateSetDispatcherEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	dispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  dispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowModuleBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateSetFollowModuleBroadcastItemResultKeySpecifier)[];
+export type CreateSetFollowModuleBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateSetFollowModuleBroadcastItemResultKeySpecifier
+)[];
 export type CreateSetFollowModuleBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowModuleEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateSetFollowModuleEIP712TypedDataKeySpecifier)[];
+export type CreateSetFollowModuleEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateSetFollowModuleEIP712TypedDataKeySpecifier
+)[];
 export type CreateSetFollowModuleEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier = ('SetFollowModuleWithSig' | CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier)[];
+export type CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier = (
+  | 'SetFollowModuleWithSig'
+  | CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateSetFollowModuleEIP712TypedDataTypesFieldPolicy = {
-	SetFollowModuleWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  SetFollowModuleWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowModuleEIP712TypedDataValueKeySpecifier = ('deadline' | 'followModule' | 'followModuleInitData' | 'nonce' | 'profileId' | CreateSetFollowModuleEIP712TypedDataValueKeySpecifier)[];
+export type CreateSetFollowModuleEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'followModule'
+  | 'followModuleInitData'
+  | 'nonce'
+  | 'profileId'
+  | CreateSetFollowModuleEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateSetFollowModuleEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	followModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	followModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  followModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  followModuleInitData?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowNFTUriBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateSetFollowNFTUriBroadcastItemResultKeySpecifier)[];
+export type CreateSetFollowNFTUriBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateSetFollowNFTUriBroadcastItemResultKeySpecifier
+)[];
 export type CreateSetFollowNFTUriBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowNFTUriEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateSetFollowNFTUriEIP712TypedDataKeySpecifier)[];
+export type CreateSetFollowNFTUriEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateSetFollowNFTUriEIP712TypedDataKeySpecifier
+)[];
 export type CreateSetFollowNFTUriEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier = ('SetFollowNFTURIWithSig' | CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier)[];
+export type CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier = (
+  | 'SetFollowNFTURIWithSig'
+  | CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateSetFollowNFTUriEIP712TypedDataTypesFieldPolicy = {
-	SetFollowNFTURIWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  SetFollowNFTURIWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier = ('deadline' | 'followNFTURI' | 'nonce' | 'profileId' | CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier)[];
+export type CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'followNFTURI'
+  | 'nonce'
+  | 'profileId'
+  | CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateSetFollowNFTUriEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	followNFTURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  followNFTURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileImageUriBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateSetProfileImageUriBroadcastItemResultKeySpecifier)[];
+export type CreateSetProfileImageUriBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateSetProfileImageUriBroadcastItemResultKeySpecifier
+)[];
 export type CreateSetProfileImageUriBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileImageUriEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateSetProfileImageUriEIP712TypedDataKeySpecifier)[];
+export type CreateSetProfileImageUriEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateSetProfileImageUriEIP712TypedDataKeySpecifier
+)[];
 export type CreateSetProfileImageUriEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier = ('SetProfileImageURIWithSig' | CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier)[];
+export type CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier = (
+  | 'SetProfileImageURIWithSig'
+  | CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateSetProfileImageUriEIP712TypedDataTypesFieldPolicy = {
-	SetProfileImageURIWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  SetProfileImageURIWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier = ('deadline' | 'imageURI' | 'nonce' | 'profileId' | CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier)[];
+export type CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'imageURI'
+  | 'nonce'
+  | 'profileId'
+  | CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateSetProfileImageUriEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	imageURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  imageURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier)[];
+export type CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier
+)[];
 export type CreateSetProfileMetadataURIBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier)[];
+export type CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier
+)[];
 export type CreateSetProfileMetadataURIEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier = ('SetProfileMetadataURIWithSig' | CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier)[];
+export type CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier = (
+  | 'SetProfileMetadataURIWithSig'
+  | CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateSetProfileMetadataURIEIP712TypedDataTypesFieldPolicy = {
-	SetProfileMetadataURIWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  SetProfileMetadataURIWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier = ('deadline' | 'metadata' | 'nonce' | 'profileId' | CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier)[];
+export type CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'metadata'
+  | 'nonce'
+  | 'profileId'
+  | CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateSetProfileMetadataURIEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  metadata?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateToggleFollowBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateToggleFollowBroadcastItemResultKeySpecifier)[];
+export type CreateToggleFollowBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateToggleFollowBroadcastItemResultKeySpecifier
+)[];
 export type CreateToggleFollowBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateToggleFollowEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | CreateToggleFollowEIP712TypedDataKeySpecifier)[];
+export type CreateToggleFollowEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | CreateToggleFollowEIP712TypedDataKeySpecifier
+)[];
 export type CreateToggleFollowEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateToggleFollowEIP712TypedDataTypesKeySpecifier = ('ToggleFollowWithSig' | CreateToggleFollowEIP712TypedDataTypesKeySpecifier)[];
+export type CreateToggleFollowEIP712TypedDataTypesKeySpecifier = (
+  | 'ToggleFollowWithSig'
+  | CreateToggleFollowEIP712TypedDataTypesKeySpecifier
+)[];
 export type CreateToggleFollowEIP712TypedDataTypesFieldPolicy = {
-	ToggleFollowWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  ToggleFollowWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateToggleFollowEIP712TypedDataValueKeySpecifier = ('deadline' | 'enables' | 'nonce' | 'profileIds' | CreateToggleFollowEIP712TypedDataValueKeySpecifier)[];
+export type CreateToggleFollowEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'enables'
+  | 'nonce'
+  | 'profileIds'
+  | CreateToggleFollowEIP712TypedDataValueKeySpecifier
+)[];
 export type CreateToggleFollowEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	enables?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileIds?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  enables?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileIds?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type CreateUnfollowBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | CreateUnfollowBroadcastItemResultKeySpecifier)[];
+export type CreateUnfollowBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | CreateUnfollowBroadcastItemResultKeySpecifier
+)[];
 export type CreateUnfollowBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type DegreesOfSeparationReferenceModuleSettingsKeySpecifier = ('commentsRestricted' | 'contractAddress' | 'degreesOfSeparation' | 'mirrorsRestricted' | 'type' | DegreesOfSeparationReferenceModuleSettingsKeySpecifier)[];
+export type DegreesOfSeparationReferenceModuleSettingsKeySpecifier = (
+  | 'commentsRestricted'
+  | 'contractAddress'
+  | 'degreesOfSeparation'
+  | 'mirrorsRestricted'
+  | 'type'
+  | DegreesOfSeparationReferenceModuleSettingsKeySpecifier
+)[];
 export type DegreesOfSeparationReferenceModuleSettingsFieldPolicy = {
-	commentsRestricted?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	degreesOfSeparation?: FieldPolicy<any> | FieldReadFunction<any>,
-	mirrorsRestricted?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  commentsRestricted?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  degreesOfSeparation?: FieldPolicy<any> | FieldReadFunction<any>;
+  mirrorsRestricted?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type DispatcherKeySpecifier = ('address' | 'canUseRelay' | DispatcherKeySpecifier)[];
 export type DispatcherFieldPolicy = {
-	address?: FieldPolicy<any> | FieldReadFunction<any>,
-	canUseRelay?: FieldPolicy<any> | FieldReadFunction<any>
+  address?: FieldPolicy<any> | FieldReadFunction<any>;
+  canUseRelay?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type DoesFollowResponseKeySpecifier = ('followerAddress' | 'follows' | 'isFinalisedOnChain' | 'profileId' | DoesFollowResponseKeySpecifier)[];
+export type DoesFollowResponseKeySpecifier = (
+  | 'followerAddress'
+  | 'follows'
+  | 'isFinalisedOnChain'
+  | 'profileId'
+  | DoesFollowResponseKeySpecifier
+)[];
 export type DoesFollowResponseFieldPolicy = {
-	followerAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	follows?: FieldPolicy<any> | FieldReadFunction<any>,
-	isFinalisedOnChain?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  followerAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  follows?: FieldPolicy<any> | FieldReadFunction<any>;
+  isFinalisedOnChain?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EIP712TypedDataDomainKeySpecifier = ('chainId' | 'name' | 'verifyingContract' | 'version' | EIP712TypedDataDomainKeySpecifier)[];
+export type EIP712TypedDataDomainKeySpecifier = (
+  | 'chainId'
+  | 'name'
+  | 'verifyingContract'
+  | 'version'
+  | EIP712TypedDataDomainKeySpecifier
+)[];
 export type EIP712TypedDataDomainFieldPolicy = {
-	chainId?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	verifyingContract?: FieldPolicy<any> | FieldReadFunction<any>,
-	version?: FieldPolicy<any> | FieldReadFunction<any>
+  chainId?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  verifyingContract?: FieldPolicy<any> | FieldReadFunction<any>;
+  version?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EIP712TypedDataFieldKeySpecifier = ('name' | 'type' | EIP712TypedDataFieldKeySpecifier)[];
+export type EIP712TypedDataFieldKeySpecifier = (
+  | 'name'
+  | 'type'
+  | EIP712TypedDataFieldKeySpecifier
+)[];
 export type EIP712TypedDataFieldFieldPolicy = {
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ERC4626FeeCollectModuleSettingsKeySpecifier = ('amount' | 'collectLimit' | 'contractAddress' | 'endTimestamp' | 'followerOnly' | 'recipient' | 'referralFee' | 'type' | 'vault' | ERC4626FeeCollectModuleSettingsKeySpecifier)[];
+export type ERC4626FeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'collectLimit'
+  | 'contractAddress'
+  | 'endTimestamp'
+  | 'followerOnly'
+  | 'recipient'
+  | 'referralFee'
+  | 'type'
+  | 'vault'
+  | ERC4626FeeCollectModuleSettingsKeySpecifier
+)[];
 export type ERC4626FeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectLimit?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>,
-	vault?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectLimit?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
+  vault?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ElectedMirrorKeySpecifier = ('mirrorId' | 'profile' | 'timestamp' | ElectedMirrorKeySpecifier)[];
+export type ElectedMirrorKeySpecifier = (
+  | 'mirrorId'
+  | 'profile'
+  | 'timestamp'
+  | ElectedMirrorKeySpecifier
+)[];
 export type ElectedMirrorFieldPolicy = {
-	mirrorId?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	timestamp?: FieldPolicy<any> | FieldReadFunction<any>
+  mirrorId?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  timestamp?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EnabledModuleKeySpecifier = ('contractAddress' | 'inputParams' | 'moduleName' | 'redeemParams' | 'returnDataParms' | EnabledModuleKeySpecifier)[];
+export type EnabledModuleKeySpecifier = (
+  | 'contractAddress'
+  | 'inputParams'
+  | 'moduleName'
+  | 'redeemParams'
+  | 'returnDataParms'
+  | EnabledModuleKeySpecifier
+)[];
 export type EnabledModuleFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	inputParams?: FieldPolicy<any> | FieldReadFunction<any>,
-	moduleName?: FieldPolicy<any> | FieldReadFunction<any>,
-	redeemParams?: FieldPolicy<any> | FieldReadFunction<any>,
-	returnDataParms?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  inputParams?: FieldPolicy<any> | FieldReadFunction<any>;
+  moduleName?: FieldPolicy<any> | FieldReadFunction<any>;
+  redeemParams?: FieldPolicy<any> | FieldReadFunction<any>;
+  returnDataParms?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EnabledModulesKeySpecifier = ('collectModules' | 'followModules' | 'referenceModules' | EnabledModulesKeySpecifier)[];
+export type EnabledModulesKeySpecifier = (
+  | 'collectModules'
+  | 'followModules'
+  | 'referenceModules'
+  | EnabledModulesKeySpecifier
+)[];
 export type EnabledModulesFieldPolicy = {
-	collectModules?: FieldPolicy<any> | FieldReadFunction<any>,
-	followModules?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModules?: FieldPolicy<any> | FieldReadFunction<any>
+  collectModules?: FieldPolicy<any> | FieldReadFunction<any>;
+  followModules?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModules?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EncryptedFieldsOutputKeySpecifier = ('animation_url' | 'content' | 'external_url' | 'image' | 'media' | EncryptedFieldsOutputKeySpecifier)[];
+export type EncryptedFieldsOutputKeySpecifier = (
+  | 'animation_url'
+  | 'content'
+  | 'external_url'
+  | 'image'
+  | 'media'
+  | EncryptedFieldsOutputKeySpecifier
+)[];
 export type EncryptedFieldsOutputFieldPolicy = {
-	animation_url?: FieldPolicy<any> | FieldReadFunction<any>,
-	content?: FieldPolicy<any> | FieldReadFunction<any>,
-	external_url?: FieldPolicy<any> | FieldReadFunction<any>,
-	image?: FieldPolicy<any> | FieldReadFunction<any>,
-	media?: FieldPolicy<any> | FieldReadFunction<any>
+  animation_url?: FieldPolicy<any> | FieldReadFunction<any>;
+  content?: FieldPolicy<any> | FieldReadFunction<any>;
+  external_url?: FieldPolicy<any> | FieldReadFunction<any>;
+  image?: FieldPolicy<any> | FieldReadFunction<any>;
+  media?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EncryptedMediaKeySpecifier = ('altTag' | 'cover' | 'height' | 'mimeType' | 'size' | 'url' | 'width' | EncryptedMediaKeySpecifier)[];
+export type EncryptedMediaKeySpecifier = (
+  | 'altTag'
+  | 'cover'
+  | 'height'
+  | 'mimeType'
+  | 'size'
+  | 'url'
+  | 'width'
+  | EncryptedMediaKeySpecifier
+)[];
 export type EncryptedMediaFieldPolicy = {
-	altTag?: FieldPolicy<any> | FieldReadFunction<any>,
-	cover?: FieldPolicy<any> | FieldReadFunction<any>,
-	height?: FieldPolicy<any> | FieldReadFunction<any>,
-	mimeType?: FieldPolicy<any> | FieldReadFunction<any>,
-	size?: FieldPolicy<any> | FieldReadFunction<any>,
-	url?: FieldPolicy<any> | FieldReadFunction<any>,
-	width?: FieldPolicy<any> | FieldReadFunction<any>
+  altTag?: FieldPolicy<any> | FieldReadFunction<any>;
+  cover?: FieldPolicy<any> | FieldReadFunction<any>;
+  height?: FieldPolicy<any> | FieldReadFunction<any>;
+  mimeType?: FieldPolicy<any> | FieldReadFunction<any>;
+  size?: FieldPolicy<any> | FieldReadFunction<any>;
+  url?: FieldPolicy<any> | FieldReadFunction<any>;
+  width?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EncryptedMediaSetKeySpecifier = ('medium' | 'original' | 'small' | EncryptedMediaSetKeySpecifier)[];
+export type EncryptedMediaSetKeySpecifier = (
+  | 'medium'
+  | 'original'
+  | 'small'
+  | EncryptedMediaSetKeySpecifier
+)[];
 export type EncryptedMediaSetFieldPolicy = {
-	medium?: FieldPolicy<any> | FieldReadFunction<any>,
-	original?: FieldPolicy<any> | FieldReadFunction<any>,
-	small?: FieldPolicy<any> | FieldReadFunction<any>
+  medium?: FieldPolicy<any> | FieldReadFunction<any>;
+  original?: FieldPolicy<any> | FieldReadFunction<any>;
+  small?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type EncryptionParamsOutputKeySpecifier = ('accessCondition' | 'encryptedFields' | 'encryptionProvider' | 'providerSpecificParams' | EncryptionParamsOutputKeySpecifier)[];
+export type EncryptionParamsOutputKeySpecifier = (
+  | 'accessCondition'
+  | 'encryptedFields'
+  | 'encryptionProvider'
+  | 'providerSpecificParams'
+  | EncryptionParamsOutputKeySpecifier
+)[];
 export type EncryptionParamsOutputFieldPolicy = {
-	accessCondition?: FieldPolicy<any> | FieldReadFunction<any>,
-	encryptedFields?: FieldPolicy<any> | FieldReadFunction<any>,
-	encryptionProvider?: FieldPolicy<any> | FieldReadFunction<any>,
-	providerSpecificParams?: FieldPolicy<any> | FieldReadFunction<any>
+  accessCondition?: FieldPolicy<any> | FieldReadFunction<any>;
+  encryptedFields?: FieldPolicy<any> | FieldReadFunction<any>;
+  encryptionProvider?: FieldPolicy<any> | FieldReadFunction<any>;
+  providerSpecificParams?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type EnsOnChainIdentityKeySpecifier = ('name' | EnsOnChainIdentityKeySpecifier)[];
 export type EnsOnChainIdentityFieldPolicy = {
-	name?: FieldPolicy<any> | FieldReadFunction<any>
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type EoaOwnershipOutputKeySpecifier = ('address' | EoaOwnershipOutputKeySpecifier)[];
 export type EoaOwnershipOutputFieldPolicy = {
-	address?: FieldPolicy<any> | FieldReadFunction<any>
+  address?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type Erc20KeySpecifier = ('address' | 'decimals' | 'name' | 'symbol' | Erc20KeySpecifier)[];
 export type Erc20FieldPolicy = {
-	address?: FieldPolicy<any> | FieldReadFunction<any>,
-	decimals?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	symbol?: FieldPolicy<any> | FieldReadFunction<any>
+  address?: FieldPolicy<any> | FieldReadFunction<any>;
+  decimals?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  symbol?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type Erc20AmountKeySpecifier = ('asset' | 'value' | Erc20AmountKeySpecifier)[];
 export type Erc20AmountFieldPolicy = {
-	asset?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  asset?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type Erc20OwnershipOutputKeySpecifier = ('amount' | 'chainID' | 'condition' | 'contractAddress' | 'decimals' | 'name' | 'symbol' | Erc20OwnershipOutputKeySpecifier)[];
+export type Erc20OwnershipOutputKeySpecifier = (
+  | 'amount'
+  | 'chainID'
+  | 'condition'
+  | 'contractAddress'
+  | 'decimals'
+  | 'name'
+  | 'symbol'
+  | Erc20OwnershipOutputKeySpecifier
+)[];
 export type Erc20OwnershipOutputFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	chainID?: FieldPolicy<any> | FieldReadFunction<any>,
-	condition?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	decimals?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	symbol?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  chainID?: FieldPolicy<any> | FieldReadFunction<any>;
+  condition?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  decimals?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  symbol?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ExploreProfileResultKeySpecifier = ('items' | 'pageInfo' | ExploreProfileResultKeySpecifier)[];
+export type ExploreProfileResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | ExploreProfileResultKeySpecifier
+)[];
 export type ExploreProfileResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ExplorePublicationResultKeySpecifier = ('items' | 'pageInfo' | ExplorePublicationResultKeySpecifier)[];
+export type ExplorePublicationResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | ExplorePublicationResultKeySpecifier
+)[];
 export type ExplorePublicationResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FeeCollectModuleSettingsKeySpecifier = ('amount' | 'contractAddress' | 'followerOnly' | 'recipient' | 'referralFee' | 'type' | FeeCollectModuleSettingsKeySpecifier)[];
+export type FeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'contractAddress'
+  | 'followerOnly'
+  | 'recipient'
+  | 'referralFee'
+  | 'type'
+  | FeeCollectModuleSettingsKeySpecifier
+)[];
 export type FeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FeeFollowModuleSettingsKeySpecifier = ('amount' | 'contractAddress' | 'recipient' | 'type' | FeeFollowModuleSettingsKeySpecifier)[];
+export type FeeFollowModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'contractAddress'
+  | 'recipient'
+  | 'type'
+  | FeeFollowModuleSettingsKeySpecifier
+)[];
 export type FeeFollowModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FeedItemKeySpecifier = ('collects' | 'comments' | 'electedMirror' | 'mirrors' | 'reactions' | 'root' | FeedItemKeySpecifier)[];
+export type FeedItemKeySpecifier = (
+  | 'collects'
+  | 'comments'
+  | 'electedMirror'
+  | 'mirrors'
+  | 'reactions'
+  | 'root'
+  | FeedItemKeySpecifier
+)[];
 export type FeedItemFieldPolicy = {
-	collects?: FieldPolicy<any> | FieldReadFunction<any>,
-	comments?: FieldPolicy<any> | FieldReadFunction<any>,
-	electedMirror?: FieldPolicy<any> | FieldReadFunction<any>,
-	mirrors?: FieldPolicy<any> | FieldReadFunction<any>,
-	reactions?: FieldPolicy<any> | FieldReadFunction<any>,
-	root?: FieldPolicy<any> | FieldReadFunction<any>
+  collects?: FieldPolicy<any> | FieldReadFunction<any>;
+  comments?: FieldPolicy<any> | FieldReadFunction<any>;
+  electedMirror?: FieldPolicy<any> | FieldReadFunction<any>;
+  mirrors?: FieldPolicy<any> | FieldReadFunction<any>;
+  reactions?: FieldPolicy<any> | FieldReadFunction<any>;
+  root?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type FollowConditionOutputKeySpecifier = ('profileId' | FollowConditionOutputKeySpecifier)[];
 export type FollowConditionOutputFieldPolicy = {
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FollowOnlyReferenceModuleSettingsKeySpecifier = ('contractAddress' | 'type' | FollowOnlyReferenceModuleSettingsKeySpecifier)[];
+export type FollowOnlyReferenceModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'type'
+  | FollowOnlyReferenceModuleSettingsKeySpecifier
+)[];
 export type FollowOnlyReferenceModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type FollowRevenueResultKeySpecifier = ('revenues' | FollowRevenueResultKeySpecifier)[];
 export type FollowRevenueResultFieldPolicy = {
-	revenues?: FieldPolicy<any> | FieldReadFunction<any>
+  revenues?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FollowerKeySpecifier = ('totalAmountOfTimesFollowed' | 'wallet' | FollowerKeySpecifier)[];
+export type FollowerKeySpecifier = (
+  | 'totalAmountOfTimesFollowed'
+  | 'wallet'
+  | FollowerKeySpecifier
+)[];
 export type FollowerFieldPolicy = {
-	totalAmountOfTimesFollowed?: FieldPolicy<any> | FieldReadFunction<any>,
-	wallet?: FieldPolicy<any> | FieldReadFunction<any>
+  totalAmountOfTimesFollowed?: FieldPolicy<any> | FieldReadFunction<any>;
+  wallet?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FollowerNftOwnedTokenIdsKeySpecifier = ('followerNftAddress' | 'tokensIds' | FollowerNftOwnedTokenIdsKeySpecifier)[];
+export type FollowerNftOwnedTokenIdsKeySpecifier = (
+  | 'followerNftAddress'
+  | 'tokensIds'
+  | FollowerNftOwnedTokenIdsKeySpecifier
+)[];
 export type FollowerNftOwnedTokenIdsFieldPolicy = {
-	followerNftAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	tokensIds?: FieldPolicy<any> | FieldReadFunction<any>
+  followerNftAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  tokensIds?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FollowingKeySpecifier = ('profile' | 'totalAmountOfTimesFollowing' | FollowingKeySpecifier)[];
+export type FollowingKeySpecifier = (
+  | 'profile'
+  | 'totalAmountOfTimesFollowing'
+  | FollowingKeySpecifier
+)[];
 export type FollowingFieldPolicy = {
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalAmountOfTimesFollowing?: FieldPolicy<any> | FieldReadFunction<any>
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalAmountOfTimesFollowing?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type FreeCollectModuleSettingsKeySpecifier = ('contractAddress' | 'followerOnly' | 'type' | FreeCollectModuleSettingsKeySpecifier)[];
+export type FreeCollectModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'followerOnly'
+  | 'type'
+  | FreeCollectModuleSettingsKeySpecifier
+)[];
 export type FreeCollectModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type GenerateModuleCurrencyApprovalKeySpecifier = ('data' | 'from' | 'to' | GenerateModuleCurrencyApprovalKeySpecifier)[];
+export type GenerateModuleCurrencyApprovalKeySpecifier = (
+  | 'data'
+  | 'from'
+  | 'to'
+  | GenerateModuleCurrencyApprovalKeySpecifier
+)[];
 export type GenerateModuleCurrencyApprovalFieldPolicy = {
-	data?: FieldPolicy<any> | FieldReadFunction<any>,
-	from?: FieldPolicy<any> | FieldReadFunction<any>,
-	to?: FieldPolicy<any> | FieldReadFunction<any>
+  data?: FieldPolicy<any> | FieldReadFunction<any>;
+  from?: FieldPolicy<any> | FieldReadFunction<any>;
+  to?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type GlobalProtocolStatsKeySpecifier = ('totalBurntProfiles' | 'totalCollects' | 'totalComments' | 'totalFollows' | 'totalMirrors' | 'totalPosts' | 'totalProfiles' | 'totalRevenue' | GlobalProtocolStatsKeySpecifier)[];
+export type GlobalProtocolStatsKeySpecifier = (
+  | 'totalBurntProfiles'
+  | 'totalCollects'
+  | 'totalComments'
+  | 'totalFollows'
+  | 'totalMirrors'
+  | 'totalPosts'
+  | 'totalProfiles'
+  | 'totalRevenue'
+  | GlobalProtocolStatsKeySpecifier
+)[];
 export type GlobalProtocolStatsFieldPolicy = {
-	totalBurntProfiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalCollects?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalComments?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalFollows?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalMirrors?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalPosts?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalProfiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalRevenue?: FieldPolicy<any> | FieldReadFunction<any>
+  totalBurntProfiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalCollects?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalComments?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalFollows?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalMirrors?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalPosts?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalProfiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalRevenue?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type LimitedFeeCollectModuleSettingsKeySpecifier = ('amount' | 'collectLimit' | 'contractAddress' | 'followerOnly' | 'recipient' | 'referralFee' | 'type' | LimitedFeeCollectModuleSettingsKeySpecifier)[];
+export type LimitedFeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'collectLimit'
+  | 'contractAddress'
+  | 'followerOnly'
+  | 'recipient'
+  | 'referralFee'
+  | 'type'
+  | LimitedFeeCollectModuleSettingsKeySpecifier
+)[];
 export type LimitedFeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectLimit?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectLimit?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type LimitedTimedFeeCollectModuleSettingsKeySpecifier = ('amount' | 'collectLimit' | 'contractAddress' | 'endTimestamp' | 'followerOnly' | 'recipient' | 'referralFee' | 'type' | LimitedTimedFeeCollectModuleSettingsKeySpecifier)[];
+export type LimitedTimedFeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'collectLimit'
+  | 'contractAddress'
+  | 'endTimestamp'
+  | 'followerOnly'
+  | 'recipient'
+  | 'referralFee'
+  | 'type'
+  | LimitedTimedFeeCollectModuleSettingsKeySpecifier
+)[];
 export type LimitedTimedFeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectLimit?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectLimit?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type LogKeySpecifier = ('address' | 'blockHash' | 'blockNumber' | 'data' | 'logIndex' | 'removed' | 'topics' | 'transactionHash' | 'transactionIndex' | LogKeySpecifier)[];
+export type LogKeySpecifier = (
+  | 'address'
+  | 'blockHash'
+  | 'blockNumber'
+  | 'data'
+  | 'logIndex'
+  | 'removed'
+  | 'topics'
+  | 'transactionHash'
+  | 'transactionIndex'
+  | LogKeySpecifier
+)[];
 export type LogFieldPolicy = {
-	address?: FieldPolicy<any> | FieldReadFunction<any>,
-	blockHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	blockNumber?: FieldPolicy<any> | FieldReadFunction<any>,
-	data?: FieldPolicy<any> | FieldReadFunction<any>,
-	logIndex?: FieldPolicy<any> | FieldReadFunction<any>,
-	removed?: FieldPolicy<any> | FieldReadFunction<any>,
-	topics?: FieldPolicy<any> | FieldReadFunction<any>,
-	transactionHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	transactionIndex?: FieldPolicy<any> | FieldReadFunction<any>
+  address?: FieldPolicy<any> | FieldReadFunction<any>;
+  blockHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  blockNumber?: FieldPolicy<any> | FieldReadFunction<any>;
+  data?: FieldPolicy<any> | FieldReadFunction<any>;
+  logIndex?: FieldPolicy<any> | FieldReadFunction<any>;
+  removed?: FieldPolicy<any> | FieldReadFunction<any>;
+  topics?: FieldPolicy<any> | FieldReadFunction<any>;
+  transactionHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  transactionIndex?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MediaKeySpecifier = ('altTag' | 'cover' | 'height' | 'mimeType' | 'size' | 'url' | 'width' | MediaKeySpecifier)[];
+export type MediaKeySpecifier = (
+  | 'altTag'
+  | 'cover'
+  | 'height'
+  | 'mimeType'
+  | 'size'
+  | 'url'
+  | 'width'
+  | MediaKeySpecifier
+)[];
 export type MediaFieldPolicy = {
-	altTag?: FieldPolicy<any> | FieldReadFunction<any>,
-	cover?: FieldPolicy<any> | FieldReadFunction<any>,
-	height?: FieldPolicy<any> | FieldReadFunction<any>,
-	mimeType?: FieldPolicy<any> | FieldReadFunction<any>,
-	size?: FieldPolicy<any> | FieldReadFunction<any>,
-	url?: FieldPolicy<any> | FieldReadFunction<any>,
-	width?: FieldPolicy<any> | FieldReadFunction<any>
+  altTag?: FieldPolicy<any> | FieldReadFunction<any>;
+  cover?: FieldPolicy<any> | FieldReadFunction<any>;
+  height?: FieldPolicy<any> | FieldReadFunction<any>;
+  mimeType?: FieldPolicy<any> | FieldReadFunction<any>;
+  size?: FieldPolicy<any> | FieldReadFunction<any>;
+  url?: FieldPolicy<any> | FieldReadFunction<any>;
+  width?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MediaOutputKeySpecifier = ('altTag' | 'cover' | 'item' | 'source' | 'type' | MediaOutputKeySpecifier)[];
+export type MediaOutputKeySpecifier = (
+  | 'altTag'
+  | 'cover'
+  | 'item'
+  | 'source'
+  | 'type'
+  | MediaOutputKeySpecifier
+)[];
 export type MediaOutputFieldPolicy = {
-	altTag?: FieldPolicy<any> | FieldReadFunction<any>,
-	cover?: FieldPolicy<any> | FieldReadFunction<any>,
-	item?: FieldPolicy<any> | FieldReadFunction<any>,
-	source?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  altTag?: FieldPolicy<any> | FieldReadFunction<any>;
+  cover?: FieldPolicy<any> | FieldReadFunction<any>;
+  item?: FieldPolicy<any> | FieldReadFunction<any>;
+  source?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type MediaSetKeySpecifier = ('medium' | 'original' | 'small' | MediaSetKeySpecifier)[];
 export type MediaSetFieldPolicy = {
-	medium?: FieldPolicy<any> | FieldReadFunction<any>,
-	original?: FieldPolicy<any> | FieldReadFunction<any>,
-	small?: FieldPolicy<any> | FieldReadFunction<any>
+  medium?: FieldPolicy<any> | FieldReadFunction<any>;
+  original?: FieldPolicy<any> | FieldReadFunction<any>;
+  small?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MetadataAttributeOutputKeySpecifier = ('displayType' | 'traitType' | 'value' | MetadataAttributeOutputKeySpecifier)[];
+export type MetadataAttributeOutputKeySpecifier = (
+  | 'displayType'
+  | 'traitType'
+  | 'value'
+  | MetadataAttributeOutputKeySpecifier
+)[];
 export type MetadataAttributeOutputFieldPolicy = {
-	displayType?: FieldPolicy<any> | FieldReadFunction<any>,
-	traitType?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  displayType?: FieldPolicy<any> | FieldReadFunction<any>;
+  traitType?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MetadataOutputKeySpecifier = ('animatedUrl' | 'attributes' | 'content' | 'contentWarning' | 'cover' | 'description' | 'encryptionParams' | 'image' | 'locale' | 'mainContentFocus' | 'media' | 'name' | 'tags' | MetadataOutputKeySpecifier)[];
+export type MetadataOutputKeySpecifier = (
+  | 'animatedUrl'
+  | 'attributes'
+  | 'content'
+  | 'contentWarning'
+  | 'cover'
+  | 'description'
+  | 'encryptionParams'
+  | 'image'
+  | 'locale'
+  | 'mainContentFocus'
+  | 'media'
+  | 'name'
+  | 'tags'
+  | MetadataOutputKeySpecifier
+)[];
 export type MetadataOutputFieldPolicy = {
-	animatedUrl?: FieldPolicy<any> | FieldReadFunction<any>,
-	attributes?: FieldPolicy<any> | FieldReadFunction<any>,
-	content?: FieldPolicy<any> | FieldReadFunction<any>,
-	contentWarning?: FieldPolicy<any> | FieldReadFunction<any>,
-	cover?: FieldPolicy<any> | FieldReadFunction<any>,
-	description?: FieldPolicy<any> | FieldReadFunction<any>,
-	encryptionParams?: FieldPolicy<any> | FieldReadFunction<any>,
-	image?: FieldPolicy<any> | FieldReadFunction<any>,
-	locale?: FieldPolicy<any> | FieldReadFunction<any>,
-	mainContentFocus?: FieldPolicy<any> | FieldReadFunction<any>,
-	media?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	tags?: FieldPolicy<any> | FieldReadFunction<any>
+  animatedUrl?: FieldPolicy<any> | FieldReadFunction<any>;
+  attributes?: FieldPolicy<any> | FieldReadFunction<any>;
+  content?: FieldPolicy<any> | FieldReadFunction<any>;
+  contentWarning?: FieldPolicy<any> | FieldReadFunction<any>;
+  cover?: FieldPolicy<any> | FieldReadFunction<any>;
+  description?: FieldPolicy<any> | FieldReadFunction<any>;
+  encryptionParams?: FieldPolicy<any> | FieldReadFunction<any>;
+  image?: FieldPolicy<any> | FieldReadFunction<any>;
+  locale?: FieldPolicy<any> | FieldReadFunction<any>;
+  mainContentFocus?: FieldPolicy<any> | FieldReadFunction<any>;
+  media?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  tags?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MirrorKeySpecifier = ('appId' | 'canComment' | 'canDecrypt' | 'canMirror' | 'collectModule' | 'collectNftAddress' | 'createdAt' | 'dataAvailabilityProofs' | 'hasCollectedByMe' | 'hidden' | 'id' | 'isDataAvailability' | 'isGated' | 'metadata' | 'mirrorOf' | 'onChainContentURI' | 'profile' | 'reaction' | 'referenceModule' | 'stats' | MirrorKeySpecifier)[];
+export type MirrorKeySpecifier = (
+  | 'appId'
+  | 'canComment'
+  | 'canDecrypt'
+  | 'canMirror'
+  | 'collectModule'
+  | 'collectNftAddress'
+  | 'createdAt'
+  | 'dataAvailabilityProofs'
+  | 'hasCollectedByMe'
+  | 'hidden'
+  | 'id'
+  | 'isDataAvailability'
+  | 'isGated'
+  | 'metadata'
+  | 'mirrorOf'
+  | 'onChainContentURI'
+  | 'profile'
+  | 'reaction'
+  | 'referenceModule'
+  | 'stats'
+  | MirrorKeySpecifier
+)[];
 export type MirrorFieldPolicy = {
-	appId?: FieldPolicy<any> | FieldReadFunction<any>,
-	canComment?: FieldPolicy<any> | FieldReadFunction<any>,
-	canDecrypt?: FieldPolicy<any> | FieldReadFunction<any>,
-	canMirror?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectNftAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	dataAvailabilityProofs?: FieldPolicy<any> | FieldReadFunction<any>,
-	hasCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	hidden?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	isDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>,
-	isGated?: FieldPolicy<any> | FieldReadFunction<any>,
-	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
-	mirrorOf?: FieldPolicy<any> | FieldReadFunction<any>,
-	onChainContentURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	reaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	stats?: FieldPolicy<any> | FieldReadFunction<any>
+  appId?: FieldPolicy<any> | FieldReadFunction<any>;
+  canComment?: FieldPolicy<any> | FieldReadFunction<any>;
+  canDecrypt?: FieldPolicy<any> | FieldReadFunction<any>;
+  canMirror?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectNftAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  dataAvailabilityProofs?: FieldPolicy<any> | FieldReadFunction<any>;
+  hasCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  hidden?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  isDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>;
+  isGated?: FieldPolicy<any> | FieldReadFunction<any>;
+  metadata?: FieldPolicy<any> | FieldReadFunction<any>;
+  mirrorOf?: FieldPolicy<any> | FieldReadFunction<any>;
+  onChainContentURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  reaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  stats?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type MirrorEventKeySpecifier = ('profile' | 'timestamp' | MirrorEventKeySpecifier)[];
 export type MirrorEventFieldPolicy = {
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	timestamp?: FieldPolicy<any> | FieldReadFunction<any>
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  timestamp?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type ModuleFeeAmountKeySpecifier = ('asset' | 'value' | ModuleFeeAmountKeySpecifier)[];
 export type ModuleFeeAmountFieldPolicy = {
-	asset?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  asset?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type ModuleInfoKeySpecifier = ('name' | 'type' | ModuleInfoKeySpecifier)[];
 export type ModuleInfoFieldPolicy = {
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MultirecipientFeeCollectModuleSettingsKeySpecifier = ('amount' | 'collectLimit' | 'contractAddress' | 'endTimestamp' | 'followerOnly' | 'recipients' | 'referralFee' | 'type' | MultirecipientFeeCollectModuleSettingsKeySpecifier)[];
+export type MultirecipientFeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'collectLimit'
+  | 'contractAddress'
+  | 'endTimestamp'
+  | 'followerOnly'
+  | 'recipients'
+  | 'referralFee'
+  | 'type'
+  | MultirecipientFeeCollectModuleSettingsKeySpecifier
+)[];
 export type MultirecipientFeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectLimit?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipients?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectLimit?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipients?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type MutationKeySpecifier = ('ach' | 'addProfileInterests' | 'addReaction' | 'authenticate' | 'broadcast' | 'broadcastDataAvailability' | 'claim' | 'createAttachMediaData' | 'createBurnProfileTypedData' | 'createCollectTypedData' | 'createCommentTypedData' | 'createCommentViaDispatcher' | 'createDataAvailabilityCommentTypedData' | 'createDataAvailabilityCommentViaDispatcher' | 'createDataAvailabilityMirrorTypedData' | 'createDataAvailabilityMirrorViaDispatcher' | 'createDataAvailabilityPostTypedData' | 'createDataAvailabilityPostViaDispatcher' | 'createFollowTypedData' | 'createMirrorTypedData' | 'createMirrorViaDispatcher' | 'createNftGallery' | 'createPostTypedData' | 'createPostViaDispatcher' | 'createProfile' | 'createSetDefaultProfileTypedData' | 'createSetDispatcherTypedData' | 'createSetFollowModuleTypedData' | 'createSetFollowNFTUriTypedData' | 'createSetFollowNFTUriViaDispatcher' | 'createSetProfileImageURITypedData' | 'createSetProfileImageURIViaDispatcher' | 'createSetProfileMetadataTypedData' | 'createSetProfileMetadataViaDispatcher' | 'createToggleFollowTypedData' | 'createUnfollowTypedData' | 'deleteNftGallery' | 'dismissRecommendedProfiles' | 'gci' | 'gcr' | 'gdi' | 'hel' | 'hidePublication' | 'idKitPhoneVerifyWebhook' | 'proxyAction' | 'refresh' | 'removeProfileInterests' | 'removeReaction' | 'reportPublication' | 'updateNftGalleryInfo' | 'updateNftGalleryItems' | 'updateNftGalleryOrder' | MutationKeySpecifier)[];
+export type MutationKeySpecifier = (
+  | 'ach'
+  | 'addProfileInterests'
+  | 'addReaction'
+  | 'authenticate'
+  | 'broadcast'
+  | 'broadcastDataAvailability'
+  | 'claim'
+  | 'createAttachMediaData'
+  | 'createBurnProfileTypedData'
+  | 'createCollectTypedData'
+  | 'createCommentTypedData'
+  | 'createCommentViaDispatcher'
+  | 'createDataAvailabilityCommentTypedData'
+  | 'createDataAvailabilityCommentViaDispatcher'
+  | 'createDataAvailabilityMirrorTypedData'
+  | 'createDataAvailabilityMirrorViaDispatcher'
+  | 'createDataAvailabilityPostTypedData'
+  | 'createDataAvailabilityPostViaDispatcher'
+  | 'createFollowTypedData'
+  | 'createMirrorTypedData'
+  | 'createMirrorViaDispatcher'
+  | 'createNftGallery'
+  | 'createPostTypedData'
+  | 'createPostViaDispatcher'
+  | 'createProfile'
+  | 'createSetDefaultProfileTypedData'
+  | 'createSetDispatcherTypedData'
+  | 'createSetFollowModuleTypedData'
+  | 'createSetFollowNFTUriTypedData'
+  | 'createSetFollowNFTUriViaDispatcher'
+  | 'createSetProfileImageURITypedData'
+  | 'createSetProfileImageURIViaDispatcher'
+  | 'createSetProfileMetadataTypedData'
+  | 'createSetProfileMetadataViaDispatcher'
+  | 'createToggleFollowTypedData'
+  | 'createUnfollowTypedData'
+  | 'deleteNftGallery'
+  | 'dismissRecommendedProfiles'
+  | 'gci'
+  | 'gcr'
+  | 'gdi'
+  | 'hel'
+  | 'hidePublication'
+  | 'idKitPhoneVerifyWebhook'
+  | 'proxyAction'
+  | 'refresh'
+  | 'removeProfileInterests'
+  | 'removeReaction'
+  | 'reportPublication'
+  | 'updateNftGalleryInfo'
+  | 'updateNftGalleryItems'
+  | 'updateNftGalleryOrder'
+  | MutationKeySpecifier
+)[];
 export type MutationFieldPolicy = {
-	ach?: FieldPolicy<any> | FieldReadFunction<any>,
-	addProfileInterests?: FieldPolicy<any> | FieldReadFunction<any>,
-	addReaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	authenticate?: FieldPolicy<any> | FieldReadFunction<any>,
-	broadcast?: FieldPolicy<any> | FieldReadFunction<any>,
-	broadcastDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>,
-	claim?: FieldPolicy<any> | FieldReadFunction<any>,
-	createAttachMediaData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createBurnProfileTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createCollectTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createCommentTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createCommentViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createDataAvailabilityCommentTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createDataAvailabilityCommentViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createDataAvailabilityMirrorTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createDataAvailabilityMirrorViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createDataAvailabilityPostTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createDataAvailabilityPostViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createFollowTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createMirrorTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createMirrorViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createNftGallery?: FieldPolicy<any> | FieldReadFunction<any>,
-	createPostTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createPostViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createProfile?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetDefaultProfileTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetDispatcherTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetFollowModuleTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetFollowNFTUriTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetFollowNFTUriViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetProfileImageURITypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetProfileImageURIViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetProfileMetadataTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createSetProfileMetadataViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	createToggleFollowTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	createUnfollowTypedData?: FieldPolicy<any> | FieldReadFunction<any>,
-	deleteNftGallery?: FieldPolicy<any> | FieldReadFunction<any>,
-	dismissRecommendedProfiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	gci?: FieldPolicy<any> | FieldReadFunction<any>,
-	gcr?: FieldPolicy<any> | FieldReadFunction<any>,
-	gdi?: FieldPolicy<any> | FieldReadFunction<any>,
-	hel?: FieldPolicy<any> | FieldReadFunction<any>,
-	hidePublication?: FieldPolicy<any> | FieldReadFunction<any>,
-	idKitPhoneVerifyWebhook?: FieldPolicy<any> | FieldReadFunction<any>,
-	proxyAction?: FieldPolicy<any> | FieldReadFunction<any>,
-	refresh?: FieldPolicy<any> | FieldReadFunction<any>,
-	removeProfileInterests?: FieldPolicy<any> | FieldReadFunction<any>,
-	removeReaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	reportPublication?: FieldPolicy<any> | FieldReadFunction<any>,
-	updateNftGalleryInfo?: FieldPolicy<any> | FieldReadFunction<any>,
-	updateNftGalleryItems?: FieldPolicy<any> | FieldReadFunction<any>,
-	updateNftGalleryOrder?: FieldPolicy<any> | FieldReadFunction<any>
+  ach?: FieldPolicy<any> | FieldReadFunction<any>;
+  addProfileInterests?: FieldPolicy<any> | FieldReadFunction<any>;
+  addReaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  authenticate?: FieldPolicy<any> | FieldReadFunction<any>;
+  broadcast?: FieldPolicy<any> | FieldReadFunction<any>;
+  broadcastDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>;
+  claim?: FieldPolicy<any> | FieldReadFunction<any>;
+  createAttachMediaData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createBurnProfileTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createCollectTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createCommentTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createCommentViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createDataAvailabilityCommentTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createDataAvailabilityCommentViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createDataAvailabilityMirrorTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createDataAvailabilityMirrorViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createDataAvailabilityPostTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createDataAvailabilityPostViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createFollowTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createMirrorTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createMirrorViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createNftGallery?: FieldPolicy<any> | FieldReadFunction<any>;
+  createPostTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createPostViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createProfile?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetDefaultProfileTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetDispatcherTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetFollowModuleTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetFollowNFTUriTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetFollowNFTUriViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetProfileImageURITypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetProfileImageURIViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetProfileMetadataTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createSetProfileMetadataViaDispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  createToggleFollowTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  createUnfollowTypedData?: FieldPolicy<any> | FieldReadFunction<any>;
+  deleteNftGallery?: FieldPolicy<any> | FieldReadFunction<any>;
+  dismissRecommendedProfiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  gci?: FieldPolicy<any> | FieldReadFunction<any>;
+  gcr?: FieldPolicy<any> | FieldReadFunction<any>;
+  gdi?: FieldPolicy<any> | FieldReadFunction<any>;
+  hel?: FieldPolicy<any> | FieldReadFunction<any>;
+  hidePublication?: FieldPolicy<any> | FieldReadFunction<any>;
+  idKitPhoneVerifyWebhook?: FieldPolicy<any> | FieldReadFunction<any>;
+  proxyAction?: FieldPolicy<any> | FieldReadFunction<any>;
+  refresh?: FieldPolicy<any> | FieldReadFunction<any>;
+  removeProfileInterests?: FieldPolicy<any> | FieldReadFunction<any>;
+  removeReaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  reportPublication?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateNftGalleryInfo?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateNftGalleryItems?: FieldPolicy<any> | FieldReadFunction<any>;
+  updateNftGalleryOrder?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NFTKeySpecifier = ('chainId' | 'collectionName' | 'contentURI' | 'contractAddress' | 'contractName' | 'description' | 'ercType' | 'name' | 'originalContent' | 'owners' | 'symbol' | 'tokenId' | NFTKeySpecifier)[];
+export type NFTKeySpecifier = (
+  | 'chainId'
+  | 'collectionName'
+  | 'contentURI'
+  | 'contractAddress'
+  | 'contractName'
+  | 'description'
+  | 'ercType'
+  | 'name'
+  | 'originalContent'
+  | 'owners'
+  | 'symbol'
+  | 'tokenId'
+  | NFTKeySpecifier
+)[];
 export type NFTFieldPolicy = {
-	chainId?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectionName?: FieldPolicy<any> | FieldReadFunction<any>,
-	contentURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractName?: FieldPolicy<any> | FieldReadFunction<any>,
-	description?: FieldPolicy<any> | FieldReadFunction<any>,
-	ercType?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	originalContent?: FieldPolicy<any> | FieldReadFunction<any>,
-	owners?: FieldPolicy<any> | FieldReadFunction<any>,
-	symbol?: FieldPolicy<any> | FieldReadFunction<any>,
-	tokenId?: FieldPolicy<any> | FieldReadFunction<any>
+  chainId?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectionName?: FieldPolicy<any> | FieldReadFunction<any>;
+  contentURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractName?: FieldPolicy<any> | FieldReadFunction<any>;
+  description?: FieldPolicy<any> | FieldReadFunction<any>;
+  ercType?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  originalContent?: FieldPolicy<any> | FieldReadFunction<any>;
+  owners?: FieldPolicy<any> | FieldReadFunction<any>;
+  symbol?: FieldPolicy<any> | FieldReadFunction<any>;
+  tokenId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NFTContentKeySpecifier = ('animatedUrl' | 'metaType' | 'uri' | NFTContentKeySpecifier)[];
+export type NFTContentKeySpecifier = (
+  | 'animatedUrl'
+  | 'metaType'
+  | 'uri'
+  | NFTContentKeySpecifier
+)[];
 export type NFTContentFieldPolicy = {
-	animatedUrl?: FieldPolicy<any> | FieldReadFunction<any>,
-	metaType?: FieldPolicy<any> | FieldReadFunction<any>,
-	uri?: FieldPolicy<any> | FieldReadFunction<any>
+  animatedUrl?: FieldPolicy<any> | FieldReadFunction<any>;
+  metaType?: FieldPolicy<any> | FieldReadFunction<any>;
+  uri?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type NFTsResultKeySpecifier = ('items' | 'pageInfo' | NFTsResultKeySpecifier)[];
 export type NFTsResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NewCollectNotificationKeySpecifier = ('collectedPublication' | 'createdAt' | 'notificationId' | 'wallet' | NewCollectNotificationKeySpecifier)[];
+export type NewCollectNotificationKeySpecifier = (
+  | 'collectedPublication'
+  | 'createdAt'
+  | 'notificationId'
+  | 'wallet'
+  | NewCollectNotificationKeySpecifier
+)[];
 export type NewCollectNotificationFieldPolicy = {
-	collectedPublication?: FieldPolicy<any> | FieldReadFunction<any>,
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	notificationId?: FieldPolicy<any> | FieldReadFunction<any>,
-	wallet?: FieldPolicy<any> | FieldReadFunction<any>
+  collectedPublication?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationId?: FieldPolicy<any> | FieldReadFunction<any>;
+  wallet?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NewCommentNotificationKeySpecifier = ('comment' | 'createdAt' | 'notificationId' | 'profile' | NewCommentNotificationKeySpecifier)[];
+export type NewCommentNotificationKeySpecifier = (
+  | 'comment'
+  | 'createdAt'
+  | 'notificationId'
+  | 'profile'
+  | NewCommentNotificationKeySpecifier
+)[];
 export type NewCommentNotificationFieldPolicy = {
-	comment?: FieldPolicy<any> | FieldReadFunction<any>,
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	notificationId?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>
+  comment?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationId?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NewFollowerNotificationKeySpecifier = ('createdAt' | 'isFollowedByMe' | 'notificationId' | 'wallet' | NewFollowerNotificationKeySpecifier)[];
+export type NewFollowerNotificationKeySpecifier = (
+  | 'createdAt'
+  | 'isFollowedByMe'
+  | 'notificationId'
+  | 'wallet'
+  | NewFollowerNotificationKeySpecifier
+)[];
 export type NewFollowerNotificationFieldPolicy = {
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	isFollowedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	notificationId?: FieldPolicy<any> | FieldReadFunction<any>,
-	wallet?: FieldPolicy<any> | FieldReadFunction<any>
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  isFollowedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationId?: FieldPolicy<any> | FieldReadFunction<any>;
+  wallet?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NewMentionNotificationKeySpecifier = ('createdAt' | 'mentionPublication' | 'notificationId' | NewMentionNotificationKeySpecifier)[];
+export type NewMentionNotificationKeySpecifier = (
+  | 'createdAt'
+  | 'mentionPublication'
+  | 'notificationId'
+  | NewMentionNotificationKeySpecifier
+)[];
 export type NewMentionNotificationFieldPolicy = {
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	mentionPublication?: FieldPolicy<any> | FieldReadFunction<any>,
-	notificationId?: FieldPolicy<any> | FieldReadFunction<any>
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  mentionPublication?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NewMirrorNotificationKeySpecifier = ('createdAt' | 'notificationId' | 'profile' | 'publication' | NewMirrorNotificationKeySpecifier)[];
+export type NewMirrorNotificationKeySpecifier = (
+  | 'createdAt'
+  | 'notificationId'
+  | 'profile'
+  | 'publication'
+  | NewMirrorNotificationKeySpecifier
+)[];
 export type NewMirrorNotificationFieldPolicy = {
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	notificationId?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	publication?: FieldPolicy<any> | FieldReadFunction<any>
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationId?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  publication?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NewReactionNotificationKeySpecifier = ('createdAt' | 'notificationId' | 'profile' | 'publication' | 'reaction' | NewReactionNotificationKeySpecifier)[];
+export type NewReactionNotificationKeySpecifier = (
+  | 'createdAt'
+  | 'notificationId'
+  | 'profile'
+  | 'publication'
+  | 'reaction'
+  | NewReactionNotificationKeySpecifier
+)[];
 export type NewReactionNotificationFieldPolicy = {
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	notificationId?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	publication?: FieldPolicy<any> | FieldReadFunction<any>,
-	reaction?: FieldPolicy<any> | FieldReadFunction<any>
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  notificationId?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  publication?: FieldPolicy<any> | FieldReadFunction<any>;
+  reaction?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NftGalleryKeySpecifier = ('createdAt' | 'id' | 'items' | 'name' | 'profileId' | 'updatedAt' | NftGalleryKeySpecifier)[];
+export type NftGalleryKeySpecifier = (
+  | 'createdAt'
+  | 'id'
+  | 'items'
+  | 'name'
+  | 'profileId'
+  | 'updatedAt'
+  | NftGalleryKeySpecifier
+)[];
 export type NftGalleryFieldPolicy = {
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>,
-	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
+  updatedAt?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NftImageKeySpecifier = ('chainId' | 'contractAddress' | 'tokenId' | 'uri' | 'verified' | NftImageKeySpecifier)[];
+export type NftImageKeySpecifier = (
+  | 'chainId'
+  | 'contractAddress'
+  | 'tokenId'
+  | 'uri'
+  | 'verified'
+  | NftImageKeySpecifier
+)[];
 export type NftImageFieldPolicy = {
-	chainId?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	tokenId?: FieldPolicy<any> | FieldReadFunction<any>,
-	uri?: FieldPolicy<any> | FieldReadFunction<any>,
-	verified?: FieldPolicy<any> | FieldReadFunction<any>
+  chainId?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  tokenId?: FieldPolicy<any> | FieldReadFunction<any>;
+  uri?: FieldPolicy<any> | FieldReadFunction<any>;
+  verified?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NftOwnershipChallengeResultKeySpecifier = ('id' | 'text' | 'timeout' | NftOwnershipChallengeResultKeySpecifier)[];
+export type NftOwnershipChallengeResultKeySpecifier = (
+  | 'id'
+  | 'text'
+  | 'timeout'
+  | NftOwnershipChallengeResultKeySpecifier
+)[];
 export type NftOwnershipChallengeResultFieldPolicy = {
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	text?: FieldPolicy<any> | FieldReadFunction<any>,
-	timeout?: FieldPolicy<any> | FieldReadFunction<any>
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  text?: FieldPolicy<any> | FieldReadFunction<any>;
+  timeout?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type NftOwnershipOutputKeySpecifier = ('chainID' | 'contractAddress' | 'contractType' | 'tokenIds' | NftOwnershipOutputKeySpecifier)[];
+export type NftOwnershipOutputKeySpecifier = (
+  | 'chainID'
+  | 'contractAddress'
+  | 'contractType'
+  | 'tokenIds'
+  | NftOwnershipOutputKeySpecifier
+)[];
 export type NftOwnershipOutputFieldPolicy = {
-	chainID?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractType?: FieldPolicy<any> | FieldReadFunction<any>,
-	tokenIds?: FieldPolicy<any> | FieldReadFunction<any>
+  chainID?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractType?: FieldPolicy<any> | FieldReadFunction<any>;
+  tokenIds?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type OnChainIdentityKeySpecifier = ('ens' | 'proofOfHumanity' | 'sybilDotOrg' | 'worldcoin' | OnChainIdentityKeySpecifier)[];
+export type OnChainIdentityKeySpecifier = (
+  | 'ens'
+  | 'proofOfHumanity'
+  | 'sybilDotOrg'
+  | 'worldcoin'
+  | OnChainIdentityKeySpecifier
+)[];
 export type OnChainIdentityFieldPolicy = {
-	ens?: FieldPolicy<any> | FieldReadFunction<any>,
-	proofOfHumanity?: FieldPolicy<any> | FieldReadFunction<any>,
-	sybilDotOrg?: FieldPolicy<any> | FieldReadFunction<any>,
-	worldcoin?: FieldPolicy<any> | FieldReadFunction<any>
+  ens?: FieldPolicy<any> | FieldReadFunction<any>;
+  proofOfHumanity?: FieldPolicy<any> | FieldReadFunction<any>;
+  sybilDotOrg?: FieldPolicy<any> | FieldReadFunction<any>;
+  worldcoin?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type OrConditionOutputKeySpecifier = ('criteria' | OrConditionOutputKeySpecifier)[];
 export type OrConditionOutputFieldPolicy = {
-	criteria?: FieldPolicy<any> | FieldReadFunction<any>
+  criteria?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type OwnerKeySpecifier = ('address' | 'amount' | OwnerKeySpecifier)[];
 export type OwnerFieldPolicy = {
-	address?: FieldPolicy<any> | FieldReadFunction<any>,
-	amount?: FieldPolicy<any> | FieldReadFunction<any>
+  address?: FieldPolicy<any> | FieldReadFunction<any>;
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedAllPublicationsTagsResultKeySpecifier = ('items' | 'pageInfo' | PaginatedAllPublicationsTagsResultKeySpecifier)[];
+export type PaginatedAllPublicationsTagsResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedAllPublicationsTagsResultKeySpecifier
+)[];
 export type PaginatedAllPublicationsTagsResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedFeedResultKeySpecifier = ('items' | 'pageInfo' | PaginatedFeedResultKeySpecifier)[];
+export type PaginatedFeedResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedFeedResultKeySpecifier
+)[];
 export type PaginatedFeedResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedFollowersResultKeySpecifier = ('items' | 'pageInfo' | PaginatedFollowersResultKeySpecifier)[];
+export type PaginatedFollowersResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedFollowersResultKeySpecifier
+)[];
 export type PaginatedFollowersResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedFollowingResultKeySpecifier = ('items' | 'pageInfo' | PaginatedFollowingResultKeySpecifier)[];
+export type PaginatedFollowingResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedFollowingResultKeySpecifier
+)[];
 export type PaginatedFollowingResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedNotificationResultKeySpecifier = ('items' | 'pageInfo' | PaginatedNotificationResultKeySpecifier)[];
+export type PaginatedNotificationResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedNotificationResultKeySpecifier
+)[];
 export type PaginatedNotificationResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedProfilePublicationsForSaleResultKeySpecifier = ('items' | 'pageInfo' | PaginatedProfilePublicationsForSaleResultKeySpecifier)[];
+export type PaginatedProfilePublicationsForSaleResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedProfilePublicationsForSaleResultKeySpecifier
+)[];
 export type PaginatedProfilePublicationsForSaleResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedProfileResultKeySpecifier = ('items' | 'pageInfo' | PaginatedProfileResultKeySpecifier)[];
+export type PaginatedProfileResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedProfileResultKeySpecifier
+)[];
 export type PaginatedProfileResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedPublicationResultKeySpecifier = ('items' | 'pageInfo' | PaginatedPublicationResultKeySpecifier)[];
+export type PaginatedPublicationResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedPublicationResultKeySpecifier
+)[];
 export type PaginatedPublicationResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedResultInfoKeySpecifier = ('next' | 'prev' | 'totalCount' | PaginatedResultInfoKeySpecifier)[];
+export type PaginatedResultInfoKeySpecifier = (
+  | 'next'
+  | 'prev'
+  | 'totalCount'
+  | PaginatedResultInfoKeySpecifier
+)[];
 export type PaginatedResultInfoFieldPolicy = {
-	next?: FieldPolicy<any> | FieldReadFunction<any>,
-	prev?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+  next?: FieldPolicy<any> | FieldReadFunction<any>;
+  prev?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalCount?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedTimelineResultKeySpecifier = ('items' | 'pageInfo' | PaginatedTimelineResultKeySpecifier)[];
+export type PaginatedTimelineResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedTimelineResultKeySpecifier
+)[];
 export type PaginatedTimelineResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedWhoCollectedResultKeySpecifier = ('items' | 'pageInfo' | PaginatedWhoCollectedResultKeySpecifier)[];
+export type PaginatedWhoCollectedResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedWhoCollectedResultKeySpecifier
+)[];
 export type PaginatedWhoCollectedResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PaginatedWhoReactedResultKeySpecifier = ('items' | 'pageInfo' | PaginatedWhoReactedResultKeySpecifier)[];
+export type PaginatedWhoReactedResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PaginatedWhoReactedResultKeySpecifier
+)[];
 export type PaginatedWhoReactedResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PendingApproveFollowsResultKeySpecifier = ('items' | 'pageInfo' | PendingApproveFollowsResultKeySpecifier)[];
+export type PendingApproveFollowsResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | PendingApproveFollowsResultKeySpecifier
+)[];
 export type PendingApproveFollowsResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PendingPostKeySpecifier = ('content' | 'id' | 'locale' | 'mainContentFocus' | 'media' | 'profile' | PendingPostKeySpecifier)[];
+export type PendingPostKeySpecifier = (
+  | 'content'
+  | 'id'
+  | 'locale'
+  | 'mainContentFocus'
+  | 'media'
+  | 'profile'
+  | PendingPostKeySpecifier
+)[];
 export type PendingPostFieldPolicy = {
-	content?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	locale?: FieldPolicy<any> | FieldReadFunction<any>,
-	mainContentFocus?: FieldPolicy<any> | FieldReadFunction<any>,
-	media?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>
+  content?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  locale?: FieldPolicy<any> | FieldReadFunction<any>;
+  mainContentFocus?: FieldPolicy<any> | FieldReadFunction<any>;
+  media?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PostKeySpecifier = ('appId' | 'canComment' | 'canDecrypt' | 'canMirror' | 'collectModule' | 'collectNftAddress' | 'collectPolicy' | 'collectedBy' | 'createdAt' | 'dataAvailabilityProofs' | 'decryptionCriteria' | 'hasCollectedByMe' | 'hasOptimisticCollectedByMe' | 'hidden' | 'id' | 'isDataAvailability' | 'isGated' | 'isOptimisticMirroredByMe' | 'metadata' | 'mirrors' | 'onChainContentURI' | 'profile' | 'reaction' | 'referenceModule' | 'referencePolicy' | 'stats' | PostKeySpecifier)[];
+export type PostKeySpecifier = (
+  | 'appId'
+  | 'canComment'
+  | 'canDecrypt'
+  | 'canMirror'
+  | 'collectModule'
+  | 'collectNftAddress'
+  | 'collectPolicy'
+  | 'collectedBy'
+  | 'createdAt'
+  | 'dataAvailabilityProofs'
+  | 'decryptionCriteria'
+  | 'hasCollectedByMe'
+  | 'hasOptimisticCollectedByMe'
+  | 'hidden'
+  | 'id'
+  | 'isDataAvailability'
+  | 'isGated'
+  | 'isOptimisticMirroredByMe'
+  | 'metadata'
+  | 'mirrors'
+  | 'onChainContentURI'
+  | 'profile'
+  | 'reaction'
+  | 'referenceModule'
+  | 'referencePolicy'
+  | 'stats'
+  | PostKeySpecifier
+)[];
 export type PostFieldPolicy = {
-	appId?: FieldPolicy<any> | FieldReadFunction<any>,
-	canComment?: FieldPolicy<any> | FieldReadFunction<any>,
-	canDecrypt?: FieldPolicy<any> | FieldReadFunction<any>,
-	canMirror?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectNftAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectPolicy?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectedBy?: FieldPolicy<any> | FieldReadFunction<any>,
-	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	dataAvailabilityProofs?: FieldPolicy<any> | FieldReadFunction<any>,
-	decryptionCriteria?: FieldPolicy<any> | FieldReadFunction<any>,
-	hasCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	hasOptimisticCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	hidden?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	isDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>,
-	isGated?: FieldPolicy<any> | FieldReadFunction<any>,
-	isOptimisticMirroredByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
-	mirrors?: FieldPolicy<any> | FieldReadFunction<any>,
-	onChainContentURI?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	reaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	referencePolicy?: FieldPolicy<any> | FieldReadFunction<any>,
-	stats?: FieldPolicy<any> | FieldReadFunction<any>
+  appId?: FieldPolicy<any> | FieldReadFunction<any>;
+  canComment?: FieldPolicy<any> | FieldReadFunction<any>;
+  canDecrypt?: FieldPolicy<any> | FieldReadFunction<any>;
+  canMirror?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectNftAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectPolicy?: FieldPolicy<any> | FieldReadFunction<any>;
+  collectedBy?: FieldPolicy<any> | FieldReadFunction<any>;
+  createdAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  dataAvailabilityProofs?: FieldPolicy<any> | FieldReadFunction<any>;
+  decryptionCriteria?: FieldPolicy<any> | FieldReadFunction<any>;
+  hasCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  hasOptimisticCollectedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  hidden?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  isDataAvailability?: FieldPolicy<any> | FieldReadFunction<any>;
+  isGated?: FieldPolicy<any> | FieldReadFunction<any>;
+  isOptimisticMirroredByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  metadata?: FieldPolicy<any> | FieldReadFunction<any>;
+  mirrors?: FieldPolicy<any> | FieldReadFunction<any>;
+  onChainContentURI?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  reaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  referencePolicy?: FieldPolicy<any> | FieldReadFunction<any>;
+  stats?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProfileKeySpecifier = ('attributes' | 'attributesMap' | 'bio' | 'coverPicture' | 'dispatcher' | 'followModule' | 'followNftAddress' | 'followPolicy' | 'followStatus' | 'handle' | 'id' | 'interests' | 'isDefault' | 'isFollowedByMe' | 'isFollowing' | 'metadata' | 'name' | 'onChainIdentity' | 'ownedBy' | 'ownedByMe' | 'picture' | 'stats' | ProfileKeySpecifier)[];
+export type ProfileKeySpecifier = (
+  | 'attributes'
+  | 'attributesMap'
+  | 'bio'
+  | 'coverPicture'
+  | 'dispatcher'
+  | 'followModule'
+  | 'followNftAddress'
+  | 'followPolicy'
+  | 'followStatus'
+  | 'handle'
+  | 'id'
+  | 'interests'
+  | 'isDefault'
+  | 'isFollowedByMe'
+  | 'isFollowing'
+  | 'metadata'
+  | 'name'
+  | 'onChainIdentity'
+  | 'ownedBy'
+  | 'ownedByMe'
+  | 'picture'
+  | 'stats'
+  | ProfileKeySpecifier
+)[];
 export type ProfileFieldPolicy = {
-	attributes?: FieldPolicy<any> | FieldReadFunction<any>,
-	attributesMap?: FieldPolicy<any> | FieldReadFunction<any>,
-	bio?: FieldPolicy<any> | FieldReadFunction<any>,
-	coverPicture?: FieldPolicy<any> | FieldReadFunction<any>,
-	dispatcher?: FieldPolicy<any> | FieldReadFunction<any>,
-	followModule?: FieldPolicy<any> | FieldReadFunction<any>,
-	followNftAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	followPolicy?: FieldPolicy<any> | FieldReadFunction<any>,
-	followStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-	handle?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	interests?: FieldPolicy<any> | FieldReadFunction<any>,
-	isDefault?: FieldPolicy<any> | FieldReadFunction<any>,
-	isFollowedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	isFollowing?: FieldPolicy<any> | FieldReadFunction<any>,
-	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
-	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	onChainIdentity?: FieldPolicy<any> | FieldReadFunction<any>,
-	ownedBy?: FieldPolicy<any> | FieldReadFunction<any>,
-	ownedByMe?: FieldPolicy<any> | FieldReadFunction<any>,
-	picture?: FieldPolicy<any> | FieldReadFunction<any>,
-	stats?: FieldPolicy<any> | FieldReadFunction<any>
+  attributes?: FieldPolicy<any> | FieldReadFunction<any>;
+  attributesMap?: FieldPolicy<any> | FieldReadFunction<any>;
+  bio?: FieldPolicy<any> | FieldReadFunction<any>;
+  coverPicture?: FieldPolicy<any> | FieldReadFunction<any>;
+  dispatcher?: FieldPolicy<any> | FieldReadFunction<any>;
+  followModule?: FieldPolicy<any> | FieldReadFunction<any>;
+  followNftAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  followPolicy?: FieldPolicy<any> | FieldReadFunction<any>;
+  followStatus?: FieldPolicy<any> | FieldReadFunction<any>;
+  handle?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  interests?: FieldPolicy<any> | FieldReadFunction<any>;
+  isDefault?: FieldPolicy<any> | FieldReadFunction<any>;
+  isFollowedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  isFollowing?: FieldPolicy<any> | FieldReadFunction<any>;
+  metadata?: FieldPolicy<any> | FieldReadFunction<any>;
+  name?: FieldPolicy<any> | FieldReadFunction<any>;
+  onChainIdentity?: FieldPolicy<any> | FieldReadFunction<any>;
+  ownedBy?: FieldPolicy<any> | FieldReadFunction<any>;
+  ownedByMe?: FieldPolicy<any> | FieldReadFunction<any>;
+  picture?: FieldPolicy<any> | FieldReadFunction<any>;
+  stats?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProfileFollowModuleSettingsKeySpecifier = ('contractAddress' | 'type' | ProfileFollowModuleSettingsKeySpecifier)[];
+export type ProfileFollowModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'type'
+  | ProfileFollowModuleSettingsKeySpecifier
+)[];
 export type ProfileFollowModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProfileOwnershipOutputKeySpecifier = ('profileId' | ProfileOwnershipOutputKeySpecifier)[];
+export type ProfileOwnershipOutputKeySpecifier = (
+  | 'profileId'
+  | ProfileOwnershipOutputKeySpecifier
+)[];
 export type ProfileOwnershipOutputFieldPolicy = {
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProfilePublicationRevenueResultKeySpecifier = ('items' | 'pageInfo' | ProfilePublicationRevenueResultKeySpecifier)[];
+export type ProfilePublicationRevenueResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | ProfilePublicationRevenueResultKeySpecifier
+)[];
 export type ProfilePublicationRevenueResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProfileSearchResultKeySpecifier = ('items' | 'pageInfo' | 'type' | ProfileSearchResultKeySpecifier)[];
+export type ProfileSearchResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | 'type'
+  | ProfileSearchResultKeySpecifier
+)[];
 export type ProfileSearchResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProfileStatsKeySpecifier = ('commentsTotal' | 'id' | 'mirrorsTotal' | 'postsTotal' | 'publicationsTotal' | 'totalCollects' | 'totalComments' | 'totalFollowers' | 'totalFollowing' | 'totalMirrors' | 'totalPosts' | 'totalPublications' | ProfileStatsKeySpecifier)[];
+export type ProfileStatsKeySpecifier = (
+  | 'commentsTotal'
+  | 'id'
+  | 'mirrorsTotal'
+  | 'postsTotal'
+  | 'publicationsTotal'
+  | 'totalCollects'
+  | 'totalComments'
+  | 'totalFollowers'
+  | 'totalFollowing'
+  | 'totalMirrors'
+  | 'totalPosts'
+  | 'totalPublications'
+  | ProfileStatsKeySpecifier
+)[];
 export type ProfileStatsFieldPolicy = {
-	commentsTotal?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	mirrorsTotal?: FieldPolicy<any> | FieldReadFunction<any>,
-	postsTotal?: FieldPolicy<any> | FieldReadFunction<any>,
-	publicationsTotal?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalCollects?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalComments?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalFollowers?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalFollowing?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalMirrors?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalPosts?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalPublications?: FieldPolicy<any> | FieldReadFunction<any>
+  commentsTotal?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  mirrorsTotal?: FieldPolicy<any> | FieldReadFunction<any>;
+  postsTotal?: FieldPolicy<any> | FieldReadFunction<any>;
+  publicationsTotal?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalCollects?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalComments?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalFollowers?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalFollowing?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalMirrors?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalPosts?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalPublications?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProviderSpecificParamsOutputKeySpecifier = ('encryptionKey' | ProviderSpecificParamsOutputKeySpecifier)[];
+export type ProviderSpecificParamsOutputKeySpecifier = (
+  | 'encryptionKey'
+  | ProviderSpecificParamsOutputKeySpecifier
+)[];
 export type ProviderSpecificParamsOutputFieldPolicy = {
-	encryptionKey?: FieldPolicy<any> | FieldReadFunction<any>
+  encryptionKey?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProxyActionErrorKeySpecifier = ('lastKnownTxId' | 'reason' | ProxyActionErrorKeySpecifier)[];
+export type ProxyActionErrorKeySpecifier = (
+  | 'lastKnownTxId'
+  | 'reason'
+  | ProxyActionErrorKeySpecifier
+)[];
 export type ProxyActionErrorFieldPolicy = {
-	lastKnownTxId?: FieldPolicy<any> | FieldReadFunction<any>,
-	reason?: FieldPolicy<any> | FieldReadFunction<any>
+  lastKnownTxId?: FieldPolicy<any> | FieldReadFunction<any>;
+  reason?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type ProxyActionQueuedKeySpecifier = ('queuedAt' | ProxyActionQueuedKeySpecifier)[];
 export type ProxyActionQueuedFieldPolicy = {
-	queuedAt?: FieldPolicy<any> | FieldReadFunction<any>
+  queuedAt?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ProxyActionStatusResultKeySpecifier = ('status' | 'txHash' | 'txId' | ProxyActionStatusResultKeySpecifier)[];
+export type ProxyActionStatusResultKeySpecifier = (
+  | 'status'
+  | 'txHash'
+  | 'txId'
+  | ProxyActionStatusResultKeySpecifier
+)[];
 export type ProxyActionStatusResultFieldPolicy = {
-	status?: FieldPolicy<any> | FieldReadFunction<any>,
-	txHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	txId?: FieldPolicy<any> | FieldReadFunction<any>
+  status?: FieldPolicy<any> | FieldReadFunction<any>;
+  txHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  txId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PublicMediaResultsKeySpecifier = ('media' | 'signedUrl' | PublicMediaResultsKeySpecifier)[];
+export type PublicMediaResultsKeySpecifier = (
+  | 'media'
+  | 'signedUrl'
+  | PublicMediaResultsKeySpecifier
+)[];
 export type PublicMediaResultsFieldPolicy = {
-	media?: FieldPolicy<any> | FieldReadFunction<any>,
-	signedUrl?: FieldPolicy<any> | FieldReadFunction<any>
+  media?: FieldPolicy<any> | FieldReadFunction<any>;
+  signedUrl?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PublicationMetadataStatusKeySpecifier = ('reason' | 'status' | PublicationMetadataStatusKeySpecifier)[];
+export type PublicationMetadataStatusKeySpecifier = (
+  | 'reason'
+  | 'status'
+  | PublicationMetadataStatusKeySpecifier
+)[];
 export type PublicationMetadataStatusFieldPolicy = {
-	reason?: FieldPolicy<any> | FieldReadFunction<any>,
-	status?: FieldPolicy<any> | FieldReadFunction<any>
+  reason?: FieldPolicy<any> | FieldReadFunction<any>;
+  status?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PublicationRevenueKeySpecifier = ('publication' | 'revenue' | PublicationRevenueKeySpecifier)[];
+export type PublicationRevenueKeySpecifier = (
+  | 'publication'
+  | 'revenue'
+  | PublicationRevenueKeySpecifier
+)[];
 export type PublicationRevenueFieldPolicy = {
-	publication?: FieldPolicy<any> | FieldReadFunction<any>,
-	revenue?: FieldPolicy<any> | FieldReadFunction<any>
+  publication?: FieldPolicy<any> | FieldReadFunction<any>;
+  revenue?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PublicationSearchResultKeySpecifier = ('items' | 'pageInfo' | 'type' | PublicationSearchResultKeySpecifier)[];
+export type PublicationSearchResultKeySpecifier = (
+  | 'items'
+  | 'pageInfo'
+  | 'type'
+  | PublicationSearchResultKeySpecifier
+)[];
 export type PublicationSearchResultFieldPolicy = {
-	items?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  items?: FieldPolicy<any> | FieldReadFunction<any>;
+  pageInfo?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PublicationStatsKeySpecifier = ('commentsTotal' | 'id' | 'totalAmountOfCollects' | 'totalAmountOfComments' | 'totalAmountOfMirrors' | 'totalDownvotes' | 'totalUpvotes' | PublicationStatsKeySpecifier)[];
+export type PublicationStatsKeySpecifier = (
+  | 'commentsTotal'
+  | 'id'
+  | 'totalAmountOfCollects'
+  | 'totalAmountOfComments'
+  | 'totalAmountOfMirrors'
+  | 'totalDownvotes'
+  | 'totalUpvotes'
+  | PublicationStatsKeySpecifier
+)[];
 export type PublicationStatsFieldPolicy = {
-	commentsTotal?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalAmountOfCollects?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalAmountOfComments?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalAmountOfMirrors?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalDownvotes?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalUpvotes?: FieldPolicy<any> | FieldReadFunction<any>
+  commentsTotal?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalAmountOfCollects?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalAmountOfComments?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalAmountOfMirrors?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalDownvotes?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalUpvotes?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type PublicationValidateMetadataResultKeySpecifier = ('reason' | 'valid' | PublicationValidateMetadataResultKeySpecifier)[];
+export type PublicationValidateMetadataResultKeySpecifier = (
+  | 'reason'
+  | 'valid'
+  | PublicationValidateMetadataResultKeySpecifier
+)[];
 export type PublicationValidateMetadataResultFieldPolicy = {
-	reason?: FieldPolicy<any> | FieldReadFunction<any>,
-	valid?: FieldPolicy<any> | FieldReadFunction<any>
+  reason?: FieldPolicy<any> | FieldReadFunction<any>;
+  valid?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type QueryKeySpecifier = ('allPublicationsTags' | 'approvedModuleAllowanceAmount' | 'challenge' | 'claimableHandles' | 'claimableStatus' | 'cur' | 'defaultProfile' | 'doesFollow' | 'enabledModuleCurrencies' | 'enabledModules' | 'exploreProfiles' | 'explorePublications' | 'feed' | 'feedHighlights' | 'followerNftOwnedTokenIds' | 'followers' | 'following' | 'gct' | 'gdm' | 'generateModuleCurrencyApprovalData' | 'globalProtocolStats' | 'hasTxHashBeenIndexed' | 'internalPublicationFilter' | 'isIDKitPhoneVerified' | 'mutualFollowersProfiles' | 'nftGalleries' | 'nftOwnershipChallenge' | 'nfts' | 'notifications' | 'pendingApprovalFollows' | 'ping' | 'profile' | 'profileFollowModuleBeenRedeemed' | 'profileFollowRevenue' | 'profileInterests' | 'profileOnChainIdentity' | 'profilePublicationRevenue' | 'profilePublicationsForSale' | 'profiles' | 'proxyActionStatus' | 'publication' | 'publicationMetadataStatus' | 'publicationRevenue' | 'publications' | 'recommendedProfiles' | 'rel' | 'search' | 'txIdToTxHash' | 'unknownEnabledModules' | 'userSigNonces' | 'validatePublicationMetadata' | 'verify' | 'whoCollectedPublication' | 'whoReactedPublication' | QueryKeySpecifier)[];
+export type QueryKeySpecifier = (
+  | 'allPublicationsTags'
+  | 'approvedModuleAllowanceAmount'
+  | 'challenge'
+  | 'claimableHandles'
+  | 'claimableStatus'
+  | 'cur'
+  | 'defaultProfile'
+  | 'doesFollow'
+  | 'enabledModuleCurrencies'
+  | 'enabledModules'
+  | 'exploreProfiles'
+  | 'explorePublications'
+  | 'feed'
+  | 'feedHighlights'
+  | 'followerNftOwnedTokenIds'
+  | 'followers'
+  | 'following'
+  | 'gct'
+  | 'gdm'
+  | 'generateModuleCurrencyApprovalData'
+  | 'globalProtocolStats'
+  | 'hasTxHashBeenIndexed'
+  | 'internalPublicationFilter'
+  | 'isIDKitPhoneVerified'
+  | 'mutualFollowersProfiles'
+  | 'nftGalleries'
+  | 'nftOwnershipChallenge'
+  | 'nfts'
+  | 'notifications'
+  | 'pendingApprovalFollows'
+  | 'ping'
+  | 'profile'
+  | 'profileFollowModuleBeenRedeemed'
+  | 'profileFollowRevenue'
+  | 'profileInterests'
+  | 'profileOnChainIdentity'
+  | 'profilePublicationRevenue'
+  | 'profilePublicationsForSale'
+  | 'profiles'
+  | 'proxyActionStatus'
+  | 'publication'
+  | 'publicationMetadataStatus'
+  | 'publicationRevenue'
+  | 'publications'
+  | 'recommendedProfiles'
+  | 'rel'
+  | 'search'
+  | 'txIdToTxHash'
+  | 'unknownEnabledModules'
+  | 'userSigNonces'
+  | 'validatePublicationMetadata'
+  | 'verify'
+  | 'whoCollectedPublication'
+  | 'whoReactedPublication'
+  | QueryKeySpecifier
+)[];
 export type QueryFieldPolicy = {
-	allPublicationsTags?: FieldPolicy<any> | FieldReadFunction<any>,
-	approvedModuleAllowanceAmount?: FieldPolicy<any> | FieldReadFunction<any>,
-	challenge?: FieldPolicy<any> | FieldReadFunction<any>,
-	claimableHandles?: FieldPolicy<any> | FieldReadFunction<any>,
-	claimableStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-	cur?: FieldPolicy<any> | FieldReadFunction<any>,
-	defaultProfile?: FieldPolicy<any> | FieldReadFunction<any>,
-	doesFollow?: FieldPolicy<any> | FieldReadFunction<any>,
-	enabledModuleCurrencies?: FieldPolicy<any> | FieldReadFunction<any>,
-	enabledModules?: FieldPolicy<any> | FieldReadFunction<any>,
-	exploreProfiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	explorePublications?: FieldPolicy<any> | FieldReadFunction<any>,
-	feed?: FieldPolicy<any> | FieldReadFunction<any>,
-	feedHighlights?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerNftOwnedTokenIds?: FieldPolicy<any> | FieldReadFunction<any>,
-	followers?: FieldPolicy<any> | FieldReadFunction<any>,
-	following?: FieldPolicy<any> | FieldReadFunction<any>,
-	gct?: FieldPolicy<any> | FieldReadFunction<any>,
-	gdm?: FieldPolicy<any> | FieldReadFunction<any>,
-	generateModuleCurrencyApprovalData?: FieldPolicy<any> | FieldReadFunction<any>,
-	globalProtocolStats?: FieldPolicy<any> | FieldReadFunction<any>,
-	hasTxHashBeenIndexed?: FieldPolicy<any> | FieldReadFunction<any>,
-	internalPublicationFilter?: FieldPolicy<any> | FieldReadFunction<any>,
-	isIDKitPhoneVerified?: FieldPolicy<any> | FieldReadFunction<any>,
-	mutualFollowersProfiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	nftGalleries?: FieldPolicy<any> | FieldReadFunction<any>,
-	nftOwnershipChallenge?: FieldPolicy<any> | FieldReadFunction<any>,
-	nfts?: FieldPolicy<any> | FieldReadFunction<any>,
-	notifications?: FieldPolicy<any> | FieldReadFunction<any>,
-	pendingApprovalFollows?: FieldPolicy<any> | FieldReadFunction<any>,
-	ping?: FieldPolicy<any> | FieldReadFunction<any>,
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileFollowModuleBeenRedeemed?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileFollowRevenue?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileInterests?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileOnChainIdentity?: FieldPolicy<any> | FieldReadFunction<any>,
-	profilePublicationRevenue?: FieldPolicy<any> | FieldReadFunction<any>,
-	profilePublicationsForSale?: FieldPolicy<any> | FieldReadFunction<any>,
-	profiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	proxyActionStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-	publication?: FieldPolicy<any> | FieldReadFunction<any>,
-	publicationMetadataStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-	publicationRevenue?: FieldPolicy<any> | FieldReadFunction<any>,
-	publications?: FieldPolicy<any> | FieldReadFunction<any>,
-	recommendedProfiles?: FieldPolicy<any> | FieldReadFunction<any>,
-	rel?: FieldPolicy<any> | FieldReadFunction<any>,
-	search?: FieldPolicy<any> | FieldReadFunction<any>,
-	txIdToTxHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	unknownEnabledModules?: FieldPolicy<any> | FieldReadFunction<any>,
-	userSigNonces?: FieldPolicy<any> | FieldReadFunction<any>,
-	validatePublicationMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
-	verify?: FieldPolicy<any> | FieldReadFunction<any>,
-	whoCollectedPublication?: FieldPolicy<any> | FieldReadFunction<any>,
-	whoReactedPublication?: FieldPolicy<any> | FieldReadFunction<any>
+  allPublicationsTags?: FieldPolicy<any> | FieldReadFunction<any>;
+  approvedModuleAllowanceAmount?: FieldPolicy<any> | FieldReadFunction<any>;
+  challenge?: FieldPolicy<any> | FieldReadFunction<any>;
+  claimableHandles?: FieldPolicy<any> | FieldReadFunction<any>;
+  claimableStatus?: FieldPolicy<any> | FieldReadFunction<any>;
+  cur?: FieldPolicy<any> | FieldReadFunction<any>;
+  defaultProfile?: FieldPolicy<any> | FieldReadFunction<any>;
+  doesFollow?: FieldPolicy<any> | FieldReadFunction<any>;
+  enabledModuleCurrencies?: FieldPolicy<any> | FieldReadFunction<any>;
+  enabledModules?: FieldPolicy<any> | FieldReadFunction<any>;
+  exploreProfiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  explorePublications?: FieldPolicy<any> | FieldReadFunction<any>;
+  feed?: FieldPolicy<any> | FieldReadFunction<any>;
+  feedHighlights?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerNftOwnedTokenIds?: FieldPolicy<any> | FieldReadFunction<any>;
+  followers?: FieldPolicy<any> | FieldReadFunction<any>;
+  following?: FieldPolicy<any> | FieldReadFunction<any>;
+  gct?: FieldPolicy<any> | FieldReadFunction<any>;
+  gdm?: FieldPolicy<any> | FieldReadFunction<any>;
+  generateModuleCurrencyApprovalData?: FieldPolicy<any> | FieldReadFunction<any>;
+  globalProtocolStats?: FieldPolicy<any> | FieldReadFunction<any>;
+  hasTxHashBeenIndexed?: FieldPolicy<any> | FieldReadFunction<any>;
+  internalPublicationFilter?: FieldPolicy<any> | FieldReadFunction<any>;
+  isIDKitPhoneVerified?: FieldPolicy<any> | FieldReadFunction<any>;
+  mutualFollowersProfiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  nftGalleries?: FieldPolicy<any> | FieldReadFunction<any>;
+  nftOwnershipChallenge?: FieldPolicy<any> | FieldReadFunction<any>;
+  nfts?: FieldPolicy<any> | FieldReadFunction<any>;
+  notifications?: FieldPolicy<any> | FieldReadFunction<any>;
+  pendingApprovalFollows?: FieldPolicy<any> | FieldReadFunction<any>;
+  ping?: FieldPolicy<any> | FieldReadFunction<any>;
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileFollowModuleBeenRedeemed?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileFollowRevenue?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileInterests?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileOnChainIdentity?: FieldPolicy<any> | FieldReadFunction<any>;
+  profilePublicationRevenue?: FieldPolicy<any> | FieldReadFunction<any>;
+  profilePublicationsForSale?: FieldPolicy<any> | FieldReadFunction<any>;
+  profiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  proxyActionStatus?: FieldPolicy<any> | FieldReadFunction<any>;
+  publication?: FieldPolicy<any> | FieldReadFunction<any>;
+  publicationMetadataStatus?: FieldPolicy<any> | FieldReadFunction<any>;
+  publicationRevenue?: FieldPolicy<any> | FieldReadFunction<any>;
+  publications?: FieldPolicy<any> | FieldReadFunction<any>;
+  recommendedProfiles?: FieldPolicy<any> | FieldReadFunction<any>;
+  rel?: FieldPolicy<any> | FieldReadFunction<any>;
+  search?: FieldPolicy<any> | FieldReadFunction<any>;
+  txIdToTxHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  unknownEnabledModules?: FieldPolicy<any> | FieldReadFunction<any>;
+  userSigNonces?: FieldPolicy<any> | FieldReadFunction<any>;
+  validatePublicationMetadata?: FieldPolicy<any> | FieldReadFunction<any>;
+  verify?: FieldPolicy<any> | FieldReadFunction<any>;
+  whoCollectedPublication?: FieldPolicy<any> | FieldReadFunction<any>;
+  whoReactedPublication?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ReactionEventKeySpecifier = ('profile' | 'reaction' | 'timestamp' | ReactionEventKeySpecifier)[];
+export type ReactionEventKeySpecifier = (
+  | 'profile'
+  | 'reaction'
+  | 'timestamp'
+  | ReactionEventKeySpecifier
+)[];
 export type ReactionEventFieldPolicy = {
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	reaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	timestamp?: FieldPolicy<any> | FieldReadFunction<any>
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  reaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  timestamp?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type RecipientDataOutputKeySpecifier = ('recipient' | 'split' | RecipientDataOutputKeySpecifier)[];
+export type RecipientDataOutputKeySpecifier = (
+  | 'recipient'
+  | 'split'
+  | RecipientDataOutputKeySpecifier
+)[];
 export type RecipientDataOutputFieldPolicy = {
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	split?: FieldPolicy<any> | FieldReadFunction<any>
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  split?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type RelayErrorKeySpecifier = ('reason' | RelayErrorKeySpecifier)[];
 export type RelayErrorFieldPolicy = {
-	reason?: FieldPolicy<any> | FieldReadFunction<any>
+  reason?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type RelayerResultKeySpecifier = ('txHash' | 'txId' | RelayerResultKeySpecifier)[];
 export type RelayerResultFieldPolicy = {
-	txHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	txId?: FieldPolicy<any> | FieldReadFunction<any>
+  txHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  txId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type ReservedClaimableHandleKeySpecifier = ('expiry' | 'handle' | 'id' | 'source' | ReservedClaimableHandleKeySpecifier)[];
+export type ReservedClaimableHandleKeySpecifier = (
+  | 'expiry'
+  | 'handle'
+  | 'id'
+  | 'source'
+  | ReservedClaimableHandleKeySpecifier
+)[];
 export type ReservedClaimableHandleFieldPolicy = {
-	expiry?: FieldPolicy<any> | FieldReadFunction<any>,
-	handle?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	source?: FieldPolicy<any> | FieldReadFunction<any>
+  expiry?: FieldPolicy<any> | FieldReadFunction<any>;
+  handle?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  source?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type RevenueAggregateKeySpecifier = ('total' | 'totalAmount' | RevenueAggregateKeySpecifier)[];
+export type RevenueAggregateKeySpecifier = (
+  | 'total'
+  | 'totalAmount'
+  | RevenueAggregateKeySpecifier
+)[];
 export type RevenueAggregateFieldPolicy = {
-	total?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalAmount?: FieldPolicy<any> | FieldReadFunction<any>
+  total?: FieldPolicy<any> | FieldReadFunction<any>;
+  totalAmount?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type RevertCollectModuleSettingsKeySpecifier = ('contractAddress' | 'type' | RevertCollectModuleSettingsKeySpecifier)[];
+export type RevertCollectModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'type'
+  | RevertCollectModuleSettingsKeySpecifier
+)[];
 export type RevertCollectModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type RevertFollowModuleSettingsKeySpecifier = ('contractAddress' | 'type' | RevertFollowModuleSettingsKeySpecifier)[];
+export type RevertFollowModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'type'
+  | RevertFollowModuleSettingsKeySpecifier
+)[];
 export type RevertFollowModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SetDefaultProfileBroadcastItemResultKeySpecifier = ('expiresAt' | 'id' | 'typedData' | SetDefaultProfileBroadcastItemResultKeySpecifier)[];
+export type SetDefaultProfileBroadcastItemResultKeySpecifier = (
+  | 'expiresAt'
+  | 'id'
+  | 'typedData'
+  | SetDefaultProfileBroadcastItemResultKeySpecifier
+)[];
 export type SetDefaultProfileBroadcastItemResultFieldPolicy = {
-	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	typedData?: FieldPolicy<any> | FieldReadFunction<any>
+  expiresAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  id?: FieldPolicy<any> | FieldReadFunction<any>;
+  typedData?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SetDefaultProfileEIP712TypedDataKeySpecifier = ('domain' | 'types' | 'value' | SetDefaultProfileEIP712TypedDataKeySpecifier)[];
+export type SetDefaultProfileEIP712TypedDataKeySpecifier = (
+  | 'domain'
+  | 'types'
+  | 'value'
+  | SetDefaultProfileEIP712TypedDataKeySpecifier
+)[];
 export type SetDefaultProfileEIP712TypedDataFieldPolicy = {
-	domain?: FieldPolicy<any> | FieldReadFunction<any>,
-	types?: FieldPolicy<any> | FieldReadFunction<any>,
-	value?: FieldPolicy<any> | FieldReadFunction<any>
+  domain?: FieldPolicy<any> | FieldReadFunction<any>;
+  types?: FieldPolicy<any> | FieldReadFunction<any>;
+  value?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SetDefaultProfileEIP712TypedDataTypesKeySpecifier = ('SetDefaultProfileWithSig' | SetDefaultProfileEIP712TypedDataTypesKeySpecifier)[];
+export type SetDefaultProfileEIP712TypedDataTypesKeySpecifier = (
+  | 'SetDefaultProfileWithSig'
+  | SetDefaultProfileEIP712TypedDataTypesKeySpecifier
+)[];
 export type SetDefaultProfileEIP712TypedDataTypesFieldPolicy = {
-	SetDefaultProfileWithSig?: FieldPolicy<any> | FieldReadFunction<any>
+  SetDefaultProfileWithSig?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SetDefaultProfileEIP712TypedDataValueKeySpecifier = ('deadline' | 'nonce' | 'profileId' | 'wallet' | SetDefaultProfileEIP712TypedDataValueKeySpecifier)[];
+export type SetDefaultProfileEIP712TypedDataValueKeySpecifier = (
+  | 'deadline'
+  | 'nonce'
+  | 'profileId'
+  | 'wallet'
+  | SetDefaultProfileEIP712TypedDataValueKeySpecifier
+)[];
 export type SetDefaultProfileEIP712TypedDataValueFieldPolicy = {
-	deadline?: FieldPolicy<any> | FieldReadFunction<any>,
-	nonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	profileId?: FieldPolicy<any> | FieldReadFunction<any>,
-	wallet?: FieldPolicy<any> | FieldReadFunction<any>
+  deadline?: FieldPolicy<any> | FieldReadFunction<any>;
+  nonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  profileId?: FieldPolicy<any> | FieldReadFunction<any>;
+  wallet?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SybilDotOrgIdentityKeySpecifier = ('source' | 'verified' | SybilDotOrgIdentityKeySpecifier)[];
+export type SybilDotOrgIdentityKeySpecifier = (
+  | 'source'
+  | 'verified'
+  | SybilDotOrgIdentityKeySpecifier
+)[];
 export type SybilDotOrgIdentityFieldPolicy = {
-	source?: FieldPolicy<any> | FieldReadFunction<any>,
-	verified?: FieldPolicy<any> | FieldReadFunction<any>
+  source?: FieldPolicy<any> | FieldReadFunction<any>;
+  verified?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SybilDotOrgIdentitySourceKeySpecifier = ('twitter' | SybilDotOrgIdentitySourceKeySpecifier)[];
+export type SybilDotOrgIdentitySourceKeySpecifier = (
+  | 'twitter'
+  | SybilDotOrgIdentitySourceKeySpecifier
+)[];
 export type SybilDotOrgIdentitySourceFieldPolicy = {
-	twitter?: FieldPolicy<any> | FieldReadFunction<any>
+  twitter?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type SybilDotOrgTwitterIdentityKeySpecifier = ('handle' | SybilDotOrgTwitterIdentityKeySpecifier)[];
+export type SybilDotOrgTwitterIdentityKeySpecifier = (
+  | 'handle'
+  | SybilDotOrgTwitterIdentityKeySpecifier
+)[];
 export type SybilDotOrgTwitterIdentityFieldPolicy = {
-	handle?: FieldPolicy<any> | FieldReadFunction<any>
+  handle?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type TagResultKeySpecifier = ('tag' | 'total' | TagResultKeySpecifier)[];
 export type TagResultFieldPolicy = {
-	tag?: FieldPolicy<any> | FieldReadFunction<any>,
-	total?: FieldPolicy<any> | FieldReadFunction<any>
+  tag?: FieldPolicy<any> | FieldReadFunction<any>;
+  total?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type TimedFeeCollectModuleSettingsKeySpecifier = ('amount' | 'contractAddress' | 'endTimestamp' | 'followerOnly' | 'recipient' | 'referralFee' | 'type' | TimedFeeCollectModuleSettingsKeySpecifier)[];
+export type TimedFeeCollectModuleSettingsKeySpecifier = (
+  | 'amount'
+  | 'contractAddress'
+  | 'endTimestamp'
+  | 'followerOnly'
+  | 'recipient'
+  | 'referralFee'
+  | 'type'
+  | TimedFeeCollectModuleSettingsKeySpecifier
+)[];
 export type TimedFeeCollectModuleSettingsFieldPolicy = {
-	amount?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-	followerOnly?: FieldPolicy<any> | FieldReadFunction<any>,
-	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
-	referralFee?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  amount?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  endTimestamp?: FieldPolicy<any> | FieldReadFunction<any>;
+  followerOnly?: FieldPolicy<any> | FieldReadFunction<any>;
+  recipient?: FieldPolicy<any> | FieldReadFunction<any>;
+  referralFee?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type TransactionErrorKeySpecifier = ('reason' | 'txReceipt' | TransactionErrorKeySpecifier)[];
+export type TransactionErrorKeySpecifier = (
+  | 'reason'
+  | 'txReceipt'
+  | TransactionErrorKeySpecifier
+)[];
 export type TransactionErrorFieldPolicy = {
-	reason?: FieldPolicy<any> | FieldReadFunction<any>,
-	txReceipt?: FieldPolicy<any> | FieldReadFunction<any>
+  reason?: FieldPolicy<any> | FieldReadFunction<any>;
+  txReceipt?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type TransactionIndexedResultKeySpecifier = ('indexed' | 'metadataStatus' | 'txHash' | 'txReceipt' | TransactionIndexedResultKeySpecifier)[];
+export type TransactionIndexedResultKeySpecifier = (
+  | 'indexed'
+  | 'metadataStatus'
+  | 'txHash'
+  | 'txReceipt'
+  | TransactionIndexedResultKeySpecifier
+)[];
 export type TransactionIndexedResultFieldPolicy = {
-	indexed?: FieldPolicy<any> | FieldReadFunction<any>,
-	metadataStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-	txHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	txReceipt?: FieldPolicy<any> | FieldReadFunction<any>
+  indexed?: FieldPolicy<any> | FieldReadFunction<any>;
+  metadataStatus?: FieldPolicy<any> | FieldReadFunction<any>;
+  txHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  txReceipt?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type TransactionReceiptKeySpecifier = ('blockHash' | 'blockNumber' | 'byzantium' | 'confirmations' | 'contractAddress' | 'cumulativeGasUsed' | 'effectiveGasPrice' | 'from' | 'gasUsed' | 'logs' | 'logsBloom' | 'root' | 'status' | 'to' | 'transactionHash' | 'transactionIndex' | 'type' | TransactionReceiptKeySpecifier)[];
+export type TransactionReceiptKeySpecifier = (
+  | 'blockHash'
+  | 'blockNumber'
+  | 'byzantium'
+  | 'confirmations'
+  | 'contractAddress'
+  | 'cumulativeGasUsed'
+  | 'effectiveGasPrice'
+  | 'from'
+  | 'gasUsed'
+  | 'logs'
+  | 'logsBloom'
+  | 'root'
+  | 'status'
+  | 'to'
+  | 'transactionHash'
+  | 'transactionIndex'
+  | 'type'
+  | TransactionReceiptKeySpecifier
+)[];
 export type TransactionReceiptFieldPolicy = {
-	blockHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	blockNumber?: FieldPolicy<any> | FieldReadFunction<any>,
-	byzantium?: FieldPolicy<any> | FieldReadFunction<any>,
-	confirmations?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	cumulativeGasUsed?: FieldPolicy<any> | FieldReadFunction<any>,
-	effectiveGasPrice?: FieldPolicy<any> | FieldReadFunction<any>,
-	from?: FieldPolicy<any> | FieldReadFunction<any>,
-	gasUsed?: FieldPolicy<any> | FieldReadFunction<any>,
-	logs?: FieldPolicy<any> | FieldReadFunction<any>,
-	logsBloom?: FieldPolicy<any> | FieldReadFunction<any>,
-	root?: FieldPolicy<any> | FieldReadFunction<any>,
-	status?: FieldPolicy<any> | FieldReadFunction<any>,
-	to?: FieldPolicy<any> | FieldReadFunction<any>,
-	transactionHash?: FieldPolicy<any> | FieldReadFunction<any>,
-	transactionIndex?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  blockHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  blockNumber?: FieldPolicy<any> | FieldReadFunction<any>;
+  byzantium?: FieldPolicy<any> | FieldReadFunction<any>;
+  confirmations?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  cumulativeGasUsed?: FieldPolicy<any> | FieldReadFunction<any>;
+  effectiveGasPrice?: FieldPolicy<any> | FieldReadFunction<any>;
+  from?: FieldPolicy<any> | FieldReadFunction<any>;
+  gasUsed?: FieldPolicy<any> | FieldReadFunction<any>;
+  logs?: FieldPolicy<any> | FieldReadFunction<any>;
+  logsBloom?: FieldPolicy<any> | FieldReadFunction<any>;
+  root?: FieldPolicy<any> | FieldReadFunction<any>;
+  status?: FieldPolicy<any> | FieldReadFunction<any>;
+  to?: FieldPolicy<any> | FieldReadFunction<any>;
+  transactionHash?: FieldPolicy<any> | FieldReadFunction<any>;
+  transactionIndex?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type UnknownCollectModuleSettingsKeySpecifier = ('collectModuleReturnData' | 'contractAddress' | 'type' | UnknownCollectModuleSettingsKeySpecifier)[];
+export type UnknownCollectModuleSettingsKeySpecifier = (
+  | 'collectModuleReturnData'
+  | 'contractAddress'
+  | 'type'
+  | UnknownCollectModuleSettingsKeySpecifier
+)[];
 export type UnknownCollectModuleSettingsFieldPolicy = {
-	collectModuleReturnData?: FieldPolicy<any> | FieldReadFunction<any>,
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  collectModuleReturnData?: FieldPolicy<any> | FieldReadFunction<any>;
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type UnknownFollowModuleSettingsKeySpecifier = ('contractAddress' | 'followModuleReturnData' | 'type' | UnknownFollowModuleSettingsKeySpecifier)[];
+export type UnknownFollowModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'followModuleReturnData'
+  | 'type'
+  | UnknownFollowModuleSettingsKeySpecifier
+)[];
 export type UnknownFollowModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	followModuleReturnData?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  followModuleReturnData?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type UnknownReferenceModuleSettingsKeySpecifier = ('contractAddress' | 'referenceModuleReturnData' | 'type' | UnknownReferenceModuleSettingsKeySpecifier)[];
+export type UnknownReferenceModuleSettingsKeySpecifier = (
+  | 'contractAddress'
+  | 'referenceModuleReturnData'
+  | 'type'
+  | UnknownReferenceModuleSettingsKeySpecifier
+)[];
 export type UnknownReferenceModuleSettingsFieldPolicy = {
-	contractAddress?: FieldPolicy<any> | FieldReadFunction<any>,
-	referenceModuleReturnData?: FieldPolicy<any> | FieldReadFunction<any>,
-	type?: FieldPolicy<any> | FieldReadFunction<any>
+  contractAddress?: FieldPolicy<any> | FieldReadFunction<any>;
+  referenceModuleReturnData?: FieldPolicy<any> | FieldReadFunction<any>;
+  type?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type UserSigNoncesKeySpecifier = ('lensHubOnChainSigNonce' | 'peripheryOnChainSigNonce' | UserSigNoncesKeySpecifier)[];
+export type UserSigNoncesKeySpecifier = (
+  | 'lensHubOnChainSigNonce'
+  | 'peripheryOnChainSigNonce'
+  | UserSigNoncesKeySpecifier
+)[];
 export type UserSigNoncesFieldPolicy = {
-	lensHubOnChainSigNonce?: FieldPolicy<any> | FieldReadFunction<any>,
-	peripheryOnChainSigNonce?: FieldPolicy<any> | FieldReadFunction<any>
+  lensHubOnChainSigNonce?: FieldPolicy<any> | FieldReadFunction<any>;
+  peripheryOnChainSigNonce?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type WalletKeySpecifier = ('address' | 'defaultProfile' | WalletKeySpecifier)[];
 export type WalletFieldPolicy = {
-	address?: FieldPolicy<any> | FieldReadFunction<any>,
-	defaultProfile?: FieldPolicy<any> | FieldReadFunction<any>
+  address?: FieldPolicy<any> | FieldReadFunction<any>;
+  defaultProfile?: FieldPolicy<any> | FieldReadFunction<any>;
 };
-export type WhoReactedResultKeySpecifier = ('profile' | 'reaction' | 'reactionAt' | 'reactionId' | WhoReactedResultKeySpecifier)[];
+export type WhoReactedResultKeySpecifier = (
+  | 'profile'
+  | 'reaction'
+  | 'reactionAt'
+  | 'reactionId'
+  | WhoReactedResultKeySpecifier
+)[];
 export type WhoReactedResultFieldPolicy = {
-	profile?: FieldPolicy<any> | FieldReadFunction<any>,
-	reaction?: FieldPolicy<any> | FieldReadFunction<any>,
-	reactionAt?: FieldPolicy<any> | FieldReadFunction<any>,
-	reactionId?: FieldPolicy<any> | FieldReadFunction<any>
+  profile?: FieldPolicy<any> | FieldReadFunction<any>;
+  reaction?: FieldPolicy<any> | FieldReadFunction<any>;
+  reactionAt?: FieldPolicy<any> | FieldReadFunction<any>;
+  reactionId?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type WorldcoinIdentityKeySpecifier = ('isHuman' | WorldcoinIdentityKeySpecifier)[];
 export type WorldcoinIdentityFieldPolicy = {
-	isHuman?: FieldPolicy<any> | FieldReadFunction<any>
+  isHuman?: FieldPolicy<any> | FieldReadFunction<any>;
 };
 export type StrictTypedTypePolicies = {
-	AaveFeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AaveFeeCollectModuleSettingsKeySpecifier | (() => undefined | AaveFeeCollectModuleSettingsKeySpecifier),
-		fields?: AaveFeeCollectModuleSettingsFieldPolicy,
-	},
-	AccessConditionOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AccessConditionOutputKeySpecifier | (() => undefined | AccessConditionOutputKeySpecifier),
-		fields?: AccessConditionOutputFieldPolicy,
-	},
-	AndConditionOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AndConditionOutputKeySpecifier | (() => undefined | AndConditionOutputKeySpecifier),
-		fields?: AndConditionOutputFieldPolicy,
-	},
-	ApprovedAllowanceAmount?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ApprovedAllowanceAmountKeySpecifier | (() => undefined | ApprovedAllowanceAmountKeySpecifier),
-		fields?: ApprovedAllowanceAmountFieldPolicy,
-	},
-	Attribute?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AttributeKeySpecifier | (() => undefined | AttributeKeySpecifier),
-		fields?: AttributeFieldPolicy,
-	},
-	AuthChallengeResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AuthChallengeResultKeySpecifier | (() => undefined | AuthChallengeResultKeySpecifier),
-		fields?: AuthChallengeResultFieldPolicy,
-	},
-	AuthenticationResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AuthenticationResultKeySpecifier | (() => undefined | AuthenticationResultKeySpecifier),
-		fields?: AuthenticationResultFieldPolicy,
-	},
-	CanCommentResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CanCommentResponseKeySpecifier | (() => undefined | CanCommentResponseKeySpecifier),
-		fields?: CanCommentResponseFieldPolicy,
-	},
-	CanDecryptResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CanDecryptResponseKeySpecifier | (() => undefined | CanDecryptResponseKeySpecifier),
-		fields?: CanDecryptResponseFieldPolicy,
-	},
-	CanMirrorResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CanMirrorResponseKeySpecifier | (() => undefined | CanMirrorResponseKeySpecifier),
-		fields?: CanMirrorResponseFieldPolicy,
-	},
-	ClaimableHandles?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ClaimableHandlesKeySpecifier | (() => undefined | ClaimableHandlesKeySpecifier),
-		fields?: ClaimableHandlesFieldPolicy,
-	},
-	CollectConditionOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CollectConditionOutputKeySpecifier | (() => undefined | CollectConditionOutputKeySpecifier),
-		fields?: CollectConditionOutputFieldPolicy,
-	},
-	CollectedEvent?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CollectedEventKeySpecifier | (() => undefined | CollectedEventKeySpecifier),
-		fields?: CollectedEventFieldPolicy,
-	},
-	Comment?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CommentKeySpecifier | (() => undefined | CommentKeySpecifier),
-		fields?: CommentFieldPolicy,
-	},
-	CreateBurnEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateBurnEIP712TypedDataKeySpecifier | (() => undefined | CreateBurnEIP712TypedDataKeySpecifier),
-		fields?: CreateBurnEIP712TypedDataFieldPolicy,
-	},
-	CreateBurnEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateBurnEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateBurnEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateBurnEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateBurnEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateBurnEIP712TypedDataValueKeySpecifier | (() => undefined | CreateBurnEIP712TypedDataValueKeySpecifier),
-		fields?: CreateBurnEIP712TypedDataValueFieldPolicy,
-	},
-	CreateBurnProfileBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateBurnProfileBroadcastItemResultKeySpecifier | (() => undefined | CreateBurnProfileBroadcastItemResultKeySpecifier),
-		fields?: CreateBurnProfileBroadcastItemResultFieldPolicy,
-	},
-	CreateCollectBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCollectBroadcastItemResultKeySpecifier | (() => undefined | CreateCollectBroadcastItemResultKeySpecifier),
-		fields?: CreateCollectBroadcastItemResultFieldPolicy,
-	},
-	CreateCollectEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCollectEIP712TypedDataKeySpecifier | (() => undefined | CreateCollectEIP712TypedDataKeySpecifier),
-		fields?: CreateCollectEIP712TypedDataFieldPolicy,
-	},
-	CreateCollectEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCollectEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateCollectEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateCollectEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateCollectEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCollectEIP712TypedDataValueKeySpecifier | (() => undefined | CreateCollectEIP712TypedDataValueKeySpecifier),
-		fields?: CreateCollectEIP712TypedDataValueFieldPolicy,
-	},
-	CreateCommentBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCommentBroadcastItemResultKeySpecifier | (() => undefined | CreateCommentBroadcastItemResultKeySpecifier),
-		fields?: CreateCommentBroadcastItemResultFieldPolicy,
-	},
-	CreateCommentEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCommentEIP712TypedDataKeySpecifier | (() => undefined | CreateCommentEIP712TypedDataKeySpecifier),
-		fields?: CreateCommentEIP712TypedDataFieldPolicy,
-	},
-	CreateCommentEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCommentEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateCommentEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateCommentEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateCommentEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateCommentEIP712TypedDataValueKeySpecifier | (() => undefined | CreateCommentEIP712TypedDataValueKeySpecifier),
-		fields?: CreateCommentEIP712TypedDataValueFieldPolicy,
-	},
-	CreateDataAvailabilityPublicationResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateDataAvailabilityPublicationResultKeySpecifier | (() => undefined | CreateDataAvailabilityPublicationResultKeySpecifier),
-		fields?: CreateDataAvailabilityPublicationResultFieldPolicy,
-	},
-	CreateFollowBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateFollowBroadcastItemResultKeySpecifier | (() => undefined | CreateFollowBroadcastItemResultKeySpecifier),
-		fields?: CreateFollowBroadcastItemResultFieldPolicy,
-	},
-	CreateFollowEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateFollowEIP712TypedDataKeySpecifier | (() => undefined | CreateFollowEIP712TypedDataKeySpecifier),
-		fields?: CreateFollowEIP712TypedDataFieldPolicy,
-	},
-	CreateFollowEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateFollowEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateFollowEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateFollowEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateFollowEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateFollowEIP712TypedDataValueKeySpecifier | (() => undefined | CreateFollowEIP712TypedDataValueKeySpecifier),
-		fields?: CreateFollowEIP712TypedDataValueFieldPolicy,
-	},
-	CreateMirrorBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateMirrorBroadcastItemResultKeySpecifier | (() => undefined | CreateMirrorBroadcastItemResultKeySpecifier),
-		fields?: CreateMirrorBroadcastItemResultFieldPolicy,
-	},
-	CreateMirrorEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateMirrorEIP712TypedDataKeySpecifier | (() => undefined | CreateMirrorEIP712TypedDataKeySpecifier),
-		fields?: CreateMirrorEIP712TypedDataFieldPolicy,
-	},
-	CreateMirrorEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateMirrorEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateMirrorEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateMirrorEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateMirrorEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateMirrorEIP712TypedDataValueKeySpecifier | (() => undefined | CreateMirrorEIP712TypedDataValueKeySpecifier),
-		fields?: CreateMirrorEIP712TypedDataValueFieldPolicy,
-	},
-	CreatePostBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreatePostBroadcastItemResultKeySpecifier | (() => undefined | CreatePostBroadcastItemResultKeySpecifier),
-		fields?: CreatePostBroadcastItemResultFieldPolicy,
-	},
-	CreatePostEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreatePostEIP712TypedDataKeySpecifier | (() => undefined | CreatePostEIP712TypedDataKeySpecifier),
-		fields?: CreatePostEIP712TypedDataFieldPolicy,
-	},
-	CreatePostEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreatePostEIP712TypedDataTypesKeySpecifier | (() => undefined | CreatePostEIP712TypedDataTypesKeySpecifier),
-		fields?: CreatePostEIP712TypedDataTypesFieldPolicy,
-	},
-	CreatePostEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreatePostEIP712TypedDataValueKeySpecifier | (() => undefined | CreatePostEIP712TypedDataValueKeySpecifier),
-		fields?: CreatePostEIP712TypedDataValueFieldPolicy,
-	},
-	CreateSetDispatcherBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetDispatcherBroadcastItemResultKeySpecifier | (() => undefined | CreateSetDispatcherBroadcastItemResultKeySpecifier),
-		fields?: CreateSetDispatcherBroadcastItemResultFieldPolicy,
-	},
-	CreateSetDispatcherEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetDispatcherEIP712TypedDataKeySpecifier | (() => undefined | CreateSetDispatcherEIP712TypedDataKeySpecifier),
-		fields?: CreateSetDispatcherEIP712TypedDataFieldPolicy,
-	},
-	CreateSetDispatcherEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetDispatcherEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateSetDispatcherEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateSetDispatcherEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateSetDispatcherEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetDispatcherEIP712TypedDataValueKeySpecifier | (() => undefined | CreateSetDispatcherEIP712TypedDataValueKeySpecifier),
-		fields?: CreateSetDispatcherEIP712TypedDataValueFieldPolicy,
-	},
-	CreateSetFollowModuleBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowModuleBroadcastItemResultKeySpecifier | (() => undefined | CreateSetFollowModuleBroadcastItemResultKeySpecifier),
-		fields?: CreateSetFollowModuleBroadcastItemResultFieldPolicy,
-	},
-	CreateSetFollowModuleEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowModuleEIP712TypedDataKeySpecifier | (() => undefined | CreateSetFollowModuleEIP712TypedDataKeySpecifier),
-		fields?: CreateSetFollowModuleEIP712TypedDataFieldPolicy,
-	},
-	CreateSetFollowModuleEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateSetFollowModuleEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateSetFollowModuleEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowModuleEIP712TypedDataValueKeySpecifier | (() => undefined | CreateSetFollowModuleEIP712TypedDataValueKeySpecifier),
-		fields?: CreateSetFollowModuleEIP712TypedDataValueFieldPolicy,
-	},
-	CreateSetFollowNFTUriBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowNFTUriBroadcastItemResultKeySpecifier | (() => undefined | CreateSetFollowNFTUriBroadcastItemResultKeySpecifier),
-		fields?: CreateSetFollowNFTUriBroadcastItemResultFieldPolicy,
-	},
-	CreateSetFollowNFTUriEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowNFTUriEIP712TypedDataKeySpecifier | (() => undefined | CreateSetFollowNFTUriEIP712TypedDataKeySpecifier),
-		fields?: CreateSetFollowNFTUriEIP712TypedDataFieldPolicy,
-	},
-	CreateSetFollowNFTUriEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateSetFollowNFTUriEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateSetFollowNFTUriEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier | (() => undefined | CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier),
-		fields?: CreateSetFollowNFTUriEIP712TypedDataValueFieldPolicy,
-	},
-	CreateSetProfileImageUriBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileImageUriBroadcastItemResultKeySpecifier | (() => undefined | CreateSetProfileImageUriBroadcastItemResultKeySpecifier),
-		fields?: CreateSetProfileImageUriBroadcastItemResultFieldPolicy,
-	},
-	CreateSetProfileImageUriEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileImageUriEIP712TypedDataKeySpecifier | (() => undefined | CreateSetProfileImageUriEIP712TypedDataKeySpecifier),
-		fields?: CreateSetProfileImageUriEIP712TypedDataFieldPolicy,
-	},
-	CreateSetProfileImageUriEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateSetProfileImageUriEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateSetProfileImageUriEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier | (() => undefined | CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier),
-		fields?: CreateSetProfileImageUriEIP712TypedDataValueFieldPolicy,
-	},
-	CreateSetProfileMetadataURIBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier | (() => undefined | CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier),
-		fields?: CreateSetProfileMetadataURIBroadcastItemResultFieldPolicy,
-	},
-	CreateSetProfileMetadataURIEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier | (() => undefined | CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier),
-		fields?: CreateSetProfileMetadataURIEIP712TypedDataFieldPolicy,
-	},
-	CreateSetProfileMetadataURIEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateSetProfileMetadataURIEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateSetProfileMetadataURIEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier | (() => undefined | CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier),
-		fields?: CreateSetProfileMetadataURIEIP712TypedDataValueFieldPolicy,
-	},
-	CreateToggleFollowBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateToggleFollowBroadcastItemResultKeySpecifier | (() => undefined | CreateToggleFollowBroadcastItemResultKeySpecifier),
-		fields?: CreateToggleFollowBroadcastItemResultFieldPolicy,
-	},
-	CreateToggleFollowEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateToggleFollowEIP712TypedDataKeySpecifier | (() => undefined | CreateToggleFollowEIP712TypedDataKeySpecifier),
-		fields?: CreateToggleFollowEIP712TypedDataFieldPolicy,
-	},
-	CreateToggleFollowEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateToggleFollowEIP712TypedDataTypesKeySpecifier | (() => undefined | CreateToggleFollowEIP712TypedDataTypesKeySpecifier),
-		fields?: CreateToggleFollowEIP712TypedDataTypesFieldPolicy,
-	},
-	CreateToggleFollowEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateToggleFollowEIP712TypedDataValueKeySpecifier | (() => undefined | CreateToggleFollowEIP712TypedDataValueKeySpecifier),
-		fields?: CreateToggleFollowEIP712TypedDataValueFieldPolicy,
-	},
-	CreateUnfollowBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | CreateUnfollowBroadcastItemResultKeySpecifier | (() => undefined | CreateUnfollowBroadcastItemResultKeySpecifier),
-		fields?: CreateUnfollowBroadcastItemResultFieldPolicy,
-	},
-	DegreesOfSeparationReferenceModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | DegreesOfSeparationReferenceModuleSettingsKeySpecifier | (() => undefined | DegreesOfSeparationReferenceModuleSettingsKeySpecifier),
-		fields?: DegreesOfSeparationReferenceModuleSettingsFieldPolicy,
-	},
-	Dispatcher?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | DispatcherKeySpecifier | (() => undefined | DispatcherKeySpecifier),
-		fields?: DispatcherFieldPolicy,
-	},
-	DoesFollowResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | DoesFollowResponseKeySpecifier | (() => undefined | DoesFollowResponseKeySpecifier),
-		fields?: DoesFollowResponseFieldPolicy,
-	},
-	EIP712TypedDataDomain?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EIP712TypedDataDomainKeySpecifier | (() => undefined | EIP712TypedDataDomainKeySpecifier),
-		fields?: EIP712TypedDataDomainFieldPolicy,
-	},
-	EIP712TypedDataField?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EIP712TypedDataFieldKeySpecifier | (() => undefined | EIP712TypedDataFieldKeySpecifier),
-		fields?: EIP712TypedDataFieldFieldPolicy,
-	},
-	ERC4626FeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ERC4626FeeCollectModuleSettingsKeySpecifier | (() => undefined | ERC4626FeeCollectModuleSettingsKeySpecifier),
-		fields?: ERC4626FeeCollectModuleSettingsFieldPolicy,
-	},
-	ElectedMirror?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ElectedMirrorKeySpecifier | (() => undefined | ElectedMirrorKeySpecifier),
-		fields?: ElectedMirrorFieldPolicy,
-	},
-	EnabledModule?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EnabledModuleKeySpecifier | (() => undefined | EnabledModuleKeySpecifier),
-		fields?: EnabledModuleFieldPolicy,
-	},
-	EnabledModules?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EnabledModulesKeySpecifier | (() => undefined | EnabledModulesKeySpecifier),
-		fields?: EnabledModulesFieldPolicy,
-	},
-	EncryptedFieldsOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EncryptedFieldsOutputKeySpecifier | (() => undefined | EncryptedFieldsOutputKeySpecifier),
-		fields?: EncryptedFieldsOutputFieldPolicy,
-	},
-	EncryptedMedia?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EncryptedMediaKeySpecifier | (() => undefined | EncryptedMediaKeySpecifier),
-		fields?: EncryptedMediaFieldPolicy,
-	},
-	EncryptedMediaSet?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EncryptedMediaSetKeySpecifier | (() => undefined | EncryptedMediaSetKeySpecifier),
-		fields?: EncryptedMediaSetFieldPolicy,
-	},
-	EncryptionParamsOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EncryptionParamsOutputKeySpecifier | (() => undefined | EncryptionParamsOutputKeySpecifier),
-		fields?: EncryptionParamsOutputFieldPolicy,
-	},
-	EnsOnChainIdentity?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EnsOnChainIdentityKeySpecifier | (() => undefined | EnsOnChainIdentityKeySpecifier),
-		fields?: EnsOnChainIdentityFieldPolicy,
-	},
-	EoaOwnershipOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | EoaOwnershipOutputKeySpecifier | (() => undefined | EoaOwnershipOutputKeySpecifier),
-		fields?: EoaOwnershipOutputFieldPolicy,
-	},
-	Erc20?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | Erc20KeySpecifier | (() => undefined | Erc20KeySpecifier),
-		fields?: Erc20FieldPolicy,
-	},
-	Erc20Amount?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | Erc20AmountKeySpecifier | (() => undefined | Erc20AmountKeySpecifier),
-		fields?: Erc20AmountFieldPolicy,
-	},
-	Erc20OwnershipOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | Erc20OwnershipOutputKeySpecifier | (() => undefined | Erc20OwnershipOutputKeySpecifier),
-		fields?: Erc20OwnershipOutputFieldPolicy,
-	},
-	ExploreProfileResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ExploreProfileResultKeySpecifier | (() => undefined | ExploreProfileResultKeySpecifier),
-		fields?: ExploreProfileResultFieldPolicy,
-	},
-	ExplorePublicationResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ExplorePublicationResultKeySpecifier | (() => undefined | ExplorePublicationResultKeySpecifier),
-		fields?: ExplorePublicationResultFieldPolicy,
-	},
-	FeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FeeCollectModuleSettingsKeySpecifier | (() => undefined | FeeCollectModuleSettingsKeySpecifier),
-		fields?: FeeCollectModuleSettingsFieldPolicy,
-	},
-	FeeFollowModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FeeFollowModuleSettingsKeySpecifier | (() => undefined | FeeFollowModuleSettingsKeySpecifier),
-		fields?: FeeFollowModuleSettingsFieldPolicy,
-	},
-	FeedItem?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FeedItemKeySpecifier | (() => undefined | FeedItemKeySpecifier),
-		fields?: FeedItemFieldPolicy,
-	},
-	FollowConditionOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FollowConditionOutputKeySpecifier | (() => undefined | FollowConditionOutputKeySpecifier),
-		fields?: FollowConditionOutputFieldPolicy,
-	},
-	FollowOnlyReferenceModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FollowOnlyReferenceModuleSettingsKeySpecifier | (() => undefined | FollowOnlyReferenceModuleSettingsKeySpecifier),
-		fields?: FollowOnlyReferenceModuleSettingsFieldPolicy,
-	},
-	FollowRevenueResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FollowRevenueResultKeySpecifier | (() => undefined | FollowRevenueResultKeySpecifier),
-		fields?: FollowRevenueResultFieldPolicy,
-	},
-	Follower?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FollowerKeySpecifier | (() => undefined | FollowerKeySpecifier),
-		fields?: FollowerFieldPolicy,
-	},
-	FollowerNftOwnedTokenIds?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FollowerNftOwnedTokenIdsKeySpecifier | (() => undefined | FollowerNftOwnedTokenIdsKeySpecifier),
-		fields?: FollowerNftOwnedTokenIdsFieldPolicy,
-	},
-	Following?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FollowingKeySpecifier | (() => undefined | FollowingKeySpecifier),
-		fields?: FollowingFieldPolicy,
-	},
-	FreeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | FreeCollectModuleSettingsKeySpecifier | (() => undefined | FreeCollectModuleSettingsKeySpecifier),
-		fields?: FreeCollectModuleSettingsFieldPolicy,
-	},
-	GenerateModuleCurrencyApproval?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | GenerateModuleCurrencyApprovalKeySpecifier | (() => undefined | GenerateModuleCurrencyApprovalKeySpecifier),
-		fields?: GenerateModuleCurrencyApprovalFieldPolicy,
-	},
-	GlobalProtocolStats?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | GlobalProtocolStatsKeySpecifier | (() => undefined | GlobalProtocolStatsKeySpecifier),
-		fields?: GlobalProtocolStatsFieldPolicy,
-	},
-	LimitedFeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | LimitedFeeCollectModuleSettingsKeySpecifier | (() => undefined | LimitedFeeCollectModuleSettingsKeySpecifier),
-		fields?: LimitedFeeCollectModuleSettingsFieldPolicy,
-	},
-	LimitedTimedFeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | LimitedTimedFeeCollectModuleSettingsKeySpecifier | (() => undefined | LimitedTimedFeeCollectModuleSettingsKeySpecifier),
-		fields?: LimitedTimedFeeCollectModuleSettingsFieldPolicy,
-	},
-	Log?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | LogKeySpecifier | (() => undefined | LogKeySpecifier),
-		fields?: LogFieldPolicy,
-	},
-	Media?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MediaKeySpecifier | (() => undefined | MediaKeySpecifier),
-		fields?: MediaFieldPolicy,
-	},
-	MediaOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MediaOutputKeySpecifier | (() => undefined | MediaOutputKeySpecifier),
-		fields?: MediaOutputFieldPolicy,
-	},
-	MediaSet?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MediaSetKeySpecifier | (() => undefined | MediaSetKeySpecifier),
-		fields?: MediaSetFieldPolicy,
-	},
-	MetadataAttributeOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MetadataAttributeOutputKeySpecifier | (() => undefined | MetadataAttributeOutputKeySpecifier),
-		fields?: MetadataAttributeOutputFieldPolicy,
-	},
-	MetadataOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MetadataOutputKeySpecifier | (() => undefined | MetadataOutputKeySpecifier),
-		fields?: MetadataOutputFieldPolicy,
-	},
-	Mirror?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MirrorKeySpecifier | (() => undefined | MirrorKeySpecifier),
-		fields?: MirrorFieldPolicy,
-	},
-	MirrorEvent?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MirrorEventKeySpecifier | (() => undefined | MirrorEventKeySpecifier),
-		fields?: MirrorEventFieldPolicy,
-	},
-	ModuleFeeAmount?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ModuleFeeAmountKeySpecifier | (() => undefined | ModuleFeeAmountKeySpecifier),
-		fields?: ModuleFeeAmountFieldPolicy,
-	},
-	ModuleInfo?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ModuleInfoKeySpecifier | (() => undefined | ModuleInfoKeySpecifier),
-		fields?: ModuleInfoFieldPolicy,
-	},
-	MultirecipientFeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MultirecipientFeeCollectModuleSettingsKeySpecifier | (() => undefined | MultirecipientFeeCollectModuleSettingsKeySpecifier),
-		fields?: MultirecipientFeeCollectModuleSettingsFieldPolicy,
-	},
-	Mutation?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | MutationKeySpecifier | (() => undefined | MutationKeySpecifier),
-		fields?: MutationFieldPolicy,
-	},
-	NFT?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NFTKeySpecifier | (() => undefined | NFTKeySpecifier),
-		fields?: NFTFieldPolicy,
-	},
-	NFTContent?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NFTContentKeySpecifier | (() => undefined | NFTContentKeySpecifier),
-		fields?: NFTContentFieldPolicy,
-	},
-	NFTsResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NFTsResultKeySpecifier | (() => undefined | NFTsResultKeySpecifier),
-		fields?: NFTsResultFieldPolicy,
-	},
-	NewCollectNotification?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NewCollectNotificationKeySpecifier | (() => undefined | NewCollectNotificationKeySpecifier),
-		fields?: NewCollectNotificationFieldPolicy,
-	},
-	NewCommentNotification?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NewCommentNotificationKeySpecifier | (() => undefined | NewCommentNotificationKeySpecifier),
-		fields?: NewCommentNotificationFieldPolicy,
-	},
-	NewFollowerNotification?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NewFollowerNotificationKeySpecifier | (() => undefined | NewFollowerNotificationKeySpecifier),
-		fields?: NewFollowerNotificationFieldPolicy,
-	},
-	NewMentionNotification?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NewMentionNotificationKeySpecifier | (() => undefined | NewMentionNotificationKeySpecifier),
-		fields?: NewMentionNotificationFieldPolicy,
-	},
-	NewMirrorNotification?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NewMirrorNotificationKeySpecifier | (() => undefined | NewMirrorNotificationKeySpecifier),
-		fields?: NewMirrorNotificationFieldPolicy,
-	},
-	NewReactionNotification?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NewReactionNotificationKeySpecifier | (() => undefined | NewReactionNotificationKeySpecifier),
-		fields?: NewReactionNotificationFieldPolicy,
-	},
-	NftGallery?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NftGalleryKeySpecifier | (() => undefined | NftGalleryKeySpecifier),
-		fields?: NftGalleryFieldPolicy,
-	},
-	NftImage?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NftImageKeySpecifier | (() => undefined | NftImageKeySpecifier),
-		fields?: NftImageFieldPolicy,
-	},
-	NftOwnershipChallengeResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NftOwnershipChallengeResultKeySpecifier | (() => undefined | NftOwnershipChallengeResultKeySpecifier),
-		fields?: NftOwnershipChallengeResultFieldPolicy,
-	},
-	NftOwnershipOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | NftOwnershipOutputKeySpecifier | (() => undefined | NftOwnershipOutputKeySpecifier),
-		fields?: NftOwnershipOutputFieldPolicy,
-	},
-	OnChainIdentity?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | OnChainIdentityKeySpecifier | (() => undefined | OnChainIdentityKeySpecifier),
-		fields?: OnChainIdentityFieldPolicy,
-	},
-	OrConditionOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | OrConditionOutputKeySpecifier | (() => undefined | OrConditionOutputKeySpecifier),
-		fields?: OrConditionOutputFieldPolicy,
-	},
-	Owner?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | OwnerKeySpecifier | (() => undefined | OwnerKeySpecifier),
-		fields?: OwnerFieldPolicy,
-	},
-	PaginatedAllPublicationsTagsResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedAllPublicationsTagsResultKeySpecifier | (() => undefined | PaginatedAllPublicationsTagsResultKeySpecifier),
-		fields?: PaginatedAllPublicationsTagsResultFieldPolicy,
-	},
-	PaginatedFeedResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedFeedResultKeySpecifier | (() => undefined | PaginatedFeedResultKeySpecifier),
-		fields?: PaginatedFeedResultFieldPolicy,
-	},
-	PaginatedFollowersResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedFollowersResultKeySpecifier | (() => undefined | PaginatedFollowersResultKeySpecifier),
-		fields?: PaginatedFollowersResultFieldPolicy,
-	},
-	PaginatedFollowingResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedFollowingResultKeySpecifier | (() => undefined | PaginatedFollowingResultKeySpecifier),
-		fields?: PaginatedFollowingResultFieldPolicy,
-	},
-	PaginatedNotificationResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedNotificationResultKeySpecifier | (() => undefined | PaginatedNotificationResultKeySpecifier),
-		fields?: PaginatedNotificationResultFieldPolicy,
-	},
-	PaginatedProfilePublicationsForSaleResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedProfilePublicationsForSaleResultKeySpecifier | (() => undefined | PaginatedProfilePublicationsForSaleResultKeySpecifier),
-		fields?: PaginatedProfilePublicationsForSaleResultFieldPolicy,
-	},
-	PaginatedProfileResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedProfileResultKeySpecifier | (() => undefined | PaginatedProfileResultKeySpecifier),
-		fields?: PaginatedProfileResultFieldPolicy,
-	},
-	PaginatedPublicationResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedPublicationResultKeySpecifier | (() => undefined | PaginatedPublicationResultKeySpecifier),
-		fields?: PaginatedPublicationResultFieldPolicy,
-	},
-	PaginatedResultInfo?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedResultInfoKeySpecifier | (() => undefined | PaginatedResultInfoKeySpecifier),
-		fields?: PaginatedResultInfoFieldPolicy,
-	},
-	PaginatedTimelineResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedTimelineResultKeySpecifier | (() => undefined | PaginatedTimelineResultKeySpecifier),
-		fields?: PaginatedTimelineResultFieldPolicy,
-	},
-	PaginatedWhoCollectedResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedWhoCollectedResultKeySpecifier | (() => undefined | PaginatedWhoCollectedResultKeySpecifier),
-		fields?: PaginatedWhoCollectedResultFieldPolicy,
-	},
-	PaginatedWhoReactedResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PaginatedWhoReactedResultKeySpecifier | (() => undefined | PaginatedWhoReactedResultKeySpecifier),
-		fields?: PaginatedWhoReactedResultFieldPolicy,
-	},
-	PendingApproveFollowsResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PendingApproveFollowsResultKeySpecifier | (() => undefined | PendingApproveFollowsResultKeySpecifier),
-		fields?: PendingApproveFollowsResultFieldPolicy,
-	},
-	PendingPost?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PendingPostKeySpecifier | (() => undefined | PendingPostKeySpecifier),
-		fields?: PendingPostFieldPolicy,
-	},
-	Post?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PostKeySpecifier | (() => undefined | PostKeySpecifier),
-		fields?: PostFieldPolicy,
-	},
-	Profile?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProfileKeySpecifier | (() => undefined | ProfileKeySpecifier),
-		fields?: ProfileFieldPolicy,
-	},
-	ProfileFollowModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProfileFollowModuleSettingsKeySpecifier | (() => undefined | ProfileFollowModuleSettingsKeySpecifier),
-		fields?: ProfileFollowModuleSettingsFieldPolicy,
-	},
-	ProfileOwnershipOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProfileOwnershipOutputKeySpecifier | (() => undefined | ProfileOwnershipOutputKeySpecifier),
-		fields?: ProfileOwnershipOutputFieldPolicy,
-	},
-	ProfilePublicationRevenueResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProfilePublicationRevenueResultKeySpecifier | (() => undefined | ProfilePublicationRevenueResultKeySpecifier),
-		fields?: ProfilePublicationRevenueResultFieldPolicy,
-	},
-	ProfileSearchResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProfileSearchResultKeySpecifier | (() => undefined | ProfileSearchResultKeySpecifier),
-		fields?: ProfileSearchResultFieldPolicy,
-	},
-	ProfileStats?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProfileStatsKeySpecifier | (() => undefined | ProfileStatsKeySpecifier),
-		fields?: ProfileStatsFieldPolicy,
-	},
-	ProviderSpecificParamsOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProviderSpecificParamsOutputKeySpecifier | (() => undefined | ProviderSpecificParamsOutputKeySpecifier),
-		fields?: ProviderSpecificParamsOutputFieldPolicy,
-	},
-	ProxyActionError?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProxyActionErrorKeySpecifier | (() => undefined | ProxyActionErrorKeySpecifier),
-		fields?: ProxyActionErrorFieldPolicy,
-	},
-	ProxyActionQueued?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProxyActionQueuedKeySpecifier | (() => undefined | ProxyActionQueuedKeySpecifier),
-		fields?: ProxyActionQueuedFieldPolicy,
-	},
-	ProxyActionStatusResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ProxyActionStatusResultKeySpecifier | (() => undefined | ProxyActionStatusResultKeySpecifier),
-		fields?: ProxyActionStatusResultFieldPolicy,
-	},
-	PublicMediaResults?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PublicMediaResultsKeySpecifier | (() => undefined | PublicMediaResultsKeySpecifier),
-		fields?: PublicMediaResultsFieldPolicy,
-	},
-	PublicationMetadataStatus?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PublicationMetadataStatusKeySpecifier | (() => undefined | PublicationMetadataStatusKeySpecifier),
-		fields?: PublicationMetadataStatusFieldPolicy,
-	},
-	PublicationRevenue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PublicationRevenueKeySpecifier | (() => undefined | PublicationRevenueKeySpecifier),
-		fields?: PublicationRevenueFieldPolicy,
-	},
-	PublicationSearchResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PublicationSearchResultKeySpecifier | (() => undefined | PublicationSearchResultKeySpecifier),
-		fields?: PublicationSearchResultFieldPolicy,
-	},
-	PublicationStats?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PublicationStatsKeySpecifier | (() => undefined | PublicationStatsKeySpecifier),
-		fields?: PublicationStatsFieldPolicy,
-	},
-	PublicationValidateMetadataResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | PublicationValidateMetadataResultKeySpecifier | (() => undefined | PublicationValidateMetadataResultKeySpecifier),
-		fields?: PublicationValidateMetadataResultFieldPolicy,
-	},
-	Query?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier),
-		fields?: QueryFieldPolicy,
-	},
-	ReactionEvent?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ReactionEventKeySpecifier | (() => undefined | ReactionEventKeySpecifier),
-		fields?: ReactionEventFieldPolicy,
-	},
-	RecipientDataOutput?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | RecipientDataOutputKeySpecifier | (() => undefined | RecipientDataOutputKeySpecifier),
-		fields?: RecipientDataOutputFieldPolicy,
-	},
-	RelayError?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | RelayErrorKeySpecifier | (() => undefined | RelayErrorKeySpecifier),
-		fields?: RelayErrorFieldPolicy,
-	},
-	RelayerResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | RelayerResultKeySpecifier | (() => undefined | RelayerResultKeySpecifier),
-		fields?: RelayerResultFieldPolicy,
-	},
-	ReservedClaimableHandle?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | ReservedClaimableHandleKeySpecifier | (() => undefined | ReservedClaimableHandleKeySpecifier),
-		fields?: ReservedClaimableHandleFieldPolicy,
-	},
-	RevenueAggregate?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | RevenueAggregateKeySpecifier | (() => undefined | RevenueAggregateKeySpecifier),
-		fields?: RevenueAggregateFieldPolicy,
-	},
-	RevertCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | RevertCollectModuleSettingsKeySpecifier | (() => undefined | RevertCollectModuleSettingsKeySpecifier),
-		fields?: RevertCollectModuleSettingsFieldPolicy,
-	},
-	RevertFollowModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | RevertFollowModuleSettingsKeySpecifier | (() => undefined | RevertFollowModuleSettingsKeySpecifier),
-		fields?: RevertFollowModuleSettingsFieldPolicy,
-	},
-	SetDefaultProfileBroadcastItemResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SetDefaultProfileBroadcastItemResultKeySpecifier | (() => undefined | SetDefaultProfileBroadcastItemResultKeySpecifier),
-		fields?: SetDefaultProfileBroadcastItemResultFieldPolicy,
-	},
-	SetDefaultProfileEIP712TypedData?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SetDefaultProfileEIP712TypedDataKeySpecifier | (() => undefined | SetDefaultProfileEIP712TypedDataKeySpecifier),
-		fields?: SetDefaultProfileEIP712TypedDataFieldPolicy,
-	},
-	SetDefaultProfileEIP712TypedDataTypes?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SetDefaultProfileEIP712TypedDataTypesKeySpecifier | (() => undefined | SetDefaultProfileEIP712TypedDataTypesKeySpecifier),
-		fields?: SetDefaultProfileEIP712TypedDataTypesFieldPolicy,
-	},
-	SetDefaultProfileEIP712TypedDataValue?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SetDefaultProfileEIP712TypedDataValueKeySpecifier | (() => undefined | SetDefaultProfileEIP712TypedDataValueKeySpecifier),
-		fields?: SetDefaultProfileEIP712TypedDataValueFieldPolicy,
-	},
-	SybilDotOrgIdentity?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SybilDotOrgIdentityKeySpecifier | (() => undefined | SybilDotOrgIdentityKeySpecifier),
-		fields?: SybilDotOrgIdentityFieldPolicy,
-	},
-	SybilDotOrgIdentitySource?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SybilDotOrgIdentitySourceKeySpecifier | (() => undefined | SybilDotOrgIdentitySourceKeySpecifier),
-		fields?: SybilDotOrgIdentitySourceFieldPolicy,
-	},
-	SybilDotOrgTwitterIdentity?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | SybilDotOrgTwitterIdentityKeySpecifier | (() => undefined | SybilDotOrgTwitterIdentityKeySpecifier),
-		fields?: SybilDotOrgTwitterIdentityFieldPolicy,
-	},
-	TagResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | TagResultKeySpecifier | (() => undefined | TagResultKeySpecifier),
-		fields?: TagResultFieldPolicy,
-	},
-	TimedFeeCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | TimedFeeCollectModuleSettingsKeySpecifier | (() => undefined | TimedFeeCollectModuleSettingsKeySpecifier),
-		fields?: TimedFeeCollectModuleSettingsFieldPolicy,
-	},
-	TransactionError?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | TransactionErrorKeySpecifier | (() => undefined | TransactionErrorKeySpecifier),
-		fields?: TransactionErrorFieldPolicy,
-	},
-	TransactionIndexedResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | TransactionIndexedResultKeySpecifier | (() => undefined | TransactionIndexedResultKeySpecifier),
-		fields?: TransactionIndexedResultFieldPolicy,
-	},
-	TransactionReceipt?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | TransactionReceiptKeySpecifier | (() => undefined | TransactionReceiptKeySpecifier),
-		fields?: TransactionReceiptFieldPolicy,
-	},
-	UnknownCollectModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | UnknownCollectModuleSettingsKeySpecifier | (() => undefined | UnknownCollectModuleSettingsKeySpecifier),
-		fields?: UnknownCollectModuleSettingsFieldPolicy,
-	},
-	UnknownFollowModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | UnknownFollowModuleSettingsKeySpecifier | (() => undefined | UnknownFollowModuleSettingsKeySpecifier),
-		fields?: UnknownFollowModuleSettingsFieldPolicy,
-	},
-	UnknownReferenceModuleSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | UnknownReferenceModuleSettingsKeySpecifier | (() => undefined | UnknownReferenceModuleSettingsKeySpecifier),
-		fields?: UnknownReferenceModuleSettingsFieldPolicy,
-	},
-	UserSigNonces?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | UserSigNoncesKeySpecifier | (() => undefined | UserSigNoncesKeySpecifier),
-		fields?: UserSigNoncesFieldPolicy,
-	},
-	Wallet?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | WalletKeySpecifier | (() => undefined | WalletKeySpecifier),
-		fields?: WalletFieldPolicy,
-	},
-	WhoReactedResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | WhoReactedResultKeySpecifier | (() => undefined | WhoReactedResultKeySpecifier),
-		fields?: WhoReactedResultFieldPolicy,
-	},
-	WorldcoinIdentity?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | WorldcoinIdentityKeySpecifier | (() => undefined | WorldcoinIdentityKeySpecifier),
-		fields?: WorldcoinIdentityFieldPolicy,
-	}
+  AaveFeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | AaveFeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | AaveFeeCollectModuleSettingsKeySpecifier);
+    fields?: AaveFeeCollectModuleSettingsFieldPolicy;
+  };
+  AccessConditionOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | AccessConditionOutputKeySpecifier
+      | (() => undefined | AccessConditionOutputKeySpecifier);
+    fields?: AccessConditionOutputFieldPolicy;
+  };
+  AndConditionOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | AndConditionOutputKeySpecifier
+      | (() => undefined | AndConditionOutputKeySpecifier);
+    fields?: AndConditionOutputFieldPolicy;
+  };
+  ApprovedAllowanceAmount?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ApprovedAllowanceAmountKeySpecifier
+      | (() => undefined | ApprovedAllowanceAmountKeySpecifier);
+    fields?: ApprovedAllowanceAmountFieldPolicy;
+  };
+  Attribute?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | AttributeKeySpecifier | (() => undefined | AttributeKeySpecifier);
+    fields?: AttributeFieldPolicy;
+  };
+  AuthChallengeResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | AuthChallengeResultKeySpecifier
+      | (() => undefined | AuthChallengeResultKeySpecifier);
+    fields?: AuthChallengeResultFieldPolicy;
+  };
+  AuthenticationResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | AuthenticationResultKeySpecifier
+      | (() => undefined | AuthenticationResultKeySpecifier);
+    fields?: AuthenticationResultFieldPolicy;
+  };
+  CanCommentResponse?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CanCommentResponseKeySpecifier
+      | (() => undefined | CanCommentResponseKeySpecifier);
+    fields?: CanCommentResponseFieldPolicy;
+  };
+  CanDecryptResponse?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CanDecryptResponseKeySpecifier
+      | (() => undefined | CanDecryptResponseKeySpecifier);
+    fields?: CanDecryptResponseFieldPolicy;
+  };
+  CanMirrorResponse?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CanMirrorResponseKeySpecifier
+      | (() => undefined | CanMirrorResponseKeySpecifier);
+    fields?: CanMirrorResponseFieldPolicy;
+  };
+  ClaimableHandles?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ClaimableHandlesKeySpecifier
+      | (() => undefined | ClaimableHandlesKeySpecifier);
+    fields?: ClaimableHandlesFieldPolicy;
+  };
+  CollectConditionOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CollectConditionOutputKeySpecifier
+      | (() => undefined | CollectConditionOutputKeySpecifier);
+    fields?: CollectConditionOutputFieldPolicy;
+  };
+  CollectedEvent?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | CollectedEventKeySpecifier | (() => undefined | CollectedEventKeySpecifier);
+    fields?: CollectedEventFieldPolicy;
+  };
+  Comment?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | CommentKeySpecifier | (() => undefined | CommentKeySpecifier);
+    fields?: CommentFieldPolicy;
+  };
+  CreateBurnEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateBurnEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateBurnEIP712TypedDataKeySpecifier);
+    fields?: CreateBurnEIP712TypedDataFieldPolicy;
+  };
+  CreateBurnEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateBurnEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateBurnEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateBurnEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateBurnEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateBurnEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateBurnEIP712TypedDataValueKeySpecifier);
+    fields?: CreateBurnEIP712TypedDataValueFieldPolicy;
+  };
+  CreateBurnProfileBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateBurnProfileBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateBurnProfileBroadcastItemResultKeySpecifier);
+    fields?: CreateBurnProfileBroadcastItemResultFieldPolicy;
+  };
+  CreateCollectBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCollectBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateCollectBroadcastItemResultKeySpecifier);
+    fields?: CreateCollectBroadcastItemResultFieldPolicy;
+  };
+  CreateCollectEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCollectEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateCollectEIP712TypedDataKeySpecifier);
+    fields?: CreateCollectEIP712TypedDataFieldPolicy;
+  };
+  CreateCollectEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCollectEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateCollectEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateCollectEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateCollectEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCollectEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateCollectEIP712TypedDataValueKeySpecifier);
+    fields?: CreateCollectEIP712TypedDataValueFieldPolicy;
+  };
+  CreateCommentBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCommentBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateCommentBroadcastItemResultKeySpecifier);
+    fields?: CreateCommentBroadcastItemResultFieldPolicy;
+  };
+  CreateCommentEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCommentEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateCommentEIP712TypedDataKeySpecifier);
+    fields?: CreateCommentEIP712TypedDataFieldPolicy;
+  };
+  CreateCommentEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCommentEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateCommentEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateCommentEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateCommentEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateCommentEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateCommentEIP712TypedDataValueKeySpecifier);
+    fields?: CreateCommentEIP712TypedDataValueFieldPolicy;
+  };
+  CreateDataAvailabilityPublicationResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateDataAvailabilityPublicationResultKeySpecifier
+      | (() => undefined | CreateDataAvailabilityPublicationResultKeySpecifier);
+    fields?: CreateDataAvailabilityPublicationResultFieldPolicy;
+  };
+  CreateFollowBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateFollowBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateFollowBroadcastItemResultKeySpecifier);
+    fields?: CreateFollowBroadcastItemResultFieldPolicy;
+  };
+  CreateFollowEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateFollowEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateFollowEIP712TypedDataKeySpecifier);
+    fields?: CreateFollowEIP712TypedDataFieldPolicy;
+  };
+  CreateFollowEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateFollowEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateFollowEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateFollowEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateFollowEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateFollowEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateFollowEIP712TypedDataValueKeySpecifier);
+    fields?: CreateFollowEIP712TypedDataValueFieldPolicy;
+  };
+  CreateMirrorBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateMirrorBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateMirrorBroadcastItemResultKeySpecifier);
+    fields?: CreateMirrorBroadcastItemResultFieldPolicy;
+  };
+  CreateMirrorEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateMirrorEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateMirrorEIP712TypedDataKeySpecifier);
+    fields?: CreateMirrorEIP712TypedDataFieldPolicy;
+  };
+  CreateMirrorEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateMirrorEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateMirrorEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateMirrorEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateMirrorEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateMirrorEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateMirrorEIP712TypedDataValueKeySpecifier);
+    fields?: CreateMirrorEIP712TypedDataValueFieldPolicy;
+  };
+  CreatePostBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreatePostBroadcastItemResultKeySpecifier
+      | (() => undefined | CreatePostBroadcastItemResultKeySpecifier);
+    fields?: CreatePostBroadcastItemResultFieldPolicy;
+  };
+  CreatePostEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreatePostEIP712TypedDataKeySpecifier
+      | (() => undefined | CreatePostEIP712TypedDataKeySpecifier);
+    fields?: CreatePostEIP712TypedDataFieldPolicy;
+  };
+  CreatePostEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreatePostEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreatePostEIP712TypedDataTypesKeySpecifier);
+    fields?: CreatePostEIP712TypedDataTypesFieldPolicy;
+  };
+  CreatePostEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreatePostEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreatePostEIP712TypedDataValueKeySpecifier);
+    fields?: CreatePostEIP712TypedDataValueFieldPolicy;
+  };
+  CreateSetDispatcherBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetDispatcherBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateSetDispatcherBroadcastItemResultKeySpecifier);
+    fields?: CreateSetDispatcherBroadcastItemResultFieldPolicy;
+  };
+  CreateSetDispatcherEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetDispatcherEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateSetDispatcherEIP712TypedDataKeySpecifier);
+    fields?: CreateSetDispatcherEIP712TypedDataFieldPolicy;
+  };
+  CreateSetDispatcherEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetDispatcherEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateSetDispatcherEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateSetDispatcherEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateSetDispatcherEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetDispatcherEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateSetDispatcherEIP712TypedDataValueKeySpecifier);
+    fields?: CreateSetDispatcherEIP712TypedDataValueFieldPolicy;
+  };
+  CreateSetFollowModuleBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowModuleBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateSetFollowModuleBroadcastItemResultKeySpecifier);
+    fields?: CreateSetFollowModuleBroadcastItemResultFieldPolicy;
+  };
+  CreateSetFollowModuleEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowModuleEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateSetFollowModuleEIP712TypedDataKeySpecifier);
+    fields?: CreateSetFollowModuleEIP712TypedDataFieldPolicy;
+  };
+  CreateSetFollowModuleEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateSetFollowModuleEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateSetFollowModuleEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateSetFollowModuleEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowModuleEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateSetFollowModuleEIP712TypedDataValueKeySpecifier);
+    fields?: CreateSetFollowModuleEIP712TypedDataValueFieldPolicy;
+  };
+  CreateSetFollowNFTUriBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowNFTUriBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateSetFollowNFTUriBroadcastItemResultKeySpecifier);
+    fields?: CreateSetFollowNFTUriBroadcastItemResultFieldPolicy;
+  };
+  CreateSetFollowNFTUriEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowNFTUriEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateSetFollowNFTUriEIP712TypedDataKeySpecifier);
+    fields?: CreateSetFollowNFTUriEIP712TypedDataFieldPolicy;
+  };
+  CreateSetFollowNFTUriEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateSetFollowNFTUriEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateSetFollowNFTUriEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateSetFollowNFTUriEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateSetFollowNFTUriEIP712TypedDataValueKeySpecifier);
+    fields?: CreateSetFollowNFTUriEIP712TypedDataValueFieldPolicy;
+  };
+  CreateSetProfileImageUriBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileImageUriBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateSetProfileImageUriBroadcastItemResultKeySpecifier);
+    fields?: CreateSetProfileImageUriBroadcastItemResultFieldPolicy;
+  };
+  CreateSetProfileImageUriEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileImageUriEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateSetProfileImageUriEIP712TypedDataKeySpecifier);
+    fields?: CreateSetProfileImageUriEIP712TypedDataFieldPolicy;
+  };
+  CreateSetProfileImageUriEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateSetProfileImageUriEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateSetProfileImageUriEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateSetProfileImageUriEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateSetProfileImageUriEIP712TypedDataValueKeySpecifier);
+    fields?: CreateSetProfileImageUriEIP712TypedDataValueFieldPolicy;
+  };
+  CreateSetProfileMetadataURIBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateSetProfileMetadataURIBroadcastItemResultKeySpecifier);
+    fields?: CreateSetProfileMetadataURIBroadcastItemResultFieldPolicy;
+  };
+  CreateSetProfileMetadataURIEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateSetProfileMetadataURIEIP712TypedDataKeySpecifier);
+    fields?: CreateSetProfileMetadataURIEIP712TypedDataFieldPolicy;
+  };
+  CreateSetProfileMetadataURIEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateSetProfileMetadataURIEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateSetProfileMetadataURIEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateSetProfileMetadataURIEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateSetProfileMetadataURIEIP712TypedDataValueKeySpecifier);
+    fields?: CreateSetProfileMetadataURIEIP712TypedDataValueFieldPolicy;
+  };
+  CreateToggleFollowBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateToggleFollowBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateToggleFollowBroadcastItemResultKeySpecifier);
+    fields?: CreateToggleFollowBroadcastItemResultFieldPolicy;
+  };
+  CreateToggleFollowEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateToggleFollowEIP712TypedDataKeySpecifier
+      | (() => undefined | CreateToggleFollowEIP712TypedDataKeySpecifier);
+    fields?: CreateToggleFollowEIP712TypedDataFieldPolicy;
+  };
+  CreateToggleFollowEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateToggleFollowEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | CreateToggleFollowEIP712TypedDataTypesKeySpecifier);
+    fields?: CreateToggleFollowEIP712TypedDataTypesFieldPolicy;
+  };
+  CreateToggleFollowEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateToggleFollowEIP712TypedDataValueKeySpecifier
+      | (() => undefined | CreateToggleFollowEIP712TypedDataValueKeySpecifier);
+    fields?: CreateToggleFollowEIP712TypedDataValueFieldPolicy;
+  };
+  CreateUnfollowBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | CreateUnfollowBroadcastItemResultKeySpecifier
+      | (() => undefined | CreateUnfollowBroadcastItemResultKeySpecifier);
+    fields?: CreateUnfollowBroadcastItemResultFieldPolicy;
+  };
+  DegreesOfSeparationReferenceModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | DegreesOfSeparationReferenceModuleSettingsKeySpecifier
+      | (() => undefined | DegreesOfSeparationReferenceModuleSettingsKeySpecifier);
+    fields?: DegreesOfSeparationReferenceModuleSettingsFieldPolicy;
+  };
+  Dispatcher?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | DispatcherKeySpecifier | (() => undefined | DispatcherKeySpecifier);
+    fields?: DispatcherFieldPolicy;
+  };
+  DoesFollowResponse?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | DoesFollowResponseKeySpecifier
+      | (() => undefined | DoesFollowResponseKeySpecifier);
+    fields?: DoesFollowResponseFieldPolicy;
+  };
+  EIP712TypedDataDomain?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EIP712TypedDataDomainKeySpecifier
+      | (() => undefined | EIP712TypedDataDomainKeySpecifier);
+    fields?: EIP712TypedDataDomainFieldPolicy;
+  };
+  EIP712TypedDataField?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EIP712TypedDataFieldKeySpecifier
+      | (() => undefined | EIP712TypedDataFieldKeySpecifier);
+    fields?: EIP712TypedDataFieldFieldPolicy;
+  };
+  ERC4626FeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ERC4626FeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | ERC4626FeeCollectModuleSettingsKeySpecifier);
+    fields?: ERC4626FeeCollectModuleSettingsFieldPolicy;
+  };
+  ElectedMirror?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | ElectedMirrorKeySpecifier | (() => undefined | ElectedMirrorKeySpecifier);
+    fields?: ElectedMirrorFieldPolicy;
+  };
+  EnabledModule?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | EnabledModuleKeySpecifier | (() => undefined | EnabledModuleKeySpecifier);
+    fields?: EnabledModuleFieldPolicy;
+  };
+  EnabledModules?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | EnabledModulesKeySpecifier | (() => undefined | EnabledModulesKeySpecifier);
+    fields?: EnabledModulesFieldPolicy;
+  };
+  EncryptedFieldsOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EncryptedFieldsOutputKeySpecifier
+      | (() => undefined | EncryptedFieldsOutputKeySpecifier);
+    fields?: EncryptedFieldsOutputFieldPolicy;
+  };
+  EncryptedMedia?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | EncryptedMediaKeySpecifier | (() => undefined | EncryptedMediaKeySpecifier);
+    fields?: EncryptedMediaFieldPolicy;
+  };
+  EncryptedMediaSet?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EncryptedMediaSetKeySpecifier
+      | (() => undefined | EncryptedMediaSetKeySpecifier);
+    fields?: EncryptedMediaSetFieldPolicy;
+  };
+  EncryptionParamsOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EncryptionParamsOutputKeySpecifier
+      | (() => undefined | EncryptionParamsOutputKeySpecifier);
+    fields?: EncryptionParamsOutputFieldPolicy;
+  };
+  EnsOnChainIdentity?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EnsOnChainIdentityKeySpecifier
+      | (() => undefined | EnsOnChainIdentityKeySpecifier);
+    fields?: EnsOnChainIdentityFieldPolicy;
+  };
+  EoaOwnershipOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | EoaOwnershipOutputKeySpecifier
+      | (() => undefined | EoaOwnershipOutputKeySpecifier);
+    fields?: EoaOwnershipOutputFieldPolicy;
+  };
+  Erc20?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | Erc20KeySpecifier | (() => undefined | Erc20KeySpecifier);
+    fields?: Erc20FieldPolicy;
+  };
+  Erc20Amount?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | Erc20AmountKeySpecifier | (() => undefined | Erc20AmountKeySpecifier);
+    fields?: Erc20AmountFieldPolicy;
+  };
+  Erc20OwnershipOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | Erc20OwnershipOutputKeySpecifier
+      | (() => undefined | Erc20OwnershipOutputKeySpecifier);
+    fields?: Erc20OwnershipOutputFieldPolicy;
+  };
+  ExploreProfileResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ExploreProfileResultKeySpecifier
+      | (() => undefined | ExploreProfileResultKeySpecifier);
+    fields?: ExploreProfileResultFieldPolicy;
+  };
+  ExplorePublicationResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ExplorePublicationResultKeySpecifier
+      | (() => undefined | ExplorePublicationResultKeySpecifier);
+    fields?: ExplorePublicationResultFieldPolicy;
+  };
+  FeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | FeeCollectModuleSettingsKeySpecifier);
+    fields?: FeeCollectModuleSettingsFieldPolicy;
+  };
+  FeeFollowModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FeeFollowModuleSettingsKeySpecifier
+      | (() => undefined | FeeFollowModuleSettingsKeySpecifier);
+    fields?: FeeFollowModuleSettingsFieldPolicy;
+  };
+  FeedItem?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | FeedItemKeySpecifier | (() => undefined | FeedItemKeySpecifier);
+    fields?: FeedItemFieldPolicy;
+  };
+  FollowConditionOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FollowConditionOutputKeySpecifier
+      | (() => undefined | FollowConditionOutputKeySpecifier);
+    fields?: FollowConditionOutputFieldPolicy;
+  };
+  FollowOnlyReferenceModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FollowOnlyReferenceModuleSettingsKeySpecifier
+      | (() => undefined | FollowOnlyReferenceModuleSettingsKeySpecifier);
+    fields?: FollowOnlyReferenceModuleSettingsFieldPolicy;
+  };
+  FollowRevenueResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FollowRevenueResultKeySpecifier
+      | (() => undefined | FollowRevenueResultKeySpecifier);
+    fields?: FollowRevenueResultFieldPolicy;
+  };
+  Follower?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | FollowerKeySpecifier | (() => undefined | FollowerKeySpecifier);
+    fields?: FollowerFieldPolicy;
+  };
+  FollowerNftOwnedTokenIds?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FollowerNftOwnedTokenIdsKeySpecifier
+      | (() => undefined | FollowerNftOwnedTokenIdsKeySpecifier);
+    fields?: FollowerNftOwnedTokenIdsFieldPolicy;
+  };
+  Following?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | FollowingKeySpecifier | (() => undefined | FollowingKeySpecifier);
+    fields?: FollowingFieldPolicy;
+  };
+  FreeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | FreeCollectModuleSettingsKeySpecifier
+      | (() => undefined | FreeCollectModuleSettingsKeySpecifier);
+    fields?: FreeCollectModuleSettingsFieldPolicy;
+  };
+  GenerateModuleCurrencyApproval?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | GenerateModuleCurrencyApprovalKeySpecifier
+      | (() => undefined | GenerateModuleCurrencyApprovalKeySpecifier);
+    fields?: GenerateModuleCurrencyApprovalFieldPolicy;
+  };
+  GlobalProtocolStats?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | GlobalProtocolStatsKeySpecifier
+      | (() => undefined | GlobalProtocolStatsKeySpecifier);
+    fields?: GlobalProtocolStatsFieldPolicy;
+  };
+  LimitedFeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | LimitedFeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | LimitedFeeCollectModuleSettingsKeySpecifier);
+    fields?: LimitedFeeCollectModuleSettingsFieldPolicy;
+  };
+  LimitedTimedFeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | LimitedTimedFeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | LimitedTimedFeeCollectModuleSettingsKeySpecifier);
+    fields?: LimitedTimedFeeCollectModuleSettingsFieldPolicy;
+  };
+  Log?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | LogKeySpecifier | (() => undefined | LogKeySpecifier);
+    fields?: LogFieldPolicy;
+  };
+  Media?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MediaKeySpecifier | (() => undefined | MediaKeySpecifier);
+    fields?: MediaFieldPolicy;
+  };
+  MediaOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MediaOutputKeySpecifier | (() => undefined | MediaOutputKeySpecifier);
+    fields?: MediaOutputFieldPolicy;
+  };
+  MediaSet?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MediaSetKeySpecifier | (() => undefined | MediaSetKeySpecifier);
+    fields?: MediaSetFieldPolicy;
+  };
+  MetadataAttributeOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | MetadataAttributeOutputKeySpecifier
+      | (() => undefined | MetadataAttributeOutputKeySpecifier);
+    fields?: MetadataAttributeOutputFieldPolicy;
+  };
+  MetadataOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MetadataOutputKeySpecifier | (() => undefined | MetadataOutputKeySpecifier);
+    fields?: MetadataOutputFieldPolicy;
+  };
+  Mirror?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MirrorKeySpecifier | (() => undefined | MirrorKeySpecifier);
+    fields?: MirrorFieldPolicy;
+  };
+  MirrorEvent?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MirrorEventKeySpecifier | (() => undefined | MirrorEventKeySpecifier);
+    fields?: MirrorEventFieldPolicy;
+  };
+  ModuleFeeAmount?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ModuleFeeAmountKeySpecifier
+      | (() => undefined | ModuleFeeAmountKeySpecifier);
+    fields?: ModuleFeeAmountFieldPolicy;
+  };
+  ModuleInfo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | ModuleInfoKeySpecifier | (() => undefined | ModuleInfoKeySpecifier);
+    fields?: ModuleInfoFieldPolicy;
+  };
+  MultirecipientFeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | MultirecipientFeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | MultirecipientFeeCollectModuleSettingsKeySpecifier);
+    fields?: MultirecipientFeeCollectModuleSettingsFieldPolicy;
+  };
+  Mutation?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | MutationKeySpecifier | (() => undefined | MutationKeySpecifier);
+    fields?: MutationFieldPolicy;
+  };
+  NFT?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | NFTKeySpecifier | (() => undefined | NFTKeySpecifier);
+    fields?: NFTFieldPolicy;
+  };
+  NFTContent?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | NFTContentKeySpecifier | (() => undefined | NFTContentKeySpecifier);
+    fields?: NFTContentFieldPolicy;
+  };
+  NFTsResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | NFTsResultKeySpecifier | (() => undefined | NFTsResultKeySpecifier);
+    fields?: NFTsResultFieldPolicy;
+  };
+  NewCollectNotification?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NewCollectNotificationKeySpecifier
+      | (() => undefined | NewCollectNotificationKeySpecifier);
+    fields?: NewCollectNotificationFieldPolicy;
+  };
+  NewCommentNotification?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NewCommentNotificationKeySpecifier
+      | (() => undefined | NewCommentNotificationKeySpecifier);
+    fields?: NewCommentNotificationFieldPolicy;
+  };
+  NewFollowerNotification?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NewFollowerNotificationKeySpecifier
+      | (() => undefined | NewFollowerNotificationKeySpecifier);
+    fields?: NewFollowerNotificationFieldPolicy;
+  };
+  NewMentionNotification?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NewMentionNotificationKeySpecifier
+      | (() => undefined | NewMentionNotificationKeySpecifier);
+    fields?: NewMentionNotificationFieldPolicy;
+  };
+  NewMirrorNotification?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NewMirrorNotificationKeySpecifier
+      | (() => undefined | NewMirrorNotificationKeySpecifier);
+    fields?: NewMirrorNotificationFieldPolicy;
+  };
+  NewReactionNotification?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NewReactionNotificationKeySpecifier
+      | (() => undefined | NewReactionNotificationKeySpecifier);
+    fields?: NewReactionNotificationFieldPolicy;
+  };
+  NftGallery?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | NftGalleryKeySpecifier | (() => undefined | NftGalleryKeySpecifier);
+    fields?: NftGalleryFieldPolicy;
+  };
+  NftImage?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | NftImageKeySpecifier | (() => undefined | NftImageKeySpecifier);
+    fields?: NftImageFieldPolicy;
+  };
+  NftOwnershipChallengeResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NftOwnershipChallengeResultKeySpecifier
+      | (() => undefined | NftOwnershipChallengeResultKeySpecifier);
+    fields?: NftOwnershipChallengeResultFieldPolicy;
+  };
+  NftOwnershipOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | NftOwnershipOutputKeySpecifier
+      | (() => undefined | NftOwnershipOutputKeySpecifier);
+    fields?: NftOwnershipOutputFieldPolicy;
+  };
+  OnChainIdentity?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | OnChainIdentityKeySpecifier
+      | (() => undefined | OnChainIdentityKeySpecifier);
+    fields?: OnChainIdentityFieldPolicy;
+  };
+  OrConditionOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | OrConditionOutputKeySpecifier
+      | (() => undefined | OrConditionOutputKeySpecifier);
+    fields?: OrConditionOutputFieldPolicy;
+  };
+  Owner?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | OwnerKeySpecifier | (() => undefined | OwnerKeySpecifier);
+    fields?: OwnerFieldPolicy;
+  };
+  PaginatedAllPublicationsTagsResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedAllPublicationsTagsResultKeySpecifier
+      | (() => undefined | PaginatedAllPublicationsTagsResultKeySpecifier);
+    fields?: PaginatedAllPublicationsTagsResultFieldPolicy;
+  };
+  PaginatedFeedResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedFeedResultKeySpecifier
+      | (() => undefined | PaginatedFeedResultKeySpecifier);
+    fields?: PaginatedFeedResultFieldPolicy;
+  };
+  PaginatedFollowersResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedFollowersResultKeySpecifier
+      | (() => undefined | PaginatedFollowersResultKeySpecifier);
+    fields?: PaginatedFollowersResultFieldPolicy;
+  };
+  PaginatedFollowingResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedFollowingResultKeySpecifier
+      | (() => undefined | PaginatedFollowingResultKeySpecifier);
+    fields?: PaginatedFollowingResultFieldPolicy;
+  };
+  PaginatedNotificationResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedNotificationResultKeySpecifier
+      | (() => undefined | PaginatedNotificationResultKeySpecifier);
+    fields?: PaginatedNotificationResultFieldPolicy;
+  };
+  PaginatedProfilePublicationsForSaleResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedProfilePublicationsForSaleResultKeySpecifier
+      | (() => undefined | PaginatedProfilePublicationsForSaleResultKeySpecifier);
+    fields?: PaginatedProfilePublicationsForSaleResultFieldPolicy;
+  };
+  PaginatedProfileResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedProfileResultKeySpecifier
+      | (() => undefined | PaginatedProfileResultKeySpecifier);
+    fields?: PaginatedProfileResultFieldPolicy;
+  };
+  PaginatedPublicationResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedPublicationResultKeySpecifier
+      | (() => undefined | PaginatedPublicationResultKeySpecifier);
+    fields?: PaginatedPublicationResultFieldPolicy;
+  };
+  PaginatedResultInfo?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedResultInfoKeySpecifier
+      | (() => undefined | PaginatedResultInfoKeySpecifier);
+    fields?: PaginatedResultInfoFieldPolicy;
+  };
+  PaginatedTimelineResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedTimelineResultKeySpecifier
+      | (() => undefined | PaginatedTimelineResultKeySpecifier);
+    fields?: PaginatedTimelineResultFieldPolicy;
+  };
+  PaginatedWhoCollectedResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedWhoCollectedResultKeySpecifier
+      | (() => undefined | PaginatedWhoCollectedResultKeySpecifier);
+    fields?: PaginatedWhoCollectedResultFieldPolicy;
+  };
+  PaginatedWhoReactedResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PaginatedWhoReactedResultKeySpecifier
+      | (() => undefined | PaginatedWhoReactedResultKeySpecifier);
+    fields?: PaginatedWhoReactedResultFieldPolicy;
+  };
+  PendingApproveFollowsResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PendingApproveFollowsResultKeySpecifier
+      | (() => undefined | PendingApproveFollowsResultKeySpecifier);
+    fields?: PendingApproveFollowsResultFieldPolicy;
+  };
+  PendingPost?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | PendingPostKeySpecifier | (() => undefined | PendingPostKeySpecifier);
+    fields?: PendingPostFieldPolicy;
+  };
+  Post?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | PostKeySpecifier | (() => undefined | PostKeySpecifier);
+    fields?: PostFieldPolicy;
+  };
+  Profile?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | ProfileKeySpecifier | (() => undefined | ProfileKeySpecifier);
+    fields?: ProfileFieldPolicy;
+  };
+  ProfileFollowModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProfileFollowModuleSettingsKeySpecifier
+      | (() => undefined | ProfileFollowModuleSettingsKeySpecifier);
+    fields?: ProfileFollowModuleSettingsFieldPolicy;
+  };
+  ProfileOwnershipOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProfileOwnershipOutputKeySpecifier
+      | (() => undefined | ProfileOwnershipOutputKeySpecifier);
+    fields?: ProfileOwnershipOutputFieldPolicy;
+  };
+  ProfilePublicationRevenueResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProfilePublicationRevenueResultKeySpecifier
+      | (() => undefined | ProfilePublicationRevenueResultKeySpecifier);
+    fields?: ProfilePublicationRevenueResultFieldPolicy;
+  };
+  ProfileSearchResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProfileSearchResultKeySpecifier
+      | (() => undefined | ProfileSearchResultKeySpecifier);
+    fields?: ProfileSearchResultFieldPolicy;
+  };
+  ProfileStats?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | ProfileStatsKeySpecifier | (() => undefined | ProfileStatsKeySpecifier);
+    fields?: ProfileStatsFieldPolicy;
+  };
+  ProviderSpecificParamsOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProviderSpecificParamsOutputKeySpecifier
+      | (() => undefined | ProviderSpecificParamsOutputKeySpecifier);
+    fields?: ProviderSpecificParamsOutputFieldPolicy;
+  };
+  ProxyActionError?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProxyActionErrorKeySpecifier
+      | (() => undefined | ProxyActionErrorKeySpecifier);
+    fields?: ProxyActionErrorFieldPolicy;
+  };
+  ProxyActionQueued?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProxyActionQueuedKeySpecifier
+      | (() => undefined | ProxyActionQueuedKeySpecifier);
+    fields?: ProxyActionQueuedFieldPolicy;
+  };
+  ProxyActionStatusResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ProxyActionStatusResultKeySpecifier
+      | (() => undefined | ProxyActionStatusResultKeySpecifier);
+    fields?: ProxyActionStatusResultFieldPolicy;
+  };
+  PublicMediaResults?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PublicMediaResultsKeySpecifier
+      | (() => undefined | PublicMediaResultsKeySpecifier);
+    fields?: PublicMediaResultsFieldPolicy;
+  };
+  PublicationMetadataStatus?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PublicationMetadataStatusKeySpecifier
+      | (() => undefined | PublicationMetadataStatusKeySpecifier);
+    fields?: PublicationMetadataStatusFieldPolicy;
+  };
+  PublicationRevenue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PublicationRevenueKeySpecifier
+      | (() => undefined | PublicationRevenueKeySpecifier);
+    fields?: PublicationRevenueFieldPolicy;
+  };
+  PublicationSearchResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PublicationSearchResultKeySpecifier
+      | (() => undefined | PublicationSearchResultKeySpecifier);
+    fields?: PublicationSearchResultFieldPolicy;
+  };
+  PublicationStats?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PublicationStatsKeySpecifier
+      | (() => undefined | PublicationStatsKeySpecifier);
+    fields?: PublicationStatsFieldPolicy;
+  };
+  PublicationValidateMetadataResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | PublicationValidateMetadataResultKeySpecifier
+      | (() => undefined | PublicationValidateMetadataResultKeySpecifier);
+    fields?: PublicationValidateMetadataResultFieldPolicy;
+  };
+  Query?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier);
+    fields?: QueryFieldPolicy;
+  };
+  ReactionEvent?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | ReactionEventKeySpecifier | (() => undefined | ReactionEventKeySpecifier);
+    fields?: ReactionEventFieldPolicy;
+  };
+  RecipientDataOutput?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | RecipientDataOutputKeySpecifier
+      | (() => undefined | RecipientDataOutputKeySpecifier);
+    fields?: RecipientDataOutputFieldPolicy;
+  };
+  RelayError?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | RelayErrorKeySpecifier | (() => undefined | RelayErrorKeySpecifier);
+    fields?: RelayErrorFieldPolicy;
+  };
+  RelayerResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | RelayerResultKeySpecifier | (() => undefined | RelayerResultKeySpecifier);
+    fields?: RelayerResultFieldPolicy;
+  };
+  ReservedClaimableHandle?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | ReservedClaimableHandleKeySpecifier
+      | (() => undefined | ReservedClaimableHandleKeySpecifier);
+    fields?: ReservedClaimableHandleFieldPolicy;
+  };
+  RevenueAggregate?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | RevenueAggregateKeySpecifier
+      | (() => undefined | RevenueAggregateKeySpecifier);
+    fields?: RevenueAggregateFieldPolicy;
+  };
+  RevertCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | RevertCollectModuleSettingsKeySpecifier
+      | (() => undefined | RevertCollectModuleSettingsKeySpecifier);
+    fields?: RevertCollectModuleSettingsFieldPolicy;
+  };
+  RevertFollowModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | RevertFollowModuleSettingsKeySpecifier
+      | (() => undefined | RevertFollowModuleSettingsKeySpecifier);
+    fields?: RevertFollowModuleSettingsFieldPolicy;
+  };
+  SetDefaultProfileBroadcastItemResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SetDefaultProfileBroadcastItemResultKeySpecifier
+      | (() => undefined | SetDefaultProfileBroadcastItemResultKeySpecifier);
+    fields?: SetDefaultProfileBroadcastItemResultFieldPolicy;
+  };
+  SetDefaultProfileEIP712TypedData?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SetDefaultProfileEIP712TypedDataKeySpecifier
+      | (() => undefined | SetDefaultProfileEIP712TypedDataKeySpecifier);
+    fields?: SetDefaultProfileEIP712TypedDataFieldPolicy;
+  };
+  SetDefaultProfileEIP712TypedDataTypes?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SetDefaultProfileEIP712TypedDataTypesKeySpecifier
+      | (() => undefined | SetDefaultProfileEIP712TypedDataTypesKeySpecifier);
+    fields?: SetDefaultProfileEIP712TypedDataTypesFieldPolicy;
+  };
+  SetDefaultProfileEIP712TypedDataValue?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SetDefaultProfileEIP712TypedDataValueKeySpecifier
+      | (() => undefined | SetDefaultProfileEIP712TypedDataValueKeySpecifier);
+    fields?: SetDefaultProfileEIP712TypedDataValueFieldPolicy;
+  };
+  SybilDotOrgIdentity?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SybilDotOrgIdentityKeySpecifier
+      | (() => undefined | SybilDotOrgIdentityKeySpecifier);
+    fields?: SybilDotOrgIdentityFieldPolicy;
+  };
+  SybilDotOrgIdentitySource?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SybilDotOrgIdentitySourceKeySpecifier
+      | (() => undefined | SybilDotOrgIdentitySourceKeySpecifier);
+    fields?: SybilDotOrgIdentitySourceFieldPolicy;
+  };
+  SybilDotOrgTwitterIdentity?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | SybilDotOrgTwitterIdentityKeySpecifier
+      | (() => undefined | SybilDotOrgTwitterIdentityKeySpecifier);
+    fields?: SybilDotOrgTwitterIdentityFieldPolicy;
+  };
+  TagResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | TagResultKeySpecifier | (() => undefined | TagResultKeySpecifier);
+    fields?: TagResultFieldPolicy;
+  };
+  TimedFeeCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | TimedFeeCollectModuleSettingsKeySpecifier
+      | (() => undefined | TimedFeeCollectModuleSettingsKeySpecifier);
+    fields?: TimedFeeCollectModuleSettingsFieldPolicy;
+  };
+  TransactionError?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | TransactionErrorKeySpecifier
+      | (() => undefined | TransactionErrorKeySpecifier);
+    fields?: TransactionErrorFieldPolicy;
+  };
+  TransactionIndexedResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | TransactionIndexedResultKeySpecifier
+      | (() => undefined | TransactionIndexedResultKeySpecifier);
+    fields?: TransactionIndexedResultFieldPolicy;
+  };
+  TransactionReceipt?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | TransactionReceiptKeySpecifier
+      | (() => undefined | TransactionReceiptKeySpecifier);
+    fields?: TransactionReceiptFieldPolicy;
+  };
+  UnknownCollectModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | UnknownCollectModuleSettingsKeySpecifier
+      | (() => undefined | UnknownCollectModuleSettingsKeySpecifier);
+    fields?: UnknownCollectModuleSettingsFieldPolicy;
+  };
+  UnknownFollowModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | UnknownFollowModuleSettingsKeySpecifier
+      | (() => undefined | UnknownFollowModuleSettingsKeySpecifier);
+    fields?: UnknownFollowModuleSettingsFieldPolicy;
+  };
+  UnknownReferenceModuleSettings?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | UnknownReferenceModuleSettingsKeySpecifier
+      | (() => undefined | UnknownReferenceModuleSettingsKeySpecifier);
+    fields?: UnknownReferenceModuleSettingsFieldPolicy;
+  };
+  UserSigNonces?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | UserSigNoncesKeySpecifier | (() => undefined | UserSigNoncesKeySpecifier);
+    fields?: UserSigNoncesFieldPolicy;
+  };
+  Wallet?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?: false | WalletKeySpecifier | (() => undefined | WalletKeySpecifier);
+    fields?: WalletFieldPolicy;
+  };
+  WhoReactedResult?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | WhoReactedResultKeySpecifier
+      | (() => undefined | WhoReactedResultKeySpecifier);
+    fields?: WhoReactedResultFieldPolicy;
+  };
+  WorldcoinIdentity?: Omit<TypePolicy, 'fields' | 'keyFields'> & {
+    keyFields?:
+      | false
+      | WorldcoinIdentityKeySpecifier
+      | (() => undefined | WorldcoinIdentityKeySpecifier);
+    fields?: WorldcoinIdentityFieldPolicy;
+  };
 };
 export type TypedTypePolicies = StrictTypedTypePolicies & TypePolicies;
 
-      export interface PossibleTypesResultData {
-        possibleTypes: {
-          [key: string]: string[]
-        }
-      }
-      const result: PossibleTypesResultData = {
-  "possibleTypes": {
-    "BroadcastDataAvailabilityUnion": [
-      "CreateDataAvailabilityPublicationResult",
-      "RelayError"
+export interface PossibleTypesResultData {
+  possibleTypes: {
+    [key: string]: string[];
+  };
+}
+const result: PossibleTypesResultData = {
+  possibleTypes: {
+    BroadcastDataAvailabilityUnion: ['CreateDataAvailabilityPublicationResult', 'RelayError'],
+    CollectModule: [
+      'AaveFeeCollectModuleSettings',
+      'ERC4626FeeCollectModuleSettings',
+      'FeeCollectModuleSettings',
+      'FreeCollectModuleSettings',
+      'LimitedFeeCollectModuleSettings',
+      'LimitedTimedFeeCollectModuleSettings',
+      'MultirecipientFeeCollectModuleSettings',
+      'RevertCollectModuleSettings',
+      'TimedFeeCollectModuleSettings',
+      'UnknownCollectModuleSettings',
     ],
-    "CollectModule": [
-      "AaveFeeCollectModuleSettings",
-      "ERC4626FeeCollectModuleSettings",
-      "FeeCollectModuleSettings",
-      "FreeCollectModuleSettings",
-      "LimitedFeeCollectModuleSettings",
-      "LimitedTimedFeeCollectModuleSettings",
-      "MultirecipientFeeCollectModuleSettings",
-      "RevertCollectModuleSettings",
-      "TimedFeeCollectModuleSettings",
-      "UnknownCollectModuleSettings"
+    FeedItemRoot: ['Comment', 'Post'],
+    FollowModule: [
+      'FeeFollowModuleSettings',
+      'ProfileFollowModuleSettings',
+      'RevertFollowModuleSettings',
+      'UnknownFollowModuleSettings',
     ],
-    "FeedItemRoot": [
-      "Comment",
-      "Post"
+    MainPostReference: ['Mirror', 'Post'],
+    MentionPublication: ['Comment', 'Post'],
+    MirrorablePublication: ['Comment', 'Post'],
+    Notification: [
+      'NewCollectNotification',
+      'NewCommentNotification',
+      'NewFollowerNotification',
+      'NewMentionNotification',
+      'NewMirrorNotification',
+      'NewReactionNotification',
     ],
-    "FollowModule": [
-      "FeeFollowModuleSettings",
-      "ProfileFollowModuleSettings",
-      "RevertFollowModuleSettings",
-      "UnknownFollowModuleSettings"
+    ProfileMedia: ['MediaSet', 'NftImage'],
+    ProxyActionStatusResultUnion: [
+      'ProxyActionError',
+      'ProxyActionQueued',
+      'ProxyActionStatusResult',
     ],
-    "MainPostReference": [
-      "Mirror",
-      "Post"
+    Publication: ['Comment', 'Mirror', 'Post'],
+    PublicationForSale: ['Comment', 'Post'],
+    PublicationSearchResultItem: ['Comment', 'Post'],
+    ReferenceModule: [
+      'DegreesOfSeparationReferenceModuleSettings',
+      'FollowOnlyReferenceModuleSettings',
+      'UnknownReferenceModuleSettings',
     ],
-    "MentionPublication": [
-      "Comment",
-      "Post"
-    ],
-    "MirrorablePublication": [
-      "Comment",
-      "Post"
-    ],
-    "Notification": [
-      "NewCollectNotification",
-      "NewCommentNotification",
-      "NewFollowerNotification",
-      "NewMentionNotification",
-      "NewMirrorNotification",
-      "NewReactionNotification"
-    ],
-    "ProfileMedia": [
-      "MediaSet",
-      "NftImage"
-    ],
-    "ProxyActionStatusResultUnion": [
-      "ProxyActionError",
-      "ProxyActionQueued",
-      "ProxyActionStatusResult"
-    ],
-    "Publication": [
-      "Comment",
-      "Mirror",
-      "Post"
-    ],
-    "PublicationForSale": [
-      "Comment",
-      "Post"
-    ],
-    "PublicationSearchResultItem": [
-      "Comment",
-      "Post"
-    ],
-    "ReferenceModule": [
-      "DegreesOfSeparationReferenceModuleSettings",
-      "FollowOnlyReferenceModuleSettings",
-      "UnknownReferenceModuleSettings"
-    ],
-    "RelayDataAvailabilityResult": [
-      "CreateDataAvailabilityPublicationResult",
-      "RelayError"
-    ],
-    "RelayResult": [
-      "RelayError",
-      "RelayerResult"
-    ],
-    "SearchResult": [
-      "ProfileSearchResult",
-      "PublicationSearchResult"
-    ],
-    "TransactionResult": [
-      "TransactionError",
-      "TransactionIndexedResult"
-    ]
-  }
+    RelayDataAvailabilityResult: ['CreateDataAvailabilityPublicationResult', 'RelayError'],
+    RelayResult: ['RelayError', 'RelayerResult'],
+    SearchResult: ['ProfileSearchResult', 'PublicationSearchResult'],
+    TransactionResult: ['TransactionError', 'TransactionIndexedResult'],
+  },
 };
-      export default result;
-    
+export default result;

--- a/packages/api-bindings/src/graphql/operations.ts
+++ b/packages/api-bindings/src/graphql/operations.ts
@@ -1,7 +1,16 @@
 /** Code generated. DO NOT EDIT. */
 /* eslint-disable @typescript-eslint/ban-types */
-import type { AppId, DecryptionCriteria, ProfileId, PublicationId } from '@lens-protocol/domain/entities';
-import type { Erc20Amount as ClientErc20Amount, EthereumAddress, Url } from '@lens-protocol/shared-kernel';
+import type {
+  AppId,
+  DecryptionCriteria,
+  ProfileId,
+  PublicationId,
+} from '@lens-protocol/domain/entities';
+import type {
+  Erc20Amount as ClientErc20Amount,
+  EthereumAddress,
+  Url,
+} from '@lens-protocol/shared-kernel';
 
 import type { CollectPolicy } from './CollectPolicy';
 import type { ContentEncryptionKey } from './ContentEncryptionKey';
@@ -224,7 +233,7 @@ export type ClaimHandleRequest = {
 export enum ClaimStatus {
   AlreadyClaimed = 'ALREADY_CLAIMED',
   ClaimFailed = 'CLAIM_FAILED',
-  NotClaimed = 'NOT_CLAIMED'
+  NotClaimed = 'NOT_CLAIMED',
 }
 
 /** Condition that signifies if address or profile has collected a publication */
@@ -269,7 +278,7 @@ export enum CollectModules {
   MultirecipientFeeCollectModule = 'MultirecipientFeeCollectModule',
   RevertCollectModule = 'RevertCollectModule',
   TimedFeeCollectModule = 'TimedFeeCollectModule',
-  UnknownCollectModule = 'UnknownCollectModule'
+  UnknownCollectModule = 'UnknownCollectModule',
 }
 
 export type CollectProxyAction = {
@@ -279,20 +288,20 @@ export type CollectProxyAction = {
 /** The comment ordering types */
 export enum CommentOrderingTypes {
   Desc = 'DESC',
-  Ranking = 'RANKING'
+  Ranking = 'RANKING',
 }
 
 /** The comment ranking filter types */
 export enum CommentRankingFilter {
   NoneRelevant = 'NONE_RELEVANT',
-  Relevant = 'RELEVANT'
+  Relevant = 'RELEVANT',
 }
 
 /** The gated publication access criteria contract types */
 export enum ContractType {
   Erc20 = 'ERC20',
   Erc721 = 'ERC721',
-  Erc1155 = 'ERC1155'
+  Erc1155 = 'ERC1155',
 }
 
 export type CreateCollectRequest = {
@@ -406,7 +415,7 @@ export type CurRequest = {
 
 /** The custom filters types */
 export enum CustomFiltersTypes {
-  Gardeners = 'GARDENERS'
+  Gardeners = 'GARDENERS',
 }
 
 /** The reason why a profile cannot decrypt a publication */
@@ -421,7 +430,7 @@ export enum DecryptFailReason {
   MissingEncryptionParams = 'MISSING_ENCRYPTION_PARAMS',
   ProfileDoesNotExist = 'PROFILE_DOES_NOT_EXIST',
   UnauthorizedAddress = 'UNAUTHORIZED_ADDRESS',
-  UnauthorizedBalance = 'UNAUTHORIZED_BALANCE'
+  UnauthorizedBalance = 'UNAUTHORIZED_BALANCE',
 }
 
 export type DefaultProfileRequest = {
@@ -472,7 +481,7 @@ export type Erc4626FeeCollectModuleParams = {
 
 /** The gated publication encryption provider */
 export enum EncryptionProvider {
-  LitProtocol = 'LIT_PROTOCOL'
+  LitProtocol = 'LIT_PROTOCOL',
 }
 
 export type EoaOwnershipInput = {
@@ -549,7 +558,7 @@ export enum FeedEventItemType {
   Mirror = 'MIRROR',
   Post = 'POST',
   ReactionComment = 'REACTION_COMMENT',
-  ReactionPost = 'REACTION_POST'
+  ReactionPost = 'REACTION_POST',
 }
 
 export type FeedHighlightsRequest = {
@@ -611,7 +620,7 @@ export enum FollowModules {
   FeeFollowModule = 'FeeFollowModule',
   ProfileFollowModule = 'ProfileFollowModule',
   RevertFollowModule = 'RevertFollowModule',
-  UnknownFollowModule = 'UnknownFollowModule'
+  UnknownFollowModule = 'UnknownFollowModule',
 }
 
 export type FollowProxyAction = {
@@ -758,7 +767,7 @@ export type IdKitPhoneVerifyWebhookRequest = {
 /** The verify webhook result status type */
 export enum IdKitPhoneVerifyWebhookResultStatusType {
   AlreadyVerified = 'ALREADY_VERIFIED',
-  Success = 'SUCCESS'
+  Success = 'SUCCESS',
 }
 
 export type IllegalReasonInputParams = {
@@ -992,7 +1001,7 @@ export enum NotificationTypes {
   MirroredComment = 'MIRRORED_COMMENT',
   MirroredPost = 'MIRRORED_POST',
   ReactionComment = 'REACTION_COMMENT',
-  ReactionPost = 'REACTION_POST'
+  ReactionPost = 'REACTION_POST',
 }
 
 export type OrConditionInput = {
@@ -1074,7 +1083,7 @@ export enum ProfileSortCriteria {
   MostFollowers = 'MOST_FOLLOWERS',
   MostMirrors = 'MOST_MIRRORS',
   MostPosts = 'MOST_POSTS',
-  MostPublication = 'MOST_PUBLICATION'
+  MostPublication = 'MOST_PUBLICATION',
 }
 
 export type ProxyActionRequest = {
@@ -1086,7 +1095,7 @@ export type ProxyActionRequest = {
 export enum ProxyActionStatusTypes {
   Complete = 'COMPLETE',
   Minting = 'MINTING',
-  Transferring = 'TRANSFERRING'
+  Transferring = 'TRANSFERRING',
 }
 
 export type PublicMediaRequest = {
@@ -1104,7 +1113,7 @@ export type PublicMediaRequest = {
 export enum PublicationContentWarning {
   Nsfw = 'NSFW',
   Sensitive = 'SENSITIVE',
-  Spoiler = 'SPOILER'
+  Spoiler = 'SPOILER',
 }
 
 /** The publication main focus */
@@ -1115,12 +1124,12 @@ export enum PublicationMainFocus {
   Image = 'IMAGE',
   Link = 'LINK',
   TextOnly = 'TEXT_ONLY',
-  Video = 'VIDEO'
+  Video = 'VIDEO',
 }
 
 /** The source of the media */
 export enum PublicationMediaSource {
-  Lens = 'LENS'
+  Lens = 'LENS',
 }
 
 /** Publication metadata content warning filters */
@@ -1133,7 +1142,7 @@ export type PublicationMetadataContentWarningFilter = {
 export enum PublicationMetadataDisplayTypes {
   Date = 'date',
   Number = 'number',
-  String = 'string'
+  String = 'string',
 }
 
 /** Publication metadata filters */
@@ -1162,7 +1171,7 @@ export enum PublicationMetadataStatusType {
   MetadataValidationFailed = 'METADATA_VALIDATION_FAILED',
   NotFound = 'NOT_FOUND',
   Pending = 'PENDING',
-  Success = 'SUCCESS'
+  Success = 'SUCCESS',
 }
 
 /** Publication metadata tag filter */
@@ -1265,7 +1274,7 @@ export type PublicationQueryRequest = {
 /** Publication reporting fraud subreason */
 export enum PublicationReportingFraudSubreason {
   Impersonation = 'IMPERSONATION',
-  Scam = 'SCAM'
+  Scam = 'SCAM',
 }
 
 /** Publication reporting illegal subreason */
@@ -1274,7 +1283,7 @@ export enum PublicationReportingIllegalSubreason {
   DirectThreat = 'DIRECT_THREAT',
   HumanAbuse = 'HUMAN_ABUSE',
   ThreatIndividual = 'THREAT_INDIVIDUAL',
-  Violence = 'VIOLENCE'
+  Violence = 'VIOLENCE',
 }
 
 /** Publication reporting reason */
@@ -1282,13 +1291,13 @@ export enum PublicationReportingReason {
   Fraud = 'FRAUD',
   Illegal = 'ILLEGAL',
   Sensitive = 'SENSITIVE',
-  Spam = 'SPAM'
+  Spam = 'SPAM',
 }
 
 /** Publication reporting sensitive subreason */
 export enum PublicationReportingSensitiveSubreason {
   Nsfw = 'NSFW',
-  Offensive = 'OFFENSIVE'
+  Offensive = 'OFFENSIVE',
 }
 
 /** Publication reporting spam subreason */
@@ -1299,7 +1308,7 @@ export enum PublicationReportingSpamSubreason {
   MisuseHashtags = 'MISUSE_HASHTAGS',
   Repetitive = 'REPETITIVE',
   SomethingElse = 'SOMETHING_ELSE',
-  Unrelated = 'UNRELATED'
+  Unrelated = 'UNRELATED',
 }
 
 export type PublicationRevenueQueryRequest = {
@@ -1317,14 +1326,14 @@ export enum PublicationSortCriteria {
   Latest = 'LATEST',
   TopCollected = 'TOP_COLLECTED',
   TopCommented = 'TOP_COMMENTED',
-  TopMirrored = 'TOP_MIRRORED'
+  TopMirrored = 'TOP_MIRRORED',
 }
 
 /** The publication types */
 export enum PublicationTypes {
   Comment = 'COMMENT',
   Mirror = 'MIRROR',
-  Post = 'POST'
+  Post = 'POST',
 }
 
 export type PublicationsQueryRequest = {
@@ -1369,7 +1378,7 @@ export type ReactionRequest = {
 /** Reaction types */
 export enum ReactionTypes {
   Downvote = 'DOWNVOTE',
-  Upvote = 'UPVOTE'
+  Upvote = 'UPVOTE',
 }
 
 export type RecipientDataInput = {
@@ -1399,7 +1408,7 @@ export type ReferenceModuleParams = {
 export enum ReferenceModules {
   DegreesOfSeparationReferenceModule = 'DegreesOfSeparationReferenceModule',
   FollowerOnlyReferenceModule = 'FollowerOnlyReferenceModule',
-  UnknownReferenceModule = 'UnknownReferenceModule'
+  UnknownReferenceModule = 'UnknownReferenceModule',
 }
 
 /** The refresh request */
@@ -1419,7 +1428,7 @@ export enum RelayErrorReasons {
   HandleTaken = 'HANDLE_TAKEN',
   NotAllowed = 'NOT_ALLOWED',
   Rejected = 'REJECTED',
-  WrongWalletSigned = 'WRONG_WALLET_SIGNED'
+  WrongWalletSigned = 'WRONG_WALLET_SIGNED',
 }
 
 /** The request object to remove interests from a profile */
@@ -1450,7 +1459,7 @@ export enum ScalarOperator {
   GreaterThanOrEqual = 'GREATER_THAN_OR_EQUAL',
   LessThan = 'LESS_THAN',
   LessThanOrEqual = 'LESS_THAN_OR_EQUAL',
-  NotEqual = 'NOT_EQUAL'
+  NotEqual = 'NOT_EQUAL',
 }
 
 export type SearchQueryRequest = {
@@ -1467,7 +1476,7 @@ export type SearchQueryRequest = {
 /** Search request types */
 export enum SearchRequestTypes {
   Profile = 'PROFILE',
-  Publication = 'PUBLICATION'
+  Publication = 'PUBLICATION',
 }
 
 export type SensitiveReasonInputParams = {
@@ -1507,7 +1516,7 @@ export type SpamReasonInputParams = {
 /** The publications tags sort criteria */
 export enum TagSortCriteria {
   Alphabetical = 'ALPHABETICAL',
-  MostPopular = 'MOST_POPULAR'
+  MostPopular = 'MOST_POPULAR',
 }
 
 export type TimedFeeCollectModuleParams = {
@@ -1523,7 +1532,7 @@ export type TimedFeeCollectModuleParams = {
 
 /** Transaction error reason */
 export enum TransactionErrorReasons {
-  Reverted = 'REVERTED'
+  Reverted = 'REVERTED',
 }
 
 export type TypedDataOptions = {
@@ -1594,7 +1603,7 @@ export type WhoReactedPublicationRequest = {
 /** The worldcoin signal type */
 export enum WorldcoinPhoneVerifyType {
   Orb = 'ORB',
-  Phone = 'PHONE'
+  Phone = 'PHONE',
 }
 
 export type WorldcoinPhoneVerifyWebhookRequest = {
@@ -1607,7 +1616,6 @@ export type AuthChallengeVariables = Exact<{
   address: Scalars['EthereumAddress'];
 }>;
 
-
 export type AuthChallengeData = { result: { text: string } };
 
 export type AuthAuthenticateVariables = Exact<{
@@ -1615,43 +1623,78 @@ export type AuthAuthenticateVariables = Exact<{
   signature: Scalars['Signature'];
 }>;
 
-
-export type AuthAuthenticateData = { result: { accessToken: string, refreshToken: string } };
+export type AuthAuthenticateData = { result: { accessToken: string; refreshToken: string } };
 
 export type AuthRefreshVariables = Exact<{
   refreshToken: Scalars['Jwt'];
 }>;
 
-
-export type AuthRefreshData = { result: { accessToken: string, refreshToken: string } };
+export type AuthRefreshData = { result: { accessToken: string; refreshToken: string } };
 
 export type CreateCollectTypedDataVariables = Exact<{
   request: CreateCollectRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreateCollectTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { CollectWithSig: Array<{ name: string, type: string }> }, domain: Eip712TypedDataDomain, value: { nonce: number, deadline: unknown, profileId: ProfileId, pubId: unknown, data: unknown } } } };
+export type CreateCollectTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { CollectWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomain;
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileId: ProfileId;
+        pubId: unknown;
+        data: unknown;
+      };
+    };
+  };
+};
 
 export type CreateCommentTypedDataVariables = Exact<{
   request: CreatePublicCommentRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreateCommentTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { CommentWithSig: Array<{ name: string, type: string }> }, domain: Eip712TypedDataDomain, value: { nonce: number, deadline: unknown, profileId: ProfileId, contentURI: unknown, profileIdPointed: ProfileId, pubIdPointed: unknown, collectModule: string, collectModuleInitData: unknown, referenceModuleData: string, referenceModule: string, referenceModuleInitData: string } } } };
+export type CreateCommentTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { CommentWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomain;
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileId: ProfileId;
+        contentURI: unknown;
+        profileIdPointed: ProfileId;
+        pubIdPointed: unknown;
+        collectModule: string;
+        collectModuleInitData: unknown;
+        referenceModuleData: string;
+        referenceModule: string;
+        referenceModuleInitData: string;
+      };
+    };
+  };
+};
 
 export type CreateCommentViaDispatcherVariables = Exact<{
   request: CreatePublicCommentRequest;
 }>;
 
+export type CreateCommentViaDispatcherData = {
+  result: RelayResult_RelayError_ | RelayResult_RelayerResult_;
+};
 
-export type CreateCommentViaDispatcherData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
-
-export type CommentWithFirstComment = (
-  { __typename: 'Comment', firstComment: Comment | null }
-  & Comment
-);
+export type CommentWithFirstComment = {
+  __typename: 'Comment';
+  firstComment: Comment | null;
+} & Comment;
 
 export type CommentsVariables = Exact<{
   observerId?: InputMaybe<Scalars['ProfileId']>;
@@ -1662,89 +1705,325 @@ export type CommentsVariables = Exact<{
   metadata?: InputMaybe<PublicationMetadataFilters>;
 }>;
 
+export type CommentsData = {
+  result: { items: Array<CommentWithFirstComment | {}>; pageInfo: CommonPaginatedResultInfo };
+};
 
-export type CommentsData = { result: { items: Array<CommentWithFirstComment | {}>, pageInfo: CommonPaginatedResultInfo } };
+export type Erc20Fields = {
+  __typename: 'Erc20';
+  name: string;
+  symbol: string;
+  decimals: number;
+  address: string;
+};
 
-export type Erc20Fields = { __typename: 'Erc20', name: string, symbol: string, decimals: number, address: string };
+export type Erc20AmountFields = { __typename: 'Erc20Amount'; value: string; asset: Erc20Fields };
 
-export type Erc20AmountFields = { __typename: 'Erc20Amount', value: string, asset: Erc20Fields };
+export type ModuleFeeAmount = { __typename: 'ModuleFeeAmount'; value: string; asset: Erc20Fields };
 
-export type ModuleFeeAmount = { __typename: 'ModuleFeeAmount', value: string, asset: Erc20Fields };
+export type AaveFeeCollectModuleSettings = {
+  __typename: 'AaveFeeCollectModuleSettings';
+  contractAddress: string;
+  followerOnly: boolean;
+  recipient: EthereumAddress;
+  referralFee: number;
+  collectLimitOptional: string | null;
+  endTimestampOptional: string | null;
+  amount: ModuleFeeAmount;
+};
 
-export type AaveFeeCollectModuleSettings = { __typename: 'AaveFeeCollectModuleSettings', contractAddress: string, followerOnly: boolean, recipient: EthereumAddress, referralFee: number, collectLimitOptional: string | null, endTimestampOptional: string | null, amount: ModuleFeeAmount };
+export type Erc4626FeeCollectModuleSettings = {
+  __typename: 'ERC4626FeeCollectModuleSettings';
+  contractAddress: string;
+  followerOnly: boolean;
+  recipient: EthereumAddress;
+  referralFee: number;
+  vault: string;
+  collectLimitOptional: string | null;
+  endTimestampOptional: string | null;
+  amount: ModuleFeeAmount;
+};
 
-export type Erc4626FeeCollectModuleSettings = { __typename: 'ERC4626FeeCollectModuleSettings', contractAddress: string, followerOnly: boolean, recipient: EthereumAddress, referralFee: number, vault: string, collectLimitOptional: string | null, endTimestampOptional: string | null, amount: ModuleFeeAmount };
-
-export type MultirecipientFeeCollectModuleSettings = { __typename: 'MultirecipientFeeCollectModuleSettings', contractAddress: string, followerOnly: boolean, referralFee: number, collectLimitOptional: string | null, endTimestampOptional: string | null, amount: ModuleFeeAmount, recipients: Array<{ recipient: EthereumAddress, split: number }> };
+export type MultirecipientFeeCollectModuleSettings = {
+  __typename: 'MultirecipientFeeCollectModuleSettings';
+  contractAddress: string;
+  followerOnly: boolean;
+  referralFee: number;
+  collectLimitOptional: string | null;
+  endTimestampOptional: string | null;
+  amount: ModuleFeeAmount;
+  recipients: Array<{ recipient: EthereumAddress; split: number }>;
+};
 
 export type UnknownCollectModuleSettings = { __typename: 'UnknownCollectModuleSettings' };
 
-export type FreeCollectModuleSettings = { __typename: 'FreeCollectModuleSettings', contractAddress: string, followerOnly: boolean };
+export type FreeCollectModuleSettings = {
+  __typename: 'FreeCollectModuleSettings';
+  contractAddress: string;
+  followerOnly: boolean;
+};
 
-export type FeeCollectModuleSettings = { __typename: 'FeeCollectModuleSettings', contractAddress: string, followerOnly: boolean, recipient: EthereumAddress, referralFee: number, amount: ModuleFeeAmount };
+export type FeeCollectModuleSettings = {
+  __typename: 'FeeCollectModuleSettings';
+  contractAddress: string;
+  followerOnly: boolean;
+  recipient: EthereumAddress;
+  referralFee: number;
+  amount: ModuleFeeAmount;
+};
 
-export type LimitedFeeCollectModuleSettings = { __typename: 'LimitedFeeCollectModuleSettings', collectLimit: string, contractAddress: string, followerOnly: boolean, recipient: EthereumAddress, referralFee: number, amount: ModuleFeeAmount };
+export type LimitedFeeCollectModuleSettings = {
+  __typename: 'LimitedFeeCollectModuleSettings';
+  collectLimit: string;
+  contractAddress: string;
+  followerOnly: boolean;
+  recipient: EthereumAddress;
+  referralFee: number;
+  amount: ModuleFeeAmount;
+};
 
-export type LimitedTimedFeeCollectModuleSettings = { __typename: 'LimitedTimedFeeCollectModuleSettings', collectLimit: string, contractAddress: string, followerOnly: boolean, endTimestamp: string, recipient: EthereumAddress, referralFee: number, amount: ModuleFeeAmount };
+export type LimitedTimedFeeCollectModuleSettings = {
+  __typename: 'LimitedTimedFeeCollectModuleSettings';
+  collectLimit: string;
+  contractAddress: string;
+  followerOnly: boolean;
+  endTimestamp: string;
+  recipient: EthereumAddress;
+  referralFee: number;
+  amount: ModuleFeeAmount;
+};
 
-export type RevertCollectModuleSettings = { __typename: 'RevertCollectModuleSettings', contractAddress: string };
+export type RevertCollectModuleSettings = {
+  __typename: 'RevertCollectModuleSettings';
+  contractAddress: string;
+};
 
-export type TimedFeeCollectModuleSettings = { __typename: 'TimedFeeCollectModuleSettings', contractAddress: string, followerOnly: boolean, endTimestamp: string, recipient: EthereumAddress, referralFee: number, amount: ModuleFeeAmount };
+export type TimedFeeCollectModuleSettings = {
+  __typename: 'TimedFeeCollectModuleSettings';
+  contractAddress: string;
+  followerOnly: boolean;
+  endTimestamp: string;
+  recipient: EthereumAddress;
+  referralFee: number;
+  amount: ModuleFeeAmount;
+};
 
-export type Wallet = { __typename: 'Wallet', address: EthereumAddress, defaultProfile: Profile | null };
+export type Wallet = {
+  __typename: 'Wallet';
+  address: EthereumAddress;
+  defaultProfile: Profile | null;
+};
 
-export type Media = { __typename: 'Media', altTag: string | null, cover: Url | null, mimeType: string | null, url: Url };
+export type Media = {
+  __typename: 'Media';
+  altTag: string | null;
+  cover: Url | null;
+  mimeType: string | null;
+  url: Url;
+};
 
-export type MediaSet = { __typename: 'MediaSet', original: Media };
+export type MediaSet = { __typename: 'MediaSet'; original: Media };
 
-export type MetadataOutput = { __typename: 'MetadataOutput', animatedUrl: Url | null, name: string | null, description: string | null, mainContentFocus: PublicationMainFocus, content: string | null, image: Url | null, media: Array<MediaSet>, attributes: Array<MetadataAttributeOutput>, encryptionParams: EncryptionParamsOutput | null };
+export type MetadataOutput = {
+  __typename: 'MetadataOutput';
+  animatedUrl: Url | null;
+  name: string | null;
+  description: string | null;
+  mainContentFocus: PublicationMainFocus;
+  content: string | null;
+  image: Url | null;
+  media: Array<MediaSet>;
+  attributes: Array<MetadataAttributeOutput>;
+  encryptionParams: EncryptionParamsOutput | null;
+};
 
-export type MetadataAttributeOutput = { __typename: 'MetadataAttributeOutput', traitType: string | null, value: string | null };
+export type MetadataAttributeOutput = {
+  __typename: 'MetadataAttributeOutput';
+  traitType: string | null;
+  value: string | null;
+};
 
-export type PublicationStats = { __typename: 'PublicationStats', totalAmountOfMirrors: number, totalUpvotes: number, totalDownvotes: number, totalAmountOfCollects: number, totalAmountOfComments: number, commentsCount: number };
+export type PublicationStats = {
+  __typename: 'PublicationStats';
+  totalAmountOfMirrors: number;
+  totalUpvotes: number;
+  totalDownvotes: number;
+  totalAmountOfCollects: number;
+  totalAmountOfComments: number;
+  commentsCount: number;
+};
 
-export type MirrorBase = { __typename: 'Mirror', id: PublicationId, createdAt: string, hidden: boolean, profile: Profile };
+export type MirrorBase = {
+  __typename: 'Mirror';
+  id: PublicationId;
+  createdAt: string;
+  hidden: boolean;
+  profile: Profile;
+};
 
-export type Mirror = (
-  { __typename: 'Mirror', mirrorOf: Comment | Post }
-  & MirrorBase
-);
+export type Mirror = { __typename: 'Mirror'; mirrorOf: Comment | Post } & MirrorBase;
 
-export type FollowOnlyReferenceModuleSettings = { __typename: 'FollowOnlyReferenceModuleSettings', contractAddress: string };
+export type FollowOnlyReferenceModuleSettings = {
+  __typename: 'FollowOnlyReferenceModuleSettings';
+  contractAddress: string;
+};
 
-export type DegreesOfSeparationReferenceModuleSettings = { __typename: 'DegreesOfSeparationReferenceModuleSettings', contractAddress: string, commentsRestricted: boolean, degreesOfSeparation: number, mirrorsRestricted: boolean };
+export type DegreesOfSeparationReferenceModuleSettings = {
+  __typename: 'DegreesOfSeparationReferenceModuleSettings';
+  contractAddress: string;
+  commentsRestricted: boolean;
+  degreesOfSeparation: number;
+  mirrorsRestricted: boolean;
+};
 
-export type UnknownReferenceModuleSettings = { __typename: 'UnknownReferenceModuleSettings', contractAddress: string, referenceModuleReturnData: string };
+export type UnknownReferenceModuleSettings = {
+  __typename: 'UnknownReferenceModuleSettings';
+  contractAddress: string;
+  referenceModuleReturnData: string;
+};
 
-export type CommentBase = { __typename: 'Comment', id: PublicationId, collectNftAddress: string | null, createdAt: string, hidden: boolean, isGated: boolean, reaction: ReactionTypes | null, hasCollectedByMe: boolean, mirrors: Array<PublicationId>, hasOptimisticCollectedByMe: boolean, isOptimisticMirroredByMe: boolean, collectPolicy: CollectPolicy, referencePolicy: ReferencePolicy, decryptionCriteria: DecryptionCriteria | null, stats: PublicationStats, metadata: MetadataOutput, profile: Profile, collectedBy: Wallet | null, collectModule: AaveFeeCollectModuleSettings | Erc4626FeeCollectModuleSettings | FeeCollectModuleSettings | FreeCollectModuleSettings | LimitedFeeCollectModuleSettings | LimitedTimedFeeCollectModuleSettings | MultirecipientFeeCollectModuleSettings | RevertCollectModuleSettings | TimedFeeCollectModuleSettings | UnknownCollectModuleSettings, referenceModule: DegreesOfSeparationReferenceModuleSettings | FollowOnlyReferenceModuleSettings | UnknownReferenceModuleSettings | null, canComment: { result: boolean }, canMirror: { result: boolean }, canObserverDecrypt: { result: boolean, reasons: Array<DecryptFailReason> | null } };
+export type CommentBase = {
+  __typename: 'Comment';
+  id: PublicationId;
+  collectNftAddress: string | null;
+  createdAt: string;
+  hidden: boolean;
+  isGated: boolean;
+  reaction: ReactionTypes | null;
+  hasCollectedByMe: boolean;
+  mirrors: Array<PublicationId>;
+  hasOptimisticCollectedByMe: boolean;
+  isOptimisticMirroredByMe: boolean;
+  collectPolicy: CollectPolicy;
+  referencePolicy: ReferencePolicy;
+  decryptionCriteria: DecryptionCriteria | null;
+  stats: PublicationStats;
+  metadata: MetadataOutput;
+  profile: Profile;
+  collectedBy: Wallet | null;
+  collectModule:
+    | AaveFeeCollectModuleSettings
+    | Erc4626FeeCollectModuleSettings
+    | FeeCollectModuleSettings
+    | FreeCollectModuleSettings
+    | LimitedFeeCollectModuleSettings
+    | LimitedTimedFeeCollectModuleSettings
+    | MultirecipientFeeCollectModuleSettings
+    | RevertCollectModuleSettings
+    | TimedFeeCollectModuleSettings
+    | UnknownCollectModuleSettings;
+  referenceModule:
+    | DegreesOfSeparationReferenceModuleSettings
+    | FollowOnlyReferenceModuleSettings
+    | UnknownReferenceModuleSettings
+    | null;
+  canComment: { result: boolean };
+  canMirror: { result: boolean };
+  canObserverDecrypt: { result: boolean; reasons: Array<DecryptFailReason> | null };
+};
 
-export type CommonPaginatedResultInfo = { __typename: 'PaginatedResultInfo', prev: string | null, next: string | null, totalCount: number | null };
+export type CommonPaginatedResultInfo = {
+  __typename: 'PaginatedResultInfo';
+  prev: string | null;
+  next: string | null;
+  totalCount: number | null;
+};
 
-export type Comment = (
-  { __typename: 'Comment', commentOn: CommentBase | MirrorBase | Post | null, mainPost: MirrorBase | Post }
-  & CommentBase
-);
+export type Comment = {
+  __typename: 'Comment';
+  commentOn: CommentBase | MirrorBase | Post | null;
+  mainPost: MirrorBase | Post;
+} & CommentBase;
 
-export type Post = { __typename: 'Post', id: PublicationId, collectNftAddress: string | null, createdAt: string, hidden: boolean, isGated: boolean, reaction: ReactionTypes | null, hasCollectedByMe: boolean, mirrors: Array<PublicationId>, hasOptimisticCollectedByMe: boolean, isOptimisticMirroredByMe: boolean, collectPolicy: CollectPolicy, referencePolicy: ReferencePolicy, decryptionCriteria: DecryptionCriteria | null, stats: PublicationStats, metadata: MetadataOutput, profile: Profile, collectedBy: Wallet | null, collectModule: AaveFeeCollectModuleSettings | Erc4626FeeCollectModuleSettings | FeeCollectModuleSettings | FreeCollectModuleSettings | LimitedFeeCollectModuleSettings | LimitedTimedFeeCollectModuleSettings | MultirecipientFeeCollectModuleSettings | RevertCollectModuleSettings | TimedFeeCollectModuleSettings | UnknownCollectModuleSettings, referenceModule: DegreesOfSeparationReferenceModuleSettings | FollowOnlyReferenceModuleSettings | UnknownReferenceModuleSettings | null, canComment: { result: boolean }, canMirror: { result: boolean }, canObserverDecrypt: { result: boolean, reasons: Array<DecryptFailReason> | null } };
+export type Post = {
+  __typename: 'Post';
+  id: PublicationId;
+  collectNftAddress: string | null;
+  createdAt: string;
+  hidden: boolean;
+  isGated: boolean;
+  reaction: ReactionTypes | null;
+  hasCollectedByMe: boolean;
+  mirrors: Array<PublicationId>;
+  hasOptimisticCollectedByMe: boolean;
+  isOptimisticMirroredByMe: boolean;
+  collectPolicy: CollectPolicy;
+  referencePolicy: ReferencePolicy;
+  decryptionCriteria: DecryptionCriteria | null;
+  stats: PublicationStats;
+  metadata: MetadataOutput;
+  profile: Profile;
+  collectedBy: Wallet | null;
+  collectModule:
+    | AaveFeeCollectModuleSettings
+    | Erc4626FeeCollectModuleSettings
+    | FeeCollectModuleSettings
+    | FreeCollectModuleSettings
+    | LimitedFeeCollectModuleSettings
+    | LimitedTimedFeeCollectModuleSettings
+    | MultirecipientFeeCollectModuleSettings
+    | RevertCollectModuleSettings
+    | TimedFeeCollectModuleSettings
+    | UnknownCollectModuleSettings;
+  referenceModule:
+    | DegreesOfSeparationReferenceModuleSettings
+    | FollowOnlyReferenceModuleSettings
+    | UnknownReferenceModuleSettings
+    | null;
+  canComment: { result: boolean };
+  canMirror: { result: boolean };
+  canObserverDecrypt: { result: boolean; reasons: Array<DecryptFailReason> | null };
+};
 
-export type PendingPost = { __typename: 'PendingPost', id: PublicationId, content: string | null, locale: string, mainContentFocus: PublicationMainFocus, media: Array<Media> | null, profile: Profile };
+export type PendingPost = {
+  __typename: 'PendingPost';
+  id: PublicationId;
+  content: string | null;
+  locale: string;
+  mainContentFocus: PublicationMainFocus;
+  media: Array<Media> | null;
+  profile: Profile;
+};
 
-export type Eip712TypedDataDomain = { __typename: 'EIP712TypedDataDomain', name: string, chainId: number, version: string, verifyingContract: string };
+export type Eip712TypedDataDomain = {
+  __typename: 'EIP712TypedDataDomain';
+  name: string;
+  chainId: number;
+  version: string;
+  verifyingContract: string;
+};
 
-export type EnabledModuleCurrenciesVariables = Exact<{ [key: string]: never; }>;
-
+export type EnabledModuleCurrenciesVariables = Exact<{ [key: string]: never }>;
 
 export type EnabledModuleCurrenciesData = { result: Array<Erc20Fields> };
 
-export type ElectedMirror = { __typename: 'ElectedMirror', mirrorId: PublicationId, timestamp: string, profile: Profile };
+export type ElectedMirror = {
+  __typename: 'ElectedMirror';
+  mirrorId: PublicationId;
+  timestamp: string;
+  profile: Profile;
+};
 
-export type MirrorEvent = { __typename: 'MirrorEvent', timestamp: string, profile: Profile };
+export type MirrorEvent = { __typename: 'MirrorEvent'; timestamp: string; profile: Profile };
 
-export type CollectedEvent = { __typename: 'CollectedEvent', timestamp: string, profile: Profile };
+export type CollectedEvent = { __typename: 'CollectedEvent'; timestamp: string; profile: Profile };
 
-export type ReactionEvent = { __typename: 'ReactionEvent', reaction: ReactionTypes, timestamp: string, profile: Profile };
+export type ReactionEvent = {
+  __typename: 'ReactionEvent';
+  reaction: ReactionTypes;
+  timestamp: string;
+  profile: Profile;
+};
 
-export type FeedItem = { __typename: 'FeedItem', root: Comment | Post, comments: Array<Comment> | null, electedMirror: ElectedMirror | null, mirrors: Array<MirrorEvent>, collects: Array<CollectedEvent>, reactions: Array<ReactionEvent> };
+export type FeedItem = {
+  __typename: 'FeedItem';
+  root: Comment | Post;
+  comments: Array<Comment> | null;
+  electedMirror: ElectedMirror | null;
+  mirrors: Array<MirrorEvent>;
+  collects: Array<CollectedEvent>;
+  reactions: Array<ReactionEvent>;
+};
 
 export type FeedVariables = Exact<{
   profileId: Scalars['ProfileId'];
@@ -1756,8 +2035,7 @@ export type FeedVariables = Exact<{
   metadata?: InputMaybe<PublicationMetadataFilters>;
 }>;
 
-
-export type FeedData = { result: { items: Array<FeedItem>, pageInfo: CommonPaginatedResultInfo } };
+export type FeedData = { result: { items: Array<FeedItem>; pageInfo: CommonPaginatedResultInfo } };
 
 export type ExploreProfilesVariables = Exact<{
   sortCriteria: ProfileSortCriteria;
@@ -1767,87 +2045,224 @@ export type ExploreProfilesVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type ExploreProfilesData = { result: { items: Array<Profile>, pageInfo: CommonPaginatedResultInfo } };
+export type ExploreProfilesData = {
+  result: { items: Array<Profile>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type CreateFollowTypedDataVariables = Exact<{
   request: FollowRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
+export type CreateFollowTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { FollowWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomain;
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileIds: Array<ProfileId>;
+        datas: Array<unknown>;
+      };
+    };
+  };
+};
 
-export type CreateFollowTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { FollowWithSig: Array<{ name: string, type: string }> }, domain: Eip712TypedDataDomain, value: { nonce: number, deadline: unknown, profileIds: Array<ProfileId>, datas: Array<unknown> } } } };
+export type NftOwnershipOutput = {
+  __typename: 'NftOwnershipOutput';
+  contractAddress: string;
+  chainID: number;
+  contractType: ContractType;
+  tokenIds: Array<string> | null;
+};
 
-export type NftOwnershipOutput = { __typename: 'NftOwnershipOutput', contractAddress: string, chainID: number, contractType: ContractType, tokenIds: Array<string> | null };
+export type Erc20OwnershipOutput = {
+  __typename: 'Erc20OwnershipOutput';
+  amount: string;
+  chainID: number;
+  condition: ScalarOperator;
+  contractAddress: string;
+  decimals: number;
+  name: string;
+  symbol: string;
+};
 
-export type Erc20OwnershipOutput = { __typename: 'Erc20OwnershipOutput', amount: string, chainID: number, condition: ScalarOperator, contractAddress: string, decimals: number, name: string, symbol: string };
+export type EoaOwnershipOutput = { __typename: 'EoaOwnershipOutput'; address: EthereumAddress };
 
-export type EoaOwnershipOutput = { __typename: 'EoaOwnershipOutput', address: EthereumAddress };
+export type ProfileOwnershipOutput = { __typename: 'ProfileOwnershipOutput'; profileId: ProfileId };
 
-export type ProfileOwnershipOutput = { __typename: 'ProfileOwnershipOutput', profileId: ProfileId };
+export type FollowConditionOutput = { __typename: 'FollowConditionOutput'; profileId: ProfileId };
 
-export type FollowConditionOutput = { __typename: 'FollowConditionOutput', profileId: ProfileId };
+export type CollectConditionOutput = {
+  __typename: 'CollectConditionOutput';
+  publicationId: PublicationId | null;
+  thisPublication: boolean | null;
+};
 
-export type CollectConditionOutput = { __typename: 'CollectConditionOutput', publicationId: PublicationId | null, thisPublication: boolean | null };
+export type LeafConditionOutput = {
+  __typename: 'AccessConditionOutput';
+  nft: NftOwnershipOutput | null;
+  token: Erc20OwnershipOutput | null;
+  eoa: EoaOwnershipOutput | null;
+  profile: ProfileOwnershipOutput | null;
+  follow: FollowConditionOutput | null;
+  collect: CollectConditionOutput | null;
+};
 
-export type LeafConditionOutput = { __typename: 'AccessConditionOutput', nft: NftOwnershipOutput | null, token: Erc20OwnershipOutput | null, eoa: EoaOwnershipOutput | null, profile: ProfileOwnershipOutput | null, follow: FollowConditionOutput | null, collect: CollectConditionOutput | null };
+export type OrConditionOutput = {
+  __typename: 'OrConditionOutput';
+  criteria: Array<LeafConditionOutput>;
+};
 
-export type OrConditionOutput = { __typename: 'OrConditionOutput', criteria: Array<LeafConditionOutput> };
+export type AndConditionOutput = {
+  __typename: 'AndConditionOutput';
+  criteria: Array<LeafConditionOutput>;
+};
 
-export type AndConditionOutput = { __typename: 'AndConditionOutput', criteria: Array<LeafConditionOutput> };
+export type AnyConditionOutput = {
+  __typename: 'AccessConditionOutput';
+  or: OrConditionOutput | null;
+  and: AndConditionOutput | null;
+} & LeafConditionOutput;
 
-export type AnyConditionOutput = (
-  { __typename: 'AccessConditionOutput', or: OrConditionOutput | null, and: AndConditionOutput | null }
-  & LeafConditionOutput
-);
+export type RootConditionOutput = {
+  __typename: 'AccessConditionOutput';
+  or: { criteria: Array<AnyConditionOutput> } | null;
+};
 
-export type RootConditionOutput = { __typename: 'AccessConditionOutput', or: { criteria: Array<AnyConditionOutput> } | null };
+export type EncryptedMedia = {
+  __typename: 'EncryptedMedia';
+  altTag: string | null;
+  cover: string | null;
+  mimeType: string | null;
+  url: Url;
+};
 
-export type EncryptedMedia = { __typename: 'EncryptedMedia', altTag: string | null, cover: string | null, mimeType: string | null, url: Url };
+export type EncryptedMediaSet = { __typename: 'EncryptedMediaSet'; original: EncryptedMedia };
 
-export type EncryptedMediaSet = { __typename: 'EncryptedMediaSet', original: EncryptedMedia };
+export type EncryptedFieldsOutput = {
+  __typename: 'EncryptedFieldsOutput';
+  animation_url: string | null;
+  content: string | null;
+  external_url: string | null;
+  image: string | null;
+  media: Array<{ original: EncryptedMedia }> | null;
+};
 
-export type EncryptedFieldsOutput = { __typename: 'EncryptedFieldsOutput', animation_url: string | null, content: string | null, external_url: string | null, image: string | null, media: Array<{ original: EncryptedMedia }> | null };
-
-export type EncryptionParamsOutput = { __typename: 'EncryptionParamsOutput', encryptionProvider: EncryptionProvider, accessCondition: RootConditionOutput, encryptedFields: EncryptedFieldsOutput, providerSpecificParams: { encryptionKey: ContentEncryptionKey } };
+export type EncryptionParamsOutput = {
+  __typename: 'EncryptionParamsOutput';
+  encryptionProvider: EncryptionProvider;
+  accessCondition: RootConditionOutput;
+  encryptedFields: EncryptedFieldsOutput;
+  providerSpecificParams: { encryptionKey: ContentEncryptionKey };
+};
 
 export type CreateMirrorTypedDataVariables = Exact<{
   request: CreateMirrorRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreateMirrorTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { MirrorWithSig: Array<{ name: string, type: string }> }, domain: Eip712TypedDataDomain, value: { nonce: number, deadline: unknown, profileId: ProfileId, profileIdPointed: ProfileId, pubIdPointed: unknown, referenceModuleData: string, referenceModule: string, referenceModuleInitData: string } } } };
+export type CreateMirrorTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { MirrorWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomain;
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileId: ProfileId;
+        profileIdPointed: ProfileId;
+        pubIdPointed: unknown;
+        referenceModuleData: string;
+        referenceModule: string;
+        referenceModuleInitData: string;
+      };
+    };
+  };
+};
 
 export type CreateMirrorViaDispatcherVariables = Exact<{
   request: CreateMirrorRequest;
 }>;
 
+export type CreateMirrorViaDispatcherData = {
+  result: RelayResult_RelayError_ | RelayResult_RelayerResult_;
+};
 
-export type CreateMirrorViaDispatcherData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
+export type ModuleInfo = { __typename: 'ModuleInfo'; name: string; type: string };
 
-export type ModuleInfo = { __typename: 'ModuleInfo', name: string, type: string };
+export type EnabledModule = {
+  __typename: 'EnabledModule';
+  moduleName: string;
+  contractAddress: string;
+  inputParams: Array<ModuleInfo>;
+  redeemParams: Array<ModuleInfo>;
+  returnDataParams: Array<ModuleInfo>;
+};
 
-export type EnabledModule = { __typename: 'EnabledModule', moduleName: string, contractAddress: string, inputParams: Array<ModuleInfo>, redeemParams: Array<ModuleInfo>, returnDataParams: Array<ModuleInfo> };
+export type EnabledModules = {
+  __typename: 'EnabledModules';
+  collectModules: Array<EnabledModule>;
+  followModules: Array<EnabledModule>;
+  referenceModules: Array<EnabledModule>;
+};
 
-export type EnabledModules = { __typename: 'EnabledModules', collectModules: Array<EnabledModule>, followModules: Array<EnabledModule>, referenceModules: Array<EnabledModule> };
-
-export type EnabledModulesVariables = Exact<{ [key: string]: never; }>;
-
+export type EnabledModulesVariables = Exact<{ [key: string]: never }>;
 
 export type EnabledModulesData = { result: EnabledModules };
 
-export type NewFollowerNotification = { __typename: 'NewFollowerNotification', notificationId: string, createdAt: string, isFollowedByMe: boolean, wallet: Wallet };
+export type NewFollowerNotification = {
+  __typename: 'NewFollowerNotification';
+  notificationId: string;
+  createdAt: string;
+  isFollowedByMe: boolean;
+  wallet: Wallet;
+};
 
-export type NewCollectNotification = { __typename: 'NewCollectNotification', notificationId: string, createdAt: string, wallet: Wallet, collectedPublication: Comment | Mirror | Post };
+export type NewCollectNotification = {
+  __typename: 'NewCollectNotification';
+  notificationId: string;
+  createdAt: string;
+  wallet: Wallet;
+  collectedPublication: Comment | Mirror | Post;
+};
 
-export type NewMirrorNotification = { __typename: 'NewMirrorNotification', notificationId: string, createdAt: string, profile: Profile, publication: Comment | Post };
+export type NewMirrorNotification = {
+  __typename: 'NewMirrorNotification';
+  notificationId: string;
+  createdAt: string;
+  profile: Profile;
+  publication: Comment | Post;
+};
 
-export type NewCommentNotification = { __typename: 'NewCommentNotification', notificationId: string, createdAt: string, profile: Profile, comment: Comment };
+export type NewCommentNotification = {
+  __typename: 'NewCommentNotification';
+  notificationId: string;
+  createdAt: string;
+  profile: Profile;
+  comment: Comment;
+};
 
-export type NewMentionNotification = { __typename: 'NewMentionNotification', notificationId: string, createdAt: string, mentionPublication: Comment | Post };
+export type NewMentionNotification = {
+  __typename: 'NewMentionNotification';
+  notificationId: string;
+  createdAt: string;
+  mentionPublication: Comment | Post;
+};
 
-export type NewReactionNotification = { __typename: 'NewReactionNotification', notificationId: string, createdAt: string, reaction: ReactionTypes, profile: Profile, publication: Comment | Mirror | Post };
+export type NewReactionNotification = {
+  __typename: 'NewReactionNotification';
+  notificationId: string;
+  createdAt: string;
+  reaction: ReactionTypes;
+  profile: Profile;
+  publication: Comment | Mirror | Post;
+};
 
 export type NotificationsVariables = Exact<{
   observerId: Scalars['ProfileId'];
@@ -1857,15 +2272,25 @@ export type NotificationsVariables = Exact<{
   notificationTypes?: InputMaybe<Array<NotificationTypes> | NotificationTypes>;
 }>;
 
-
-export type NotificationsData = { result: { items: Array<NewCollectNotification | NewCommentNotification | NewFollowerNotification | NewMentionNotification | NewMirrorNotification | NewReactionNotification>, pageInfo: CommonPaginatedResultInfo } };
+export type NotificationsData = {
+  result: {
+    items: Array<
+      | NewCollectNotification
+      | NewCommentNotification
+      | NewFollowerNotification
+      | NewMentionNotification
+      | NewMirrorNotification
+      | NewReactionNotification
+    >;
+    pageInfo: CommonPaginatedResultInfo;
+  };
+};
 
 export type UnreadNotificationCountVariables = Exact<{
   profileId: Scalars['ProfileId'];
   sources?: InputMaybe<Array<Scalars['Sources']> | Scalars['Sources']>;
   notificationTypes?: InputMaybe<Array<NotificationTypes> | NotificationTypes>;
 }>;
-
 
 export type UnreadNotificationCountData = { result: { pageInfo: { totalCount: number | null } } };
 
@@ -1874,45 +2299,144 @@ export type CreatePostTypedDataVariables = Exact<{
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreatePostTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { PostWithSig: Array<{ name: string, type: string }> }, domain: Eip712TypedDataDomain, value: { nonce: number, deadline: unknown, profileId: ProfileId, contentURI: unknown, collectModule: string, collectModuleInitData: unknown, referenceModule: string, referenceModuleInitData: string } } } };
+export type CreatePostTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { PostWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomain;
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileId: ProfileId;
+        contentURI: unknown;
+        collectModule: string;
+        collectModuleInitData: unknown;
+        referenceModule: string;
+        referenceModuleInitData: string;
+      };
+    };
+  };
+};
 
 export type CreatePostViaDispatcherVariables = Exact<{
   request: CreatePublicPostRequest;
 }>;
 
-
-export type CreatePostViaDispatcherData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
+export type CreatePostViaDispatcherData = {
+  result: RelayResult_RelayError_ | RelayResult_RelayerResult_;
+};
 
 export type CreateSetDispatcherTypedDataVariables = Exact<{
   request: SetDispatcherRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
+export type CreateSetDispatcherTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { SetDispatcherWithSig: Array<{ name: string; type: string }> };
+      domain: { name: string; chainId: number; version: string; verifyingContract: string };
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileId: ProfileId;
+        dispatcher: EthereumAddress;
+      };
+    };
+  };
+};
 
-export type CreateSetDispatcherTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { SetDispatcherWithSig: Array<{ name: string, type: string }> }, domain: { name: string, chainId: number, version: string, verifyingContract: string }, value: { nonce: number, deadline: unknown, profileId: ProfileId, dispatcher: EthereumAddress } } } };
+export type FeeFollowModuleSettings = {
+  __typename: 'FeeFollowModuleSettings';
+  contractAddress: string;
+  recipient: EthereumAddress;
+  amount: ModuleFeeAmount;
+};
 
-export type FeeFollowModuleSettings = { __typename: 'FeeFollowModuleSettings', contractAddress: string, recipient: EthereumAddress, amount: ModuleFeeAmount };
+export type ProfileFollowModuleSettings = {
+  __typename: 'ProfileFollowModuleSettings';
+  contractAddress: string;
+};
 
-export type ProfileFollowModuleSettings = { __typename: 'ProfileFollowModuleSettings', contractAddress: string };
+export type RevertFollowModuleSettings = {
+  __typename: 'RevertFollowModuleSettings';
+  contractAddress: string;
+};
 
-export type RevertFollowModuleSettings = { __typename: 'RevertFollowModuleSettings', contractAddress: string };
+export type UnknownFollowModuleSettings = {
+  __typename: 'UnknownFollowModuleSettings';
+  contractAddress: string;
+};
 
-export type UnknownFollowModuleSettings = { __typename: 'UnknownFollowModuleSettings', contractAddress: string };
+export type NftImage = {
+  __typename: 'NftImage';
+  contractAddress: string;
+  tokenId: string;
+  uri: Url;
+  verified: boolean;
+};
 
-export type NftImage = { __typename: 'NftImage', contractAddress: string, tokenId: string, uri: Url, verified: boolean };
+export type Attribute = {
+  __typename: 'Attribute';
+  displayType: string | null;
+  key: string;
+  value: string;
+};
 
-export type Attribute = { __typename: 'Attribute', displayType: string | null, key: string, value: string };
+export type ProfileStats = {
+  __typename: 'ProfileStats';
+  totalCollects: number;
+  totalComments: number;
+  totalFollowers: number;
+  totalFollowing: number;
+  totalMirrors: number;
+  totalPosts: number;
+  totalPublications: number;
+  commentsCount: number;
+  postsCount: number;
+  mirrorsCount: number;
+};
 
-export type ProfileStats = { __typename: 'ProfileStats', totalCollects: number, totalComments: number, totalFollowers: number, totalFollowing: number, totalMirrors: number, totalPosts: number, totalPublications: number, commentsCount: number, postsCount: number, mirrorsCount: number };
-
-export type Profile = { __typename: 'Profile', id: ProfileId, name: string | null, bio: string | null, handle: string, ownedBy: EthereumAddress, followPolicy: FollowPolicy, isFollowedByMe: boolean, followStatus: FollowStatus | null, ownedByMe: boolean, attributes: ProfileAttributes, isFollowingObserver: boolean, picture: MediaSet | NftImage | null, coverPicture: MediaSet | NftImage | null, stats: ProfileStats, followModule: FeeFollowModuleSettings | ProfileFollowModuleSettings | RevertFollowModuleSettings | UnknownFollowModuleSettings | null, __attributes: Array<Attribute> | null, dispatcher: { address: EthereumAddress, canUseRelay: boolean } | null, onChainIdentity: { proofOfHumanity: boolean, ens: { name: unknown | null } | null, sybilDotOrg: { verified: boolean, source: { twitter: { handle: string | null } } }, worldcoin: { isHuman: boolean } } };
+export type Profile = {
+  __typename: 'Profile';
+  id: ProfileId;
+  name: string | null;
+  bio: string | null;
+  handle: string;
+  ownedBy: EthereumAddress;
+  followPolicy: FollowPolicy;
+  isFollowedByMe: boolean;
+  followStatus: FollowStatus | null;
+  ownedByMe: boolean;
+  attributes: ProfileAttributes;
+  isFollowingObserver: boolean;
+  picture: MediaSet | NftImage | null;
+  coverPicture: MediaSet | NftImage | null;
+  stats: ProfileStats;
+  followModule:
+    | FeeFollowModuleSettings
+    | ProfileFollowModuleSettings
+    | RevertFollowModuleSettings
+    | UnknownFollowModuleSettings
+    | null;
+  __attributes: Array<Attribute> | null;
+  dispatcher: { address: EthereumAddress; canUseRelay: boolean } | null;
+  onChainIdentity: {
+    proofOfHumanity: boolean;
+    ens: { name: unknown | null } | null;
+    sybilDotOrg: { verified: boolean; source: { twitter: { handle: string | null } } };
+    worldcoin: { isHuman: boolean };
+  };
+};
 
 export type ProfilesToFollowVariables = Exact<{
   observerId?: InputMaybe<Scalars['ProfileId']>;
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
-
 
 export type ProfilesToFollowData = { result: Array<Profile> };
 
@@ -1921,7 +2445,6 @@ export type GetProfileVariables = Exact<{
   observerId?: InputMaybe<Scalars['ProfileId']>;
   sources?: InputMaybe<Array<Scalars['Sources']> | Scalars['Sources']>;
 }>;
-
 
 export type GetProfileData = { result: Profile | null };
 
@@ -1936,13 +2459,13 @@ export type GetAllProfilesVariables = Exact<{
   sources?: InputMaybe<Array<Scalars['Sources']> | Scalars['Sources']>;
 }>;
 
-
-export type GetAllProfilesData = { result: { items: Array<Profile>, pageInfo: CommonPaginatedResultInfo } };
+export type GetAllProfilesData = {
+  result: { items: Array<Profile>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type CreateProfileVariables = Exact<{
   request: CreateProfileRequest;
 }>;
-
 
 export type CreateProfileData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
 
@@ -1954,50 +2477,86 @@ export type MutualFollowersProfilesVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type MutualFollowersProfilesData = { result: { items: Array<Profile>, pageInfo: CommonPaginatedResultInfo } };
+export type MutualFollowersProfilesData = {
+  result: { items: Array<Profile>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type CreateSetFollowModuleTypedDataVariables = Exact<{
   request: CreateSetFollowModuleRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreateSetFollowModuleTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { SetFollowModuleWithSig: Array<{ name: string, type: string }> }, domain: { name: string, chainId: number, version: string, verifyingContract: string }, value: { nonce: number, deadline: unknown, profileId: ProfileId, followModule: string, followModuleInitData: unknown } } } };
+export type CreateSetFollowModuleTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { SetFollowModuleWithSig: Array<{ name: string; type: string }> };
+      domain: { name: string; chainId: number; version: string; verifyingContract: string };
+      value: {
+        nonce: number;
+        deadline: unknown;
+        profileId: ProfileId;
+        followModule: string;
+        followModuleInitData: unknown;
+      };
+    };
+  };
+};
 
 export type CreateSetProfileImageUriTypedDataVariables = Exact<{
   request: UpdateProfileImageRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreateSetProfileImageUriTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { SetProfileImageURIWithSig: Array<{ name: string, type: string }> }, domain: { name: string, chainId: number, version: string, verifyingContract: string }, value: { nonce: number, deadline: unknown, profileId: ProfileId, imageURI: Url } } } };
+export type CreateSetProfileImageUriTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { SetProfileImageURIWithSig: Array<{ name: string; type: string }> };
+      domain: { name: string; chainId: number; version: string; verifyingContract: string };
+      value: { nonce: number; deadline: unknown; profileId: ProfileId; imageURI: Url };
+    };
+  };
+};
 
 export type CreateSetProfileImageUriViaDispatcherVariables = Exact<{
   request: UpdateProfileImageRequest;
 }>;
 
-
-export type CreateSetProfileImageUriViaDispatcherData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
+export type CreateSetProfileImageUriViaDispatcherData = {
+  result: RelayResult_RelayError_ | RelayResult_RelayerResult_;
+};
 
 export type CreateSetProfileMetadataTypedDataVariables = Exact<{
   request: CreatePublicSetProfileMetadataUriRequest;
   options?: InputMaybe<TypedDataOptions>;
 }>;
 
-
-export type CreateSetProfileMetadataTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { SetProfileMetadataURIWithSig: Array<{ name: string, type: string }> }, domain: { name: string, chainId: number, version: string, verifyingContract: string }, value: { nonce: number, deadline: unknown, profileId: ProfileId, metadata: Url } } } };
+export type CreateSetProfileMetadataTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { SetProfileMetadataURIWithSig: Array<{ name: string; type: string }> };
+      domain: { name: string; chainId: number; version: string; verifyingContract: string };
+      value: { nonce: number; deadline: unknown; profileId: ProfileId; metadata: Url };
+    };
+  };
+};
 
 export type CreateSetProfileMetadataViaDispatcherVariables = Exact<{
   request: CreatePublicSetProfileMetadataUriRequest;
 }>;
 
+export type CreateSetProfileMetadataViaDispatcherData = {
+  result: RelayResult_RelayError_ | RelayResult_RelayerResult_;
+};
 
-export type CreateSetProfileMetadataViaDispatcherData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
+export type Follower = { __typename: 'Follower'; wallet: Wallet };
 
-export type Follower = { __typename: 'Follower', wallet: Wallet };
-
-export type Following = { __typename: 'Following', profile: Profile };
+export type Following = { __typename: 'Following'; profile: Profile };
 
 export type ProfileFollowersVariables = Exact<{
   profileId: Scalars['ProfileId'];
@@ -2007,8 +2566,9 @@ export type ProfileFollowersVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type ProfileFollowersData = { result: { items: Array<Follower>, pageInfo: CommonPaginatedResultInfo } };
+export type ProfileFollowersData = {
+  result: { items: Array<Follower>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type ProfileFollowingVariables = Exact<{
   walletAddress: Scalars['EthereumAddress'];
@@ -2018,26 +2578,36 @@ export type ProfileFollowingVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
+export type ProfileFollowingData = {
+  result: { items: Array<Following>; pageInfo: CommonPaginatedResultInfo };
+};
 
-export type ProfileFollowingData = { result: { items: Array<Following>, pageInfo: CommonPaginatedResultInfo } };
+export type ProxyActionStatusResult = {
+  __typename: 'ProxyActionStatusResult';
+  txHash: string;
+  txId: string;
+  status: ProxyActionStatusTypes;
+};
 
-export type ProxyActionStatusResult = { __typename: 'ProxyActionStatusResult', txHash: string, txId: string, status: ProxyActionStatusTypes };
+export type ProxyActionError = {
+  __typename: 'ProxyActionError';
+  reason: string;
+  lastKnownTxId: string | null;
+};
 
-export type ProxyActionError = { __typename: 'ProxyActionError', reason: string, lastKnownTxId: string | null };
-
-export type ProxyActionQueued = { __typename: 'ProxyActionQueued', queuedAt: string };
+export type ProxyActionQueued = { __typename: 'ProxyActionQueued'; queuedAt: string };
 
 export type ProxyActionStatusVariables = Exact<{
   proxyActionId: Scalars['ProxyActionId'];
 }>;
 
-
-export type ProxyActionStatusData = { result: ProxyActionError | ProxyActionQueued | ProxyActionStatusResult };
+export type ProxyActionStatusData = {
+  result: ProxyActionError | ProxyActionQueued | ProxyActionStatusResult;
+};
 
 export type ProxyActionVariables = Exact<{
   request: ProxyActionRequest;
 }>;
-
 
 export type ProxyActionData = { result: string };
 
@@ -2047,7 +2617,6 @@ export type PublicationVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
 export type PublicationData = { result: Comment | Mirror | Post | null };
 
 export type PublicationByTxHashVariables = Exact<{
@@ -2056,13 +2625,11 @@ export type PublicationByTxHashVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
 export type PublicationByTxHashData = { result: CommentWithFirstComment | Mirror | Post | null };
 
 export type HidePublicationVariables = Exact<{
   publicationId: Scalars['InternalPublicationId'];
 }>;
-
 
 export type HidePublicationData = { hidePublication: void | null };
 
@@ -2076,8 +2643,9 @@ export type PublicationsVariables = Exact<{
   metadata?: InputMaybe<PublicationMetadataFilters>;
 }>;
 
-
-export type PublicationsData = { result: { items: Array<Comment | Mirror | Post>, pageInfo: CommonPaginatedResultInfo } };
+export type PublicationsData = {
+  result: { items: Array<Comment | Mirror | Post>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type ExplorePublicationsVariables = Exact<{
   cursor?: InputMaybe<Scalars['Cursor']>;
@@ -2091,8 +2659,9 @@ export type ExplorePublicationsVariables = Exact<{
   timestamp?: InputMaybe<Scalars['TimestampScalar']>;
 }>;
 
-
-export type ExplorePublicationsData = { result: { items: Array<Comment | Mirror | Post>, pageInfo: CommonPaginatedResultInfo } };
+export type ExplorePublicationsData = {
+  result: { items: Array<Comment | Mirror | Post>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type WhoCollectedPublicationVariables = Exact<{
   publicationId: Scalars['InternalPublicationId'];
@@ -2102,8 +2671,9 @@ export type WhoCollectedPublicationVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type WhoCollectedPublicationData = { result: { items: Array<Wallet>, pageInfo: CommonPaginatedResultInfo } };
+export type WhoCollectedPublicationData = {
+  result: { items: Array<Wallet>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type ProfilePublicationsForSaleVariables = Exact<{
   profileId: Scalars['ProfileId'];
@@ -2113,15 +2683,15 @@ export type ProfilePublicationsForSaleVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type ProfilePublicationsForSaleData = { result: { items: Array<Comment | Post>, pageInfo: CommonPaginatedResultInfo } };
+export type ProfilePublicationsForSaleData = {
+  result: { items: Array<Comment | Post>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type AddReactionVariables = Exact<{
   publicationId: Scalars['InternalPublicationId'];
   reaction: ReactionTypes;
   profileId: Scalars['ProfileId'];
 }>;
-
 
 export type AddReactionData = { addReaction: void | null };
 
@@ -2131,10 +2701,15 @@ export type RemoveReactionVariables = Exact<{
   profileId: Scalars['ProfileId'];
 }>;
 
-
 export type RemoveReactionData = { removeReaction: void | null };
 
-export type WhoReactedResult = { __typename: 'WhoReactedResult', reactionId: unknown, reaction: ReactionTypes, reactionAt: string, profile: Profile };
+export type WhoReactedResult = {
+  __typename: 'WhoReactedResult';
+  reactionId: unknown;
+  reaction: ReactionTypes;
+  reactionAt: string;
+  profile: Profile;
+};
 
 export type WhoReactedPublicationVariables = Exact<{
   limit?: InputMaybe<Scalars['LimitScalar']>;
@@ -2144,8 +2719,9 @@ export type WhoReactedPublicationVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type WhoReactedPublicationData = { result: { items: Array<WhoReactedResult>, pageInfo: CommonPaginatedResultInfo } };
+export type WhoReactedPublicationData = {
+  result: { items: Array<WhoReactedResult>; pageInfo: CommonPaginatedResultInfo };
+};
 
 export type ReportPublicationVariables = Exact<{
   publicationId: Scalars['InternalPublicationId'];
@@ -2153,19 +2729,25 @@ export type ReportPublicationVariables = Exact<{
   additionalComments?: InputMaybe<Scalars['String']>;
 }>;
 
-
 export type ReportPublicationData = { reportPublication: void | null };
 
-export type RevenueAggregate = { __typename: 'RevenueAggregate', totalAmount: ClientErc20Amount, __total: Erc20AmountFields };
+export type RevenueAggregate = {
+  __typename: 'RevenueAggregate';
+  totalAmount: ClientErc20Amount;
+  __total: Erc20AmountFields;
+};
 
-export type PublicationRevenue = { __typename: 'PublicationRevenue', publication: Comment | Mirror | Post, revenue: RevenueAggregate };
+export type PublicationRevenue = {
+  __typename: 'PublicationRevenue';
+  publication: Comment | Mirror | Post;
+  revenue: RevenueAggregate;
+};
 
 export type GetPublicationRevenueVariables = Exact<{
   publicationId: Scalars['InternalPublicationId'];
   observerId?: InputMaybe<Scalars['ProfileId']>;
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
-
 
 export type GetPublicationRevenueData = { result: PublicationRevenue | null };
 
@@ -2178,15 +2760,18 @@ export type GetProfilePublicationRevenueVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
+export type GetProfilePublicationRevenueData = {
+  result: { items: Array<PublicationRevenue>; pageInfo: CommonPaginatedResultInfo };
+};
 
-export type GetProfilePublicationRevenueData = { result: { items: Array<PublicationRevenue>, pageInfo: CommonPaginatedResultInfo } };
-
-export type ProfileFollowRevenue = { __typename: 'FollowRevenueResult', revenues: Array<RevenueAggregate> };
+export type ProfileFollowRevenue = {
+  __typename: 'FollowRevenueResult';
+  revenues: Array<RevenueAggregate>;
+};
 
 export type ProfileFollowRevenueVariables = Exact<{
   profileId: Scalars['ProfileId'];
 }>;
-
 
 export type ProfileFollowRevenueData = { result: ProfileFollowRevenue };
 
@@ -2198,8 +2783,15 @@ export type SearchPublicationsVariables = Exact<{
   observerId?: InputMaybe<Scalars['ProfileId']>;
 }>;
 
-
-export type SearchPublicationsData = { result: { __typename: 'PublicationSearchResult', items: Array<Comment | Post>, pageInfo: CommonPaginatedResultInfo } | {} };
+export type SearchPublicationsData = {
+  result:
+    | {
+        __typename: 'PublicationSearchResult';
+        items: Array<Comment | Post>;
+        pageInfo: CommonPaginatedResultInfo;
+      }
+    | {};
+};
 
 export type SearchProfilesVariables = Exact<{
   limit: Scalars['LimitScalar'];
@@ -2209,12 +2801,19 @@ export type SearchProfilesVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
+export type SearchProfilesData = {
+  result:
+    | {
+        __typename: 'ProfileSearchResult';
+        items: Array<Profile>;
+        pageInfo: CommonPaginatedResultInfo;
+      }
+    | {};
+};
 
-export type SearchProfilesData = { result: { __typename: 'ProfileSearchResult', items: Array<Profile>, pageInfo: CommonPaginatedResultInfo } | {} };
+export type RelayerResult = { __typename: 'RelayerResult'; txHash: string; txId: string };
 
-export type RelayerResult = { __typename: 'RelayerResult', txHash: string, txId: string };
-
-export type RelayError = { __typename: 'RelayError', reason: RelayErrorReasons };
+export type RelayError = { __typename: 'RelayError'; reason: RelayErrorReasons };
 
 type RelayResult_RelayError_ = RelayError;
 
@@ -2222,14 +2821,17 @@ type RelayResult_RelayerResult_ = RelayerResult;
 
 export type RelayResult = RelayResult_RelayError_ | RelayResult_RelayerResult_;
 
-export type TransactionIndexedResult = { __typename: 'TransactionIndexedResult', indexed: boolean, txHash: string };
+export type TransactionIndexedResult = {
+  __typename: 'TransactionIndexedResult';
+  indexed: boolean;
+  txHash: string;
+};
 
-export type TransactionError = { __typename: 'TransactionError', reason: TransactionErrorReasons };
+export type TransactionError = { __typename: 'TransactionError'; reason: TransactionErrorReasons };
 
 export type HasTxHashBeenIndexedVariables = Exact<{
   request: HasTxHashBeenIndexedRequest;
 }>;
-
 
 export type HasTxHashBeenIndexedData = { result: TransactionError | TransactionIndexedResult };
 
@@ -2237,15 +2839,25 @@ export type BroadcastProtocolCallVariables = Exact<{
   request: BroadcastRequest;
 }>;
 
-
-export type BroadcastProtocolCallData = { result: RelayResult_RelayError_ | RelayResult_RelayerResult_ };
+export type BroadcastProtocolCallData = {
+  result: RelayResult_RelayError_ | RelayResult_RelayerResult_;
+};
 
 export type CreateUnfollowTypedDataVariables = Exact<{
   request: UnfollowRequest;
 }>;
 
-
-export type CreateUnfollowTypedDataData = { result: { id: string, expiresAt: string, typedData: { types: { BurnWithSig: Array<{ name: string, type: string }> }, domain: Eip712TypedDataDomain, value: { nonce: number, deadline: unknown, tokenId: string } } } };
+export type CreateUnfollowTypedDataData = {
+  result: {
+    id: string;
+    expiresAt: string;
+    typedData: {
+      types: { BurnWithSig: Array<{ name: string; type: string }> };
+      domain: Eip712TypedDataDomain;
+      value: { nonce: number; deadline: unknown; tokenId: string };
+    };
+  };
+};
 
 export type WalletCollectedPublicationsVariables = Exact<{
   observerId?: InputMaybe<Scalars['ProfileId']>;
@@ -2255,5 +2867,6 @@ export type WalletCollectedPublicationsVariables = Exact<{
   sources: Array<Scalars['Sources']> | Scalars['Sources'];
 }>;
 
-
-export type WalletCollectedPublicationsData = { result: { items: Array<Comment | Mirror | Post>, pageInfo: CommonPaginatedResultInfo } };
+export type WalletCollectedPublicationsData = {
+  result: { items: Array<Comment | Mirror | Post>; pageInfo: CommonPaginatedResultInfo };
+};

--- a/packages/api-bindings/src/graphql/utils/types.ts
+++ b/packages/api-bindings/src/graphql/utils/types.ts
@@ -1,5 +1,16 @@
+/**
+ * @internal
+ */
 export type Typename<T> = { [key in '__typename']: T };
+
+/**
+ * @internal
+ */
 export type JustTypename<T extends Typename<string>> = Pick<T, '__typename'>;
+
+/**
+ * @internal
+ */
 export type PickByTypename<T extends Typename<string>, P extends T['__typename']> = T extends {
   __typename?: P;
 }

--- a/packages/domain/src/entities/Profile.ts
+++ b/packages/domain/src/entities/Profile.ts
@@ -1,4 +1,4 @@
-export type ProfileId = string;
+export type ProfileId = `0x${string}`;
 
 export class Profile {
   private constructor(readonly id: ProfileId, readonly handle: string) {}

--- a/packages/domain/src/entities/__helpers__/mocks.ts
+++ b/packages/domain/src/entities/__helpers__/mocks.ts
@@ -53,7 +53,7 @@ import {
 import { Wallet } from '../Wallet';
 
 export function mockProfileId(): ProfileId {
-  return faker.datatype.hexadecimal({ length: 2 });
+  return faker.datatype.hexadecimal({ length: 2 }) as ProfileId;
 }
 
 export function mockPublicationId(profileId: ProfileId = mockProfileId()): PublicationId {
@@ -273,7 +273,7 @@ export class MockedNativeTransaction<
 
 export function mockProfile() {
   return Profile.create({
-    id: faker.datatype.uuid(),
+    id: mockProfileId(),
     handle: faker.internet.userName(),
   });
 }

--- a/packages/domain/src/use-cases/profile/FollowProfiles.ts
+++ b/packages/domain/src/use-cases/profile/FollowProfiles.ts
@@ -5,6 +5,7 @@ import {
   PendingSigningRequestError,
   UserRejectedError,
   WalletConnectionError,
+  ProfileId,
 } from '../../entities';
 import { IGenericResultPresenter } from '../transactions/IGenericResultPresenter';
 import {
@@ -26,22 +27,22 @@ export type FollowRequestFee = {
 
 export type UnconstrainedFollowRequest = {
   followerAddress: string;
-  profileId: string;
+  profileId: ProfileId;
   kind: TransactionKind.FOLLOW_PROFILES;
 };
 
 export type PaidFollowRequest = {
   followerAddress: string;
-  profileId: string;
+  profileId: ProfileId;
   kind: TransactionKind.FOLLOW_PROFILES;
   fee: FollowRequestFee;
 };
 
 export type ProfileOwnerFollowRequest = {
   followerAddress: string;
-  profileId: string;
+  profileId: ProfileId;
   kind: TransactionKind.FOLLOW_PROFILES;
-  followerProfileId: string;
+  followerProfileId: ProfileId;
 };
 
 export type FollowRequest =

--- a/packages/domain/src/use-cases/profile/IActiveProfilePresenter.ts
+++ b/packages/domain/src/use-cases/profile/IActiveProfilePresenter.ts
@@ -1,5 +1,7 @@
+import { ProfileId } from '../../entities';
+
 export type ProfileIdentifier = {
-  id: string;
+  id: ProfileId;
   handle: string;
 };
 

--- a/packages/domain/src/use-cases/profile/UnfollowProfile.ts
+++ b/packages/domain/src/use-cases/profile/UnfollowProfile.ts
@@ -1,4 +1,4 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import {
   IProtocolCallPresenter,
   IUnsignedProtocolCallGateway,
@@ -6,7 +6,7 @@ import {
 } from '../transactions/ProtocolCallUseCase';
 
 export type UnfollowRequest = {
-  profileId: string;
+  profileId: ProfileId;
   kind: TransactionKind.UNFOLLOW_PROFILE;
 };
 

--- a/packages/domain/src/use-cases/profile/UpdateDispatcherConfig.ts
+++ b/packages/domain/src/use-cases/profile/UpdateDispatcherConfig.ts
@@ -1,4 +1,4 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import {
   IProtocolCallPresenter,
   IUnsignedProtocolCallGateway,
@@ -6,7 +6,7 @@ import {
 } from '../transactions/ProtocolCallUseCase';
 
 export type UpdateDispatcherConfigRequest = {
-  profileId: string;
+  profileId: ProfileId;
   enabled: boolean;
   kind: TransactionKind.UPDATE_DISPATCHER_CONFIG;
 };

--- a/packages/domain/src/use-cases/profile/UpdateFollowPolicy.ts
+++ b/packages/domain/src/use-cases/profile/UpdateFollowPolicy.ts
@@ -1,6 +1,6 @@
 import { Amount, Erc20 } from '@lens-protocol/shared-kernel';
 
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import {
   IProtocolCallPresenter,
   IUnsignedProtocolCallGateway,
@@ -26,7 +26,7 @@ export type NoFeeFollowConfig = {
 };
 
 export type UpdateFollowPolicyRequest = {
-  profileId: string;
+  profileId: ProfileId;
   policy: ChargeFollowConfig | NoFeeFollowConfig;
   kind: TransactionKind.UPDATE_FOLLOW_POLICY;
 };

--- a/packages/domain/src/use-cases/profile/UpdateProfileDetails.ts
+++ b/packages/domain/src/use-cases/profile/UpdateProfileDetails.ts
@@ -1,4 +1,4 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import {
   DelegableProtocolCallUseCase,
   IDelegableProtocolCallGateway,
@@ -16,7 +16,7 @@ export type UpdateProfileDetailsRequest = {
   delegate: boolean;
   kind: TransactionKind.UPDATE_PROFILE_DETAILS;
   name: string;
-  profileId: string;
+  profileId: ProfileId;
 };
 
 export type IProfileDetailsCallGateway = IDelegableProtocolCallGateway<UpdateProfileDetailsRequest>;

--- a/packages/domain/src/use-cases/profile/UpdateProfileImage.ts
+++ b/packages/domain/src/use-cases/profile/UpdateProfileImage.ts
@@ -1,4 +1,4 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import {
   DelegableProtocolCallUseCase,
   IDelegableProtocolCallGateway,
@@ -14,7 +14,7 @@ import { NftOwnershipSignature } from './ProveNftOwnership';
  */
 export type UpdateNftProfileImageRequest = {
   kind: TransactionKind.UPDATE_PROFILE_IMAGE;
-  profileId: string;
+  profileId: ProfileId;
   signature: NftOwnershipSignature;
   delegate: boolean;
 };
@@ -22,7 +22,7 @@ export type UpdateNftProfileImageRequest = {
 export type UpdateOffChainProfileImageRequest = {
   url: string;
   kind: TransactionKind.UPDATE_PROFILE_IMAGE;
-  profileId: string;
+  profileId: ProfileId;
   delegate: boolean;
 };
 

--- a/packages/domain/src/use-cases/publications/CollectPublication.ts
+++ b/packages/domain/src/use-cases/publications/CollectPublication.ts
@@ -5,6 +5,7 @@ import {
   PendingSigningRequestError,
   UserRejectedError,
   WalletConnectionError,
+  ProfileId,
 } from '../../entities';
 import { IGenericResultPresenter } from '../transactions/IGenericResultPresenter';
 import {
@@ -24,7 +25,7 @@ export enum CollectType {
 }
 
 export type FreeCollectRequest = {
-  profileId: string;
+  profileId: ProfileId;
   type: CollectType.FREE;
   publicationId: string;
   kind: TransactionKind.COLLECT_PUBLICATION;
@@ -36,7 +37,7 @@ export type CollectFee = {
 };
 
 export type PaidCollectRequest = {
-  profileId: string;
+  profileId: ProfileId;
   type: CollectType.PAID;
   publicationId: string;
   fee: CollectFee;

--- a/packages/domain/src/use-cases/publications/CreateComment.ts
+++ b/packages/domain/src/use-cases/publications/CreateComment.ts
@@ -1,6 +1,6 @@
 import { invariant } from '@lens-protocol/shared-kernel';
 
-import { AppId, DecryptionCriteria, TransactionKind } from '../../entities';
+import { AppId, DecryptionCriteria, ProfileId, TransactionKind } from '../../entities';
 import {
   DelegableProtocolCallUseCase,
   IDelegableProtocolCallGateway,
@@ -18,7 +18,7 @@ export type CreateCommentRequest = {
   media?: MediaObject[];
   reference: ReferencePolicyConfig;
   collect: CollectPolicyConfig;
-  profileId: string;
+  profileId: ProfileId;
   kind: TransactionKind.CREATE_COMMENT;
   locale: Locale;
   delegate: boolean;

--- a/packages/domain/src/use-cases/publications/CreateMirror.ts
+++ b/packages/domain/src/use-cases/publications/CreateMirror.ts
@@ -1,4 +1,4 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import {
   DelegableProtocolCallUseCase,
   IProtocolCallPresenter,
@@ -7,7 +7,7 @@ import {
 import { IUnsignedProtocolCallGateway } from '../transactions/ProtocolCallUseCase';
 
 export type CreateMirrorRequest = {
-  profileId: string;
+  profileId: ProfileId;
   publicationId: string;
   kind: TransactionKind.MIRROR_PUBLICATION;
   delegate: boolean;

--- a/packages/domain/src/use-cases/publications/CreatePost.ts
+++ b/packages/domain/src/use-cases/publications/CreatePost.ts
@@ -1,6 +1,6 @@
 import { invariant } from '@lens-protocol/shared-kernel';
 
-import { AppId, DecryptionCriteria, TransactionKind } from '../../entities';
+import { AppId, DecryptionCriteria, ProfileId, TransactionKind } from '../../entities';
 import {
   DelegableProtocolCallUseCase,
   IDelegableProtocolCallGateway,
@@ -17,7 +17,7 @@ export type CreatePostRequest = {
   media?: MediaObject[];
   reference: ReferencePolicyConfig;
   collect: CollectPolicyConfig;
-  profileId: string;
+  profileId: ProfileId;
   kind: TransactionKind.CREATE_POST;
   locale: Locale;
   delegate: boolean;

--- a/packages/domain/src/use-cases/publications/__helpers__/mocks.ts
+++ b/packages/domain/src/use-cases/publications/__helpers__/mocks.ts
@@ -182,7 +182,7 @@ export function mockCreateEncryptedPostRequest(
 
 export function mockReactionRequest(overrides?: Partial<ReactionRequest>): ReactionRequest {
   return {
-    profileId: faker.datatype.uuid(),
+    profileId: mockProfileId(),
     publicationId: faker.datatype.uuid(),
     reactionType: ReactionType.UPVOTE,
     ...overrides,

--- a/packages/gated-content/src/conditions/__tests__/follow-condition.spec.ts
+++ b/packages/gated-content/src/conditions/__tests__/follow-condition.spec.ts
@@ -83,7 +83,7 @@ describe(`Given the "${transformFollowCondition.name}" function`, () => {
       {
         description: 'if with invalid profile Id',
         condition: mockFollowConditionInput({
-          profileId: 'a',
+          profileId: mockProfileId(),
         }),
       },
     ])(`should throw an ${InvalidAccessCriteriaError.name} $description`, ({ condition }) => {

--- a/packages/gated-content/src/conditions/__tests__/profile-condition.spec.ts
+++ b/packages/gated-content/src/conditions/__tests__/profile-condition.spec.ts
@@ -73,7 +73,7 @@ describe(`Given the "${mockProfileOwnershipInput.name}" function`, () => {
       {
         description: 'if with invalid profile Id',
         condition: mockProfileOwnershipInput({
-          profileId: 'a',
+          profileId: mockProfileId(),
         }),
       },
     ])(`should throw an ${InvalidAccessCriteriaError.name} $description`, ({ condition }) => {

--- a/packages/react/src/profile/adapters/ActiveProfileGateway.ts
+++ b/packages/react/src/profile/adapters/ActiveProfileGateway.ts
@@ -1,11 +1,11 @@
-import { Profile } from '@lens-protocol/domain/entities';
+import { Profile, ProfileId } from '@lens-protocol/domain/entities';
 import * as profileUseCases from '@lens-protocol/domain/use-cases/profile';
 import * as walletsUseCases from '@lens-protocol/domain/use-cases/wallets';
 import { IStorage } from '@lens-protocol/storage';
 import { z } from 'zod';
 
 export const StoredActiveProfileData = z.object({
-  id: z.string(),
+  id: z.custom<ProfileId>(),
   handle: z.string(),
 });
 

--- a/packages/react/src/profile/adapters/ProfileGateway.ts
+++ b/packages/react/src/profile/adapters/ProfileGateway.ts
@@ -7,7 +7,7 @@ import {
   GetAllProfilesVariables,
   GetAllProfilesDocument,
 } from '@lens-protocol/api-bindings';
-import { Profile } from '@lens-protocol/domain/entities';
+import { Profile, ProfileId } from '@lens-protocol/domain/entities';
 import { IProfileGateway } from '@lens-protocol/domain/use-cases/profile';
 
 export class ProfileGateway implements IProfileGateway {
@@ -39,7 +39,7 @@ export class ProfileGateway implements IProfileGateway {
     });
   }
 
-  async getProfileById(profileId: string): Promise<Profile | null> {
+  async getProfileById(profileId: ProfileId): Promise<Profile | null> {
     const { data } = await this.apolloClient.query<GetProfileData, GetProfileVariables>({
       query: GetProfileDocument,
       // 'sources' and 'observerId' are not needed. We just use 'id' and 'handle' for now.

--- a/packages/react/src/publication/__tests__/useReaction.spec.ts
+++ b/packages/react/src/publication/__tests__/useReaction.spec.ts
@@ -6,7 +6,7 @@ import {
   createRemoveReactionMockedResponse,
   mockPostFragment,
 } from '@lens-protocol/api-bindings/mocks';
-import { ReactionType } from '@lens-protocol/domain/entities';
+import { ProfileId, ReactionType } from '@lens-protocol/domain/entities';
 import { act } from '@testing-library/react';
 
 import { renderHookWithMocks } from '../../__helpers__/testing-library';
@@ -17,7 +17,7 @@ function setupUseReaction({
   mocks = [],
   profileId,
 }: {
-  profileId: string;
+  profileId: ProfileId;
   mocks?: ReadonlyArray<MockedResponse<unknown>>;
 }) {
   const apolloClient = createMockApolloClientWithMultipleResponses(mocks);

--- a/packages/react/src/publication/adapters/__tests__/ReactionGateway.spec.ts
+++ b/packages/react/src/publication/adapters/__tests__/ReactionGateway.spec.ts
@@ -6,14 +6,14 @@ import {
   createRemoveReactionMockedResponse,
   createRemoveReactionMockedResponseWithGraphqlValidationError,
 } from '@lens-protocol/api-bindings/mocks';
-import { mockReactionRequest } from '@lens-protocol/domain/mocks';
+import { mockProfileId, mockReactionRequest } from '@lens-protocol/domain/mocks';
 
 import { ReactionGateway } from '../ReactionGateway';
 
 describe(`Given an instance of the ${ReactionGateway.name}`, () => {
   describe(`and the ${ReactionGateway.prototype.add.name} method`, () => {
     it(`should add reaction with success`, async () => {
-      const profileId = faker.datatype.uuid();
+      const profileId = mockProfileId();
       const publicationId = faker.datatype.uuid();
 
       const apolloClient = createMockApolloClientWithMultipleResponses([
@@ -38,7 +38,7 @@ describe(`Given an instance of the ${ReactionGateway.name}`, () => {
 
   describe(`and the ${ReactionGateway.prototype.remove.name} method`, () => {
     it(`should remove reaction with success`, async () => {
-      const profileId = faker.datatype.uuid();
+      const profileId = mockProfileId();
       const publicationId = faker.datatype.uuid();
 
       const apolloClient = createMockApolloClientWithMultipleResponses([
@@ -61,7 +61,7 @@ describe(`Given an instance of the ${ReactionGateway.name}`, () => {
     });
 
     it(`should be resilient to ${ValidationError.name} and resolve the promise`, async () => {
-      const profileId = faker.datatype.uuid();
+      const profileId = mockProfileId();
       const publicationId = faker.datatype.uuid();
       const apolloClient = createMockApolloClientWithMultipleResponses([
         createRemoveReactionMockedResponseWithGraphqlValidationError({

--- a/packages/react/src/publication/useReaction.ts
+++ b/packages/react/src/publication/useReaction.ts
@@ -1,11 +1,11 @@
 import { resolveApiReactionType, ContentPublication } from '@lens-protocol/api-bindings';
-import { ReactionType } from '@lens-protocol/domain/entities';
+import { ProfileId, ReactionType } from '@lens-protocol/domain/entities';
 import { useState } from 'react';
 
 import { useReactionController } from './adapters/useReactionController';
 
 export type UseReactionArgs = {
-  profileId: string;
+  profileId: ProfileId;
 };
 
 export type ReactionArgs = {

--- a/packages/react/src/transactions/adapters/PendingTransactionGateway/schema/common.ts
+++ b/packages/react/src/transactions/adapters/PendingTransactionGateway/schema/common.ts
@@ -1,3 +1,4 @@
+import { ProfileId } from '@lens-protocol/domain/entities';
 import { Amount, ChainType, erc20, Kind } from '@lens-protocol/shared-kernel';
 import { z } from 'zod';
 
@@ -18,3 +19,5 @@ export const Erc20AmountSchema = z
     value: z.string(),
   })
   .transform((value) => Amount.erc20(value.asset, value.value));
+
+export const ProfileIdSchema = z.custom<ProfileId>(); // TODO add validation function

--- a/packages/react/src/transactions/adapters/PendingTransactionGateway/schema/profiles.ts
+++ b/packages/react/src/transactions/adapters/PendingTransactionGateway/schema/profiles.ts
@@ -2,7 +2,7 @@ import { TransactionKind } from '@lens-protocol/domain/entities';
 import { FollowPolicyType } from '@lens-protocol/domain/use-cases/profile';
 import { z } from 'zod';
 
-import { Erc20AmountSchema } from './common';
+import { Erc20AmountSchema, ProfileIdSchema } from './common';
 
 export const CreateProfileRequestSchema = z.object({
   handle: z.string(),
@@ -17,31 +17,31 @@ const FollowRequestFeeSchema = z.object({
 
 export const UnconstrainedFollowRequestSchema = z.object({
   followerAddress: z.string(),
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.FOLLOW_PROFILES),
 });
 
 export const PaidFollowRequestSchema = z.object({
   followerAddress: z.string(),
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.FOLLOW_PROFILES),
   fee: FollowRequestFeeSchema,
 });
 
 export const ProfileOwnerFollowRequestSchema = z.object({
   followerAddress: z.string(),
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.FOLLOW_PROFILES),
   followerProfileId: z.string(),
 });
 
 export const UnfollowRequestSchema = z.object({
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.UNFOLLOW_PROFILE),
 });
 
 export const UpdateDispatcherConfigRequestSchema = z.object({
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   enabled: z.boolean(),
   kind: z.literal(TransactionKind.UPDATE_DISPATCHER_CONFIG),
 });
@@ -61,7 +61,7 @@ const NoFeeFollowPolicySchema = z.object({
 });
 
 export const UpdateFollowPolicyRequestSchema = z.object({
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   policy: z.union([ChargeFollowPolicySchema, NoFeeFollowPolicySchema]),
   kind: z.literal(TransactionKind.UPDATE_FOLLOW_POLICY),
 });
@@ -75,7 +75,7 @@ export const UpdateProfileDetailsRequestSchema = z.object({
   bio: z.string().nullable().optional(),
   coverPicture: z.string().nullable().optional(),
   name: z.string(),
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.UPDATE_PROFILE_DETAILS),
   delegate: z.boolean(),
 });
@@ -87,7 +87,7 @@ const NftOwnershipSignatureSchema = z.object({
 
 export const UpdateNftProfileImageRequestSchema = z.object({
   kind: z.literal(TransactionKind.UPDATE_PROFILE_IMAGE),
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   signature: NftOwnershipSignatureSchema,
   delegate: z.boolean(),
 });
@@ -95,6 +95,6 @@ export const UpdateNftProfileImageRequestSchema = z.object({
 export const UpdateOffChainProfileImageRequestSchema = z.object({
   url: z.string(),
   kind: z.literal(TransactionKind.UPDATE_PROFILE_IMAGE),
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   delegate: z.boolean(),
 });

--- a/packages/react/src/transactions/adapters/PendingTransactionGateway/schema/publications.ts
+++ b/packages/react/src/transactions/adapters/PendingTransactionGateway/schema/publications.ts
@@ -10,7 +10,7 @@ import {
 import { z } from 'zod';
 
 import { appId } from '../../../../utils';
-import { Erc20AmountSchema } from './common';
+import { Erc20AmountSchema, ProfileIdSchema } from './common';
 
 const NftAttributeSchema = z.union([
   z.object({
@@ -100,7 +100,7 @@ export const CreatePostRequestSchema = z.object({
   media: z.array(MediaSchema).optional(),
   reference: ReferencePolicyConfigSchema,
   collect: CollectPolicySchema,
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.CREATE_POST),
   locale: z.string(),
   delegate: z.boolean(),
@@ -114,21 +114,21 @@ export const CreateCommentRequestSchema = z.object({
   media: z.array(MediaSchema).optional(),
   reference: ReferencePolicyConfigSchema,
   collect: CollectPolicySchema,
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.CREATE_COMMENT),
   locale: z.string(),
   delegate: z.boolean(),
 });
 
 export const CreateMirrorRequestSchema = z.object({
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   publicationId: z.string(),
   kind: z.literal(TransactionKind.MIRROR_PUBLICATION),
   delegate: z.boolean(),
 });
 
 export const FreeCollectRequestSchema = z.object({
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   type: z.literal(CollectType.FREE),
   publicationId: z.string(),
   kind: z.literal(TransactionKind.COLLECT_PUBLICATION),
@@ -140,7 +140,7 @@ const CollectFeeSchema = z.object({
 });
 
 export const PaidCollectRequestSchema = z.object({
-  profileId: z.string(),
+  profileId: ProfileIdSchema,
   type: z.literal(CollectType.PAID),
   publicationId: z.string(),
   fee: CollectFeeSchema,

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/ProfileMetadataCallGateway.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/ProfileMetadataCallGateway.ts
@@ -17,6 +17,7 @@ import {
 import {
   NativeTransaction,
   Nonce,
+  ProfileId,
   TransactionError,
   TransactionErrorReason,
 } from '@lens-protocol/domain/entities';
@@ -121,7 +122,7 @@ export class ProfileMetadataCallGateway
     };
   }
 
-  private async retrieveProfileDetails(profileId: string): Promise<Profile> {
+  private async retrieveProfileDetails(profileId: ProfileId): Promise<Profile> {
     const { data } = await this.apolloClient.query<GetProfileData, GetProfileVariables>({
       fetchPolicy: 'cache-first',
       query: GetProfileDocument,

--- a/packages/react/src/transactions/adapters/responders/__tests__/UpdateFollowPolicyResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/UpdateFollowPolicyResponder.spec.ts
@@ -5,6 +5,7 @@ import {
   mockProfileFragment,
   mockSources,
 } from '@lens-protocol/api-bindings/mocks';
+import { ProfileId } from '@lens-protocol/domain/entities';
 import {
   mockBroadcastedTransactionData,
   mockChargeFollowConfig,
@@ -50,7 +51,7 @@ function setupUpdateFollowPolicyResponder({
   return {
     responder,
 
-    profileFromCache(profileId: string) {
+    profileFromCache(profileId: ProfileId) {
       return apolloClient.cache.readFragment({
         id: apolloClient.cache.identify({
           __typename: 'Profile',

--- a/packages/react/src/transactions/infrastructure/ProfileCacheManager.ts
+++ b/packages/react/src/transactions/infrastructure/ProfileCacheManager.ts
@@ -8,6 +8,7 @@ import {
   FragmentProfile,
   Sources,
 } from '@lens-protocol/api-bindings';
+import { ProfileId } from '@lens-protocol/domain/entities';
 import { never } from '@lens-protocol/shared-kernel';
 
 import { activeProfileIdentifierVar } from '../../profile/adapters/ActiveProfilePresenter';
@@ -20,7 +21,7 @@ export class ProfileCacheManager implements IProfileCacheManager {
     return this.request(args, 'cache-first');
   }
 
-  async refreshProfile(id: string) {
+  async refreshProfile(id: ProfileId) {
     const profile = await this.request({ id }, 'network-only');
 
     return profile ?? never();

--- a/packages/shared-kernel/src/crypto/Amount.ts
+++ b/packages/shared-kernel/src/crypto/Amount.ts
@@ -66,7 +66,7 @@ export const Denomination = {
  * @typeParam T - The {@link Asset} type of the amount.
  * @remarks
  *
- * Amount hides all the complexity of dealing with different precision of different assets.
+ * Amount hides all the complexity of dealing with the specific precision constraints of different assets.
  * It offers a consistent interface to perform arithmetic operations on amounts.
  *
  * Amount is immutable. All arithmetic operations return a new Amount instance.


### PR DESCRIPTION
This improves the typesafety of the whole Lens SDK as enforces that only `ProfileId` from previously fetched data can be used in hooks that requires a profile Id to be specified. If manually typed for any reason (e.g. prototype or very edge cases) the consumer is still able to provide a profile Id without as they could do before.

Where this change shines is in the generated documentation. In several circumstanced Profile ID was resolved as `string` making the documentation look inconsistent. It now shows `ProfileId` type in all places.