### PR TITLE
chore: remove `resultCaching` in apollo config because its true by default

### DIFF
--- a/packages/api-bindings/src/apollo/cache/createApolloCache.ts
+++ b/packages/api-bindings/src/apollo/cache/createApolloCache.ts
@@ -87,7 +87,6 @@ export function createApolloCache({
 }: TypePoliciesArgs): ApolloCache<NormalizedCacheObject> {
   return new InMemoryCache({
     possibleTypes: generatedIntrospection.possibleTypes,
-    resultCaching: true,
     typePolicies: createTypePolicies({ activeWalletVar }),
   });
 }


### PR DESCRIPTION
https://www.apollographql.com/docs/react/caching/cache-configuration/#resultcaching