### PR TITLE
feat: `PayTransaction` use case and first pass at changes to rejected meta-tx flow

### DIFF
--- a/packages/domain/src/entities/Transactions.ts
+++ b/packages/domain/src/entities/Transactions.ts
@@ -37,27 +37,14 @@ export interface IUnsignedProtocolCall<T extends TransactionRequestModel> {
   readonly nonce: Nonce;
 }
 
-export class SignedProtocolCall<T extends TransactionRequestModel> {
-  private constructor(
-    readonly id: string,
-    readonly signature: Signature,
-    readonly request: T,
-    readonly nonce: Nonce,
-  ) {}
+export interface ISignedProtocolCall<T extends TransactionRequestModel> {
+  readonly id: string;
 
-  static create<T extends TransactionRequestModel>({
-    id,
-    signature,
-    request,
-    nonce,
-  }: {
-    id: string;
-    signature: Signature;
-    request: T;
-    nonce: Nonce;
-  }) {
-    return new SignedProtocolCall(id, signature, request, nonce);
-  }
+  readonly signature: Signature;
+
+  readonly request: T;
+
+  readonly nonce: Nonce;
 }
 
 export enum TransactionEvent {

--- a/packages/domain/src/entities/Wallet.ts
+++ b/packages/domain/src/entities/Wallet.ts
@@ -1,7 +1,7 @@
 import { CryptoNativeAsset, EthereumAddress, PromiseResult } from '@lens-protocol/shared-kernel';
 
 import {
-  SignedProtocolCall,
+  ISignedProtocolCall,
   TransactionRequestModel,
   IUnsignedProtocolCall,
   UnsignedTransaction,
@@ -52,7 +52,7 @@ export abstract class Wallet {
   abstract signProtocolCall<T extends TransactionRequestModel>(
     unsignedCall: IUnsignedProtocolCall<T>,
   ): PromiseResult<
-    SignedProtocolCall<T>,
+    ISignedProtocolCall<T>,
     PendingSigningRequestError | UserRejectedError | WalletConnectionError
   >;
 

--- a/packages/domain/src/use-cases/lifecycle/Bootstrap.ts
+++ b/packages/domain/src/use-cases/lifecycle/Bootstrap.ts
@@ -4,13 +4,13 @@ import { ICredentials, TransactionRequestModel, Wallet } from '../../entities';
 import { ActiveProfileLoader, IActiveProfileGateway } from '../profile';
 import { TransactionQueue } from '../transactions';
 import {
-  ActiveWallet,
   IActiveWalletPresenter,
   ICredentialsReader,
   ICredentialsWriter,
   ILogoutPresenter,
   LogoutReason,
 } from '../wallets';
+import { ActiveWallet } from '../wallets/ActiveWallet';
 
 export class CredentialsExpiredError extends Error {
   name = 'CredentialsExpiredError' as const;

--- a/packages/domain/src/use-cases/transactions/PayTransaction.ts
+++ b/packages/domain/src/use-cases/transactions/PayTransaction.ts
@@ -1,4 +1,5 @@
 import { Brand, failure, success } from '@lens-protocol/shared-kernel';
+
 import {
   InsufficientGasError,
   PendingSigningRequestError,
@@ -8,7 +9,7 @@ import {
   WalletConnectionError,
 } from '../../entities';
 import { UnsignedTransaction } from '../../entities/Transactions';
-import { ActiveWallet } from '../wallets';
+import { ActiveWallet } from '../wallets/ActiveWallet';
 import { IGenericResultPresenter } from './IGenericResultPresenter';
 import { TransactionQueue } from './TransactionQueue';
 

--- a/packages/domain/src/use-cases/transactions/PayTransaction.ts
+++ b/packages/domain/src/use-cases/transactions/PayTransaction.ts
@@ -1,0 +1,56 @@
+import { Brand, failure, success } from '@lens-protocol/shared-kernel';
+import {
+  InsufficientGasError,
+  PendingSigningRequestError,
+  TransactionRequestModel,
+  UserRejectedError,
+  Wallet,
+  WalletConnectionError,
+} from '../../entities';
+import { UnsignedTransaction } from '../../entities/Transactions';
+import { ActiveWallet } from '../wallets';
+import { IGenericResultPresenter } from './IGenericResultPresenter';
+import { TransactionQueue } from './TransactionQueue';
+
+export type Data = Brand<string, 'Data'>;
+
+export type WithData<T extends TransactionRequestModel> = T extends { data: Data } ? T : never;
+
+export interface IPayTransactionGateway<T extends TransactionRequestModel> {
+  prepareSelfFundedTransaction(
+    request: WithData<T>,
+    wallet: Wallet,
+  ): Promise<UnsignedTransaction<T>>;
+}
+
+export type IPayTransactionPresenter = IGenericResultPresenter<
+  void,
+  PendingSigningRequestError | InsufficientGasError | UserRejectedError | WalletConnectionError
+>;
+
+export class PayTransaction<T extends TransactionRequestModel> {
+  constructor(
+    private readonly activeWallet: ActiveWallet,
+    private readonly gateway: IPayTransactionGateway<T>,
+    private readonly presenter: IPayTransactionPresenter,
+    private readonly queue: TransactionQueue<TransactionRequestModel>,
+  ) {}
+
+  async execute(request: WithData<T>) {
+    const wallet = await this.activeWallet.requireActiveWallet();
+
+    const approveTransaction = await this.gateway.prepareSelfFundedTransaction(request, wallet);
+
+    const relayResult = await wallet.sendTransaction(approveTransaction);
+
+    if (relayResult.isFailure()) {
+      this.presenter.present(failure(relayResult.error));
+      return;
+    }
+
+    const transaction = relayResult.value;
+    await this.queue.push(transaction);
+
+    this.presenter.present(success());
+  }
+}

--- a/packages/domain/src/use-cases/transactions/ProtocolCallUseCase.ts
+++ b/packages/domain/src/use-cases/transactions/ProtocolCallUseCase.ts
@@ -4,7 +4,7 @@ import {
   IUnsignedProtocolCall,
   Nonce,
   TransactionKind,
-  SignedProtocolCall,
+  ISignedProtocolCall,
   TransactionRequestModel,
   MetaTransaction,
   PendingSigningRequestError,
@@ -22,7 +22,7 @@ export interface IMetaTransactionNonceGateway {
 
 export interface IProtocolCallRelayer<T extends TransactionRequestModel> {
   relayProtocolCall(
-    signedCall: SignedProtocolCall<T>,
+    signedCall: ISignedProtocolCall<T>,
   ): PromiseResult<MetaTransaction<T>, BroadcastingError>;
 }
 

--- a/packages/domain/src/use-cases/transactions/__helpers__/mocks.ts
+++ b/packages/domain/src/use-cases/transactions/__helpers__/mocks.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../entities/__helpers__/mocks';
 import { BroadcastingError } from '../BroadcastingError';
 import { IDelegableProtocolCallGateway, WithDelegateFlag } from '../DelegableProtocolCallUseCase';
+import { Data, WithData } from '../PayTransaction';
 import {
   IMetaTransactionNonceGateway,
   IProtocolCallRelayer,
@@ -125,5 +126,12 @@ export function mockTransactionRequestModelWithDelegateFlag({
   return {
     kind: TransactionKind.CREATE_POST,
     delegate,
+  } as WithDelegateFlag<TransactionRequestModel>;
+}
+
+export function mockTransactionRequestModelWithData(): WithData<TransactionRequestModel> {
+  return {
+    kind: TransactionKind.CREATE_POST,
+    data: faker.datatype.hexadecimal({ length: 32 }) as Data,
   } as WithDelegateFlag<TransactionRequestModel>;
 }

--- a/packages/domain/src/use-cases/transactions/__helpers__/mocks.ts
+++ b/packages/domain/src/use-cases/transactions/__helpers__/mocks.ts
@@ -9,7 +9,7 @@ import {
   NativeTransaction,
   Nonce,
   ProxyTransaction,
-  SignedProtocolCall,
+  ISignedProtocolCall,
   TransactionKind,
   TransactionRequestModel,
 } from '../../../entities';
@@ -35,7 +35,7 @@ export function mockIProtocolCallRelayer<T extends TransactionRequestModel>({
   signedCall,
   result,
 }: {
-  signedCall: SignedProtocolCall<T>;
+  signedCall: ISignedProtocolCall<T>;
   result: Result<MetaTransaction<T>, BroadcastingError>;
 }) {
   const transactionRelayer = mock<IProtocolCallRelayer<T>>();

--- a/packages/domain/src/use-cases/transactions/__tests__/PayTransaction.spec.ts
+++ b/packages/domain/src/use-cases/transactions/__tests__/PayTransaction.spec.ts
@@ -1,0 +1,127 @@
+import { failure, matic, success } from '@lens-protocol/shared-kernel';
+import { mock } from 'jest-mock-extended';
+import { when } from 'jest-when';
+
+import {
+  NativeTransaction,
+  UnsignedTransaction,
+  InsufficientGasError,
+  Wallet,
+  WalletConnectionError,
+  WalletConnectionErrorReason,
+  UserRejectedError,
+  PendingSigningRequestError,
+  TransactionRequestModel,
+} from '../../../entities';
+import {
+  MockedNativeTransaction,
+  mockUnsignedTransaction,
+  mockWallet,
+} from '../../../entities/__helpers__/mocks';
+import { mockActiveWallet, mockIPayTransactionGateway } from '../../../mocks';
+import { TransactionQueue } from '../../transactions/TransactionQueue';
+import {
+  mockTransactionQueue,
+  mockTransactionRequestModelWithData,
+} from '../../transactions/__helpers__/mocks';
+import {
+  IPayTransactionGateway,
+  IPayTransactionPresenter,
+  PayTransaction,
+} from '../PayTransaction';
+
+function setupPayTransaction({
+  gateway,
+  presenter = mock<IPayTransactionPresenter>(),
+  queue = mockTransactionQueue<TransactionRequestModel>(),
+  wallet,
+}: {
+  gateway: IPayTransactionGateway<TransactionRequestModel>;
+  presenter?: IPayTransactionPresenter;
+  queue?: TransactionQueue<TransactionRequestModel>;
+  wallet: Wallet;
+}) {
+  return new PayTransaction(mockActiveWallet({ wallet }), gateway, presenter, queue);
+}
+
+describe(`Given the ${PayTransaction.name} interactor`, () => {
+  const request = mockTransactionRequestModelWithData();
+  const unsignedTransaction = mockUnsignedTransaction(request);
+  const transaction = MockedNativeTransaction.fromUnsignedTransaction(unsignedTransaction);
+
+  describe(`when invoking the "${PayTransaction.prototype.execute.name}" method with a request if type WithData<T>`, () => {
+    it(`should:
+        - create an ${UnsignedTransaction.name}<T>
+        - sign and broadcast the transaction with the user's wallet
+        - queue the resulting ${NativeTransaction.name} into the ${TransactionQueue.name}
+        - present successful result`, async () => {
+      const wallet = mockWallet();
+      const queue = mockTransactionQueue<TransactionRequestModel>();
+      const gateway = mockIPayTransactionGateway({
+        request,
+        wallet,
+        unsignedTransaction,
+      });
+      const presenter = mock<IPayTransactionPresenter>();
+      const payTransaction = setupPayTransaction({
+        gateway,
+        presenter,
+        queue,
+        wallet,
+      });
+
+      when(wallet.sendTransaction)
+        .calledWith(unsignedTransaction)
+        .mockResolvedValue(success(transaction));
+
+      await payTransaction.execute(request);
+
+      expect(queue.push).toHaveBeenCalledWith(transaction);
+      expect(presenter.present).toHaveBeenCalledWith(success());
+    });
+
+    it.each([
+      {
+        ErrorCtor: PendingSigningRequestError,
+        error: new PendingSigningRequestError(),
+      },
+      {
+        ErrorCtor: WalletConnectionError,
+        error: new WalletConnectionError(WalletConnectionErrorReason.WRONG_ACCOUNT),
+      },
+      {
+        ErrorCtor: InsufficientGasError,
+        error: new InsufficientGasError(matic()),
+      },
+      {
+        ErrorCtor: UserRejectedError,
+        error: new UserRejectedError('user does not want'),
+      },
+    ])(
+      `should present any "$ErrorCtor.name" the transaction sending fails with`,
+      async ({ error }) => {
+        const wallet = mockWallet();
+        when(wallet.sendTransaction)
+          .calledWith(unsignedTransaction)
+          .mockResolvedValue(failure(error));
+
+        const gateway = mockIPayTransactionGateway({
+          request,
+          wallet,
+          unsignedTransaction,
+        });
+
+        const presenter = mock<IPayTransactionPresenter>();
+        const payTransaction = setupPayTransaction({
+          gateway,
+          presenter,
+          wallet,
+        });
+
+        await payTransaction.execute(request);
+
+        expect(presenter.present).toHaveBeenCalledWith(failure(error));
+      },
+    );
+  });
+});

--- a/packages/domain/src/use-cases/transactions/__tests__/ProtocolCallUseCase.spec.ts
+++ b/packages/domain/src/use-cases/transactions/__tests__/ProtocolCallUseCase.spec.ts
@@ -9,7 +9,6 @@ import {
   UserRejectedError,
   Wallet,
   MetaTransaction,
-  SignedProtocolCall,
   TransactionRequestModel,
 } from '../../../entities';
 import {
@@ -71,7 +70,7 @@ describe(`Given an instance of the ${ProtocolCallUseCase.name}<T> interactor`, (
     it(`should:
         - create an IUnsignedProtocolCall<T> passing the Nonce override from the IPendingTransactionGateway
         - sign it with the user's ${Wallet.name}
-        - relay the resulting ${SignedProtocolCall.name}<T>
+        - relay the resulting ISignedProtocolCall<T>
         - push the resulting ${MetaTransaction.name}<T> into the `, async () => {
       const nonce = mockNonce();
 

--- a/packages/domain/src/use-cases/transactions/index.ts
+++ b/packages/domain/src/use-cases/transactions/index.ts
@@ -5,3 +5,4 @@ export * from './SignlessProtocolCallUseCase';
 export * from './SupportedTransactionRequest';
 export * from './TransactionQueue';
 export * from './BroadcastingError';
+export * from './PayTransaction';

--- a/packages/domain/src/use-cases/wallets/__helpers__/mocks.ts
+++ b/packages/domain/src/use-cases/wallets/__helpers__/mocks.ts
@@ -3,8 +3,14 @@ import { mockDaiAmount, mockEthereumAddress } from '@lens-protocol/shared-kernel
 import { mock } from 'jest-mock-extended';
 import { when } from 'jest-when';
 
-import { Wallet, TransactionKind } from '../../../entities';
+import {
+  Wallet,
+  TransactionKind,
+  TransactionRequestModel,
+  UnsignedTransaction,
+} from '../../../entities';
 import { mockWallet } from '../../../entities/__helpers__/mocks';
+import { IPayTransactionGateway, WithData } from '../../transactions/PayTransaction';
 import { ActiveWallet } from '../ActiveWallet';
 import { WalletData } from '../IActiveWalletPresenter';
 import {
@@ -134,4 +140,22 @@ export function mockWalletLoginRequest(
     address: mockEthereumAddress(),
     ...overrides,
   };
+}
+
+export function mockIPayTransactionGateway<T extends TransactionRequestModel>({
+  request,
+  wallet,
+  unsignedTransaction,
+}: {
+  request: WithData<T>;
+  wallet: Wallet;
+  unsignedTransaction: UnsignedTransaction<T>;
+}): IPayTransactionGateway<T> {
+  const gateway = mock<IPayTransactionGateway<T>>();
+
+  when(gateway.prepareSelfFundedTransaction)
+    .calledWith(request, wallet)
+    .mockResolvedValue(unsignedTransaction);
+
+  return gateway;
 }

--- a/packages/react/src/transactions/adapters/CollectPublicationCallGateway.ts
+++ b/packages/react/src/transactions/adapters/CollectPublicationCallGateway.ts
@@ -12,7 +12,7 @@ import {
 } from '@lens-protocol/domain/use-cases/publications';
 import { invariant } from '@lens-protocol/shared-kernel';
 
-import { UnsignedLensProtocolCall } from '../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../wallet/adapters/ConcreteWallet';
 
 export class CollectPublicationCallGateway implements ICollectPublicationCallGateway {
   constructor(private apolloClient: LensApolloClient) {}
@@ -20,7 +20,7 @@ export class CollectPublicationCallGateway implements ICollectPublicationCallGat
   async createUnsignedProtocolCall<T extends CollectRequest>(
     request: T,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<T>> {
+  ): Promise<UnsignedProtocolCall<T>> {
     const { data } = await this.apolloClient.mutate<
       CreateCollectTypedDataData,
       CreateCollectTypedDataVariables
@@ -36,10 +36,12 @@ export class CollectPublicationCallGateway implements ICollectPublicationCallGat
 
     invariant(data, 'Cannot generate typed data for collect');
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'collectWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 }

--- a/packages/react/src/transactions/adapters/DispatcherConfigCallGateway.ts
+++ b/packages/react/src/transactions/adapters/DispatcherConfigCallGateway.ts
@@ -11,7 +11,7 @@ import {
   UpdateDispatcherConfigRequest,
 } from '@lens-protocol/domain/use-cases/profile';
 
-import { UnsignedLensProtocolCall } from '../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../wallet/adapters/ConcreteWallet';
 
 export class DispatcherConfigCallGateway implements IDispatcherConfigCallGateway {
   constructor(private apolloClient: LensApolloClient) {}
@@ -19,7 +19,7 @@ export class DispatcherConfigCallGateway implements IDispatcherConfigCallGateway
   async createUnsignedProtocolCall<T extends UpdateDispatcherConfigRequest>(
     request: T,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<T>> {
+  ): Promise<UnsignedProtocolCall<T>> {
     const { data } = await this.apolloClient.mutate<
       CreateSetDispatcherTypedDataData,
       CreateSetDispatcherTypedDataVariables
@@ -34,10 +34,12 @@ export class DispatcherConfigCallGateway implements IDispatcherConfigCallGateway
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'setDispatcherWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 }

--- a/packages/react/src/transactions/adapters/FollowPolicyCallGateway.ts
+++ b/packages/react/src/transactions/adapters/FollowPolicyCallGateway.ts
@@ -12,7 +12,7 @@ import {
   UpdateFollowPolicyRequest,
 } from '@lens-protocol/domain/use-cases/profile';
 
-import { UnsignedLensProtocolCall } from '../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../wallet/adapters/ConcreteWallet';
 
 function buildFollowModuleRequest(request: UpdateFollowPolicyRequest) {
   switch (request.policy.type) {
@@ -47,7 +47,7 @@ export class FollowPolicyCallGateway implements IFollowPolicyCallGateway {
   async createUnsignedProtocolCall<T extends UpdateFollowPolicyRequest>(
     request: T,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<T>> {
+  ): Promise<UnsignedProtocolCall<T>> {
     const { data } = await this.apolloClient.mutate<
       CreateSetFollowModuleTypedDataData,
       CreateSetFollowModuleTypedDataVariables
@@ -62,10 +62,12 @@ export class FollowPolicyCallGateway implements IFollowPolicyCallGateway {
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'setFollowModuleWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 }

--- a/packages/react/src/transactions/adapters/FollowProfilesCallGateway.ts
+++ b/packages/react/src/transactions/adapters/FollowProfilesCallGateway.ts
@@ -15,7 +15,7 @@ import {
   isProfileOwnerFollowRequest,
 } from '@lens-protocol/domain/use-cases/profile';
 
-import { UnsignedLensProtocolCall } from '../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../wallet/adapters/ConcreteWallet';
 
 function resolveProfileFollow(request: FollowRequest): Follow[] {
   if (isPaidFollowRequest(request)) {
@@ -51,7 +51,7 @@ export class FollowProfilesCallGateway implements IFollowProfilesCallGateway {
   async createUnsignedProtocolCall<T extends FollowRequest>(
     request: T,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<T>> {
+  ): Promise<UnsignedProtocolCall<T>> {
     const { data } = await this.apolloClient.mutate<
       CreateFollowTypedDataData,
       CreateFollowTypedDataVariables
@@ -65,10 +65,12 @@ export class FollowProfilesCallGateway implements IFollowProfilesCallGateway {
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'followWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 }

--- a/packages/react/src/transactions/adapters/ProfileImageCallGateway.ts
+++ b/packages/react/src/transactions/adapters/ProfileImageCallGateway.ts
@@ -23,7 +23,7 @@ import {
 import { ChainType, failure, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { v4 } from 'uuid';
 
-import { UnsignedLensProtocolCall } from '../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../wallet/adapters/ConcreteWallet';
 import { ITransactionFactory } from './ITransactionFactory';
 import { RelayReceipt } from './RelayReceipt';
 
@@ -56,7 +56,7 @@ export class ProfileImageCallGateway implements IProfileImageCallGateway {
   async createUnsignedProtocolCall(
     request: UpdateProfileImageRequest,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<UpdateProfileImageRequest>> {
+  ): Promise<UnsignedProtocolCall<UpdateProfileImageRequest>> {
     const { data } = await this.apolloClient.mutate<
       CreateSetProfileImageUriTypedDataData,
       CreateSetProfileImageUriTypedDataVariables
@@ -68,11 +68,13 @@ export class ProfileImageCallGateway implements IProfileImageCallGateway {
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'setProfileImageURIWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 
   private async broadcast(

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/ProfileMetadataCallGateway.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/ProfileMetadataCallGateway.ts
@@ -29,7 +29,7 @@ import {
 import { ChainType, failure, never, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { v4 } from 'uuid';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { IMetadataUploader } from '../IMetadataUploader';
 import { ITransactionFactory } from '../ITransactionFactory';
 import { RelayReceipt } from '../RelayReceipt';
@@ -69,13 +69,19 @@ export class ProfileMetadataCallGateway
   async createUnsignedProtocolCall<T extends UpdateProfileDetailsRequest>(
     request: T,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<T>> {
+  ): Promise<UnsignedProtocolCall<T>> {
     const result = await this.createSetProfileMetadataTypedData(
       await this.resolveCreateSetProfileMetadataUriRequest(request),
       nonce,
     );
 
-    return new UnsignedLensProtocolCall(result.id, request, omitTypename(result.typedData));
+    return UnsignedProtocolCall.create({
+      contractAddress: result.typedData.domain.verifyingContract,
+      functionName: 'setProfileMetadataURIWithSig',
+      id: result.id,
+      request,
+      typedData: omitTypename(result.typedData),
+    });
   }
 
   private async createSetProfileMetadataTypedData(

--- a/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/__tests__/ProfileMetadataCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/ProfileMetadataCallGateway/__tests__/ProfileMetadataCallGateway.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '@lens-protocol/domain/use-cases/transactions';
 import { ChainType, Url } from '@lens-protocol/shared-kernel';
 
-import { UnsignedLensProtocolCall } from '../../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../../wallet/adapters/ConcreteWallet';
 import { mockIMetadataUploader, mockITransactionFactory } from '../../__helpers__/mocks';
 import { ProfileMetadataCallGateway } from '../ProfileMetadataCallGateway';
 
@@ -62,7 +62,7 @@ describe(`Given an instance of the ${ProfileMetadataCallGateway.name}`, () => {
     it(`should:
         - create a new Profile Metadata updating the profile details
         - upload it via the IMetadataUploader<ProfileMetadata>
-        - create an instance of the ${UnsignedLensProtocolCall.name} w/ the expected typed data`, async () => {
+        - create an instance of the ${UnsignedProtocolCall.name} w/ the expected typed data`, async () => {
       const data = mockCreateSetProfileMetadataTypedDataData();
 
       const { gateway, uploader } = setupTestScenario({
@@ -89,7 +89,7 @@ describe(`Given an instance of the ${ProfileMetadataCallGateway.name}`, () => {
           bio: request.bio,
         }),
       );
-      expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+      expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
       expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
     });
 

--- a/packages/react/src/transactions/adapters/ProtocolCallRelayer.ts
+++ b/packages/react/src/transactions/adapters/ProtocolCallRelayer.ts
@@ -7,7 +7,7 @@ import {
 } from '@lens-protocol/api-bindings';
 import {
   MetaTransaction,
-  SignedProtocolCall,
+  ISignedProtocolCall,
   TransactionRequestModel,
 } from '@lens-protocol/domain/entities';
 import {
@@ -29,7 +29,7 @@ export class ProtocolCallRelayer implements IProtocolCallRelayer<SupportedTransa
   ) {}
 
   async relayProtocolCall<T extends SupportedTransactionRequest>(
-    signedCall: SignedProtocolCall<T>,
+    signedCall: ISignedProtocolCall<T>,
   ): PromiseResult<MetaTransaction<T>, BroadcastingError> {
     const result = await this.broadcast(signedCall);
 
@@ -50,7 +50,7 @@ export class ProtocolCallRelayer implements IProtocolCallRelayer<SupportedTransa
   }
 
   private async broadcast<T extends TransactionRequestModel>(
-    signedCall: SignedProtocolCall<T>,
+    signedCall: ISignedProtocolCall<T>,
   ): PromiseResult<RelayReceipt, BroadcastingError> {
     try {
       const { data } = await this.apolloClient.mutate<

--- a/packages/react/src/transactions/adapters/UnfollowProfileCallGateway.ts
+++ b/packages/react/src/transactions/adapters/UnfollowProfileCallGateway.ts
@@ -10,21 +10,14 @@ import {
   UnfollowRequest,
 } from '@lens-protocol/domain/use-cases/profile';
 
-import { UnsignedLensProtocolCall } from '../../wallet/adapters/ConcreteWallet';
-import { TypedData } from './TypedData';
-
-class UnsignedUnfollowCall<T extends UnfollowRequest> extends UnsignedLensProtocolCall<T> {
-  constructor(data: { id: string; request: T; typedData: TypedData }) {
-    super(data.id, data.request, data.typedData);
-  }
-}
+import { UnsignedProtocolCall } from '../../wallet/adapters/ConcreteWallet';
 
 export class UnfollowProfileCallGateway implements IUnfollowProfileCallGateway {
   constructor(private apolloClient: LensApolloClient) {}
 
   async createUnsignedProtocolCall<T extends UnfollowRequest>(
     request: T,
-  ): Promise<UnsignedLensProtocolCall<T>> {
+  ): Promise<UnsignedProtocolCall<T>> {
     const { data } = await this.apolloClient.mutate<
       CreateUnfollowTypedDataData,
       CreateUnfollowTypedDataVariables
@@ -37,7 +30,9 @@ export class UnfollowProfileCallGateway implements IUnfollowProfileCallGateway {
       },
     });
 
-    return new UnsignedUnfollowCall({
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'burnWithSig',
       id: data.result.id,
       request,
       typedData: omitTypename(data.result.typedData),

--- a/packages/react/src/transactions/adapters/__tests__/CollectPublicationCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/CollectPublicationCallGateway.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@lens-protocol/api-bindings/mocks';
 import { mockFreeCollectRequest, mockNonce } from '@lens-protocol/domain/mocks';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { CollectPublicationCallGateway } from '../CollectPublicationCallGateway';
 
 function mockCreateCollectTypedDatMutationMockedResponse({
@@ -36,7 +36,7 @@ describe(`Given an instance of the ${CollectPublicationCallGateway.name}`, () =>
   const request = mockFreeCollectRequest();
 
   describe(`when calling the "${CollectPublicationCallGateway.prototype.createUnsignedProtocolCall.name}"`, () => {
-    it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+    it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
       const data = mockCreateCollectTypedDataData();
 
       const apollo = createMockApolloClientWithMultipleResponses([
@@ -49,11 +49,11 @@ describe(`Given an instance of the ${CollectPublicationCallGateway.name}`, () =>
           data,
         }),
       ]);
-      const collectPublicationCallGateway = new CollectPublicationCallGateway(apollo);
 
+      const collectPublicationCallGateway = new CollectPublicationCallGateway(apollo);
       const unsignedCall = await collectPublicationCallGateway.createUnsignedProtocolCall(request);
 
-      expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+      expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
       expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
     });
 
@@ -72,8 +72,8 @@ describe(`Given an instance of the ${CollectPublicationCallGateway.name}`, () =>
           data: mockCreateCollectTypedDataData({ nonce }),
         }),
       ]);
-      const collectPublicationCallGateway = new CollectPublicationCallGateway(apollo);
 
+      const collectPublicationCallGateway = new CollectPublicationCallGateway(apollo);
       const unsignedCall = await collectPublicationCallGateway.createUnsignedProtocolCall(
         request,
         nonce,

--- a/packages/react/src/transactions/adapters/__tests__/DispatcherConfigCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/DispatcherConfigCallGateway.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@lens-protocol/api-bindings/mocks';
 import { mockNonce, mockUpdateDispatcherConfigRequest } from '@lens-protocol/domain/mocks';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { DispatcherConfigCallGateway } from '../DispatcherConfigCallGateway';
 
 function mockCreateSetDispatcherTypedDataMutationMockedResponse({
@@ -34,7 +34,7 @@ function mockCreateSetDispatcherTypedDataMutationMockedResponse({
 
 describe(`Given an instance of the ${DispatcherConfigCallGateway.name}`, () => {
   describe(`when calling the "${DispatcherConfigCallGateway.prototype.createUnsignedProtocolCall.name}" method`, () => {
-    it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+    it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
       const request = mockUpdateDispatcherConfigRequest();
 
       const data = mockCreateSetDispatcherTypedDataData();
@@ -55,7 +55,7 @@ describe(`Given an instance of the ${DispatcherConfigCallGateway.name}`, () => {
 
       const unsignedCall = await dispatcherConfigCallGateway.createUnsignedProtocolCall(request);
 
-      expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+      expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
       expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
     });
 

--- a/packages/react/src/transactions/adapters/__tests__/FollowPolicyCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/FollowPolicyCallGateway.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '@lens-protocol/domain/use-cases/profile';
 import { never } from '@lens-protocol/shared-kernel';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { FollowPolicyCallGateway } from '../FollowPolicyCallGateway';
 
 function createCreateSetFollowModuleTypedDataMockedResponse({
@@ -77,7 +77,7 @@ describe(`Given an instance of the ${FollowPolicyCallGateway.name}`, () => {
     ({ policy, expectedFollowModule }) => {
       const request = mockUpdateFollowPolicyRequest({ policy });
 
-      it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+      it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
         const data = mockCreateSetFollowModuleTypedDataData();
 
         const apollo = createMockApolloClientWithMultipleResponses([
@@ -95,7 +95,7 @@ describe(`Given an instance of the ${FollowPolicyCallGateway.name}`, () => {
 
         const unsignedCall = await followFeeTransactionGateway.createUnsignedProtocolCall(request);
 
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
 

--- a/packages/react/src/transactions/adapters/__tests__/FollowProfilesCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/FollowProfilesCallGateway.spec.ts
@@ -16,7 +16,7 @@ import {
   mockUnconstrainedFollowRequest,
 } from '@lens-protocol/domain/mocks';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { FollowProfilesCallGateway } from '../FollowProfilesCallGateway';
 
 function createCreateFollowTypedDataMutationMockedResponse({
@@ -40,7 +40,7 @@ function createCreateFollowTypedDataMutationMockedResponse({
 describe(`Given an instance of the ${FollowProfilesCallGateway.name}`, () => {
   describe(`when calling the "${FollowProfilesCallGateway.prototype.createUnsignedProtocolCall.name}" method`, () => {
     describe('with an UnconstrainedFollowRequest', () => {
-      it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+      it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
         const request = mockUnconstrainedFollowRequest();
         const data = mockCreateFollowTypedDataData();
 
@@ -62,13 +62,13 @@ describe(`Given an instance of the ${FollowProfilesCallGateway.name}`, () => {
 
         const unsignedCall = await followFeeTransactionGateway.createUnsignedProtocolCall(request);
 
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
     });
 
     describe('with a ProfileOwnerFollowRequest', () => {
-      it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+      it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
         const request = mockProfileOwnerFollowRequest();
         const data = mockCreateFollowTypedDataData();
 
@@ -95,13 +95,13 @@ describe(`Given an instance of the ${FollowProfilesCallGateway.name}`, () => {
 
         const unsignedCall = await followFeeTransactionGateway.createUnsignedProtocolCall(request);
 
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
     });
 
     describe(`with a PaidFollowRequest`, () => {
-      it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+      it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
         const request = mockPaidFollowRequest();
         const data = mockCreateFollowTypedDataData();
 
@@ -131,7 +131,7 @@ describe(`Given an instance of the ${FollowProfilesCallGateway.name}`, () => {
 
         const unsignedCall = await followProfilesCallGateway.createUnsignedProtocolCall(request);
 
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
     });

--- a/packages/react/src/transactions/adapters/__tests__/ProfileImageCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/ProfileImageCallGateway.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '@lens-protocol/domain/use-cases/transactions';
 import { ChainType } from '@lens-protocol/shared-kernel';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { ProfileImageCallGateway } from '../ProfileImageCallGateway';
 import { mockITransactionFactory } from '../__helpers__/mocks';
 
@@ -59,7 +59,7 @@ describe(`Given an instance of the ${ProfileImageCallGateway.name}`, () => {
     const { request, expectedRequestVars } = createExerciseData();
 
     describe(`when calling the "${ProfileImageCallGateway.prototype.createUnsignedProtocolCall.name}"`, () => {
-      it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+      it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
         const data = mockCreateSetProfileImageUriTypedDataData();
 
         const apollo = createMockApolloClientWithMultipleResponses([
@@ -76,7 +76,7 @@ describe(`Given an instance of the ${ProfileImageCallGateway.name}`, () => {
 
         const unsignedCall = await gateway.createUnsignedProtocolCall(request);
 
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
 

--- a/packages/react/src/transactions/adapters/__tests__/ProtocolCallRelayer.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/ProtocolCallRelayer.spec.ts
@@ -6,7 +6,7 @@ import {
   mockRelayErrorFragment,
 } from '@lens-protocol/api-bindings/mocks';
 import {
-  SignedProtocolCall,
+  ISignedProtocolCall,
   MetaTransaction,
   TransactionRequestModel,
 } from '@lens-protocol/domain/entities';
@@ -27,7 +27,7 @@ function setupProtocolCallRelayer({
   signedCall,
 }: {
   relayResult: RelayResult;
-  signedCall: SignedProtocolCall<TransactionRequestModel>;
+  signedCall: ISignedProtocolCall<TransactionRequestModel>;
 }) {
   const factory = mockITransactionFactory();
   const apollo = createMockApolloClientWithMultipleResponses([
@@ -47,7 +47,7 @@ function setupProtocolCallRelayer({
 describe(`Given an instance of the ${ProtocolCallRelayer.name}`, () => {
   const signedCall = mockSignedProtocolCall<SupportedTransactionRequest>();
 
-  describe(`when relaying a ${SignedProtocolCall.name} succeeds`, () => {
+  describe(`when relaying an ISignedProtocolCall succeeds`, () => {
     it(`should resolve with a success(${MetaTransaction.name}) on Polygon`, async () => {
       const relayResult = mockRelayerResultFragment();
 
@@ -65,29 +65,31 @@ describe(`Given an instance of the ${ProtocolCallRelayer.name}`, () => {
     });
   });
 
-  describe(`when relaying a ${SignedProtocolCall.name} fails with a Rejected reason`, () => {
-    it(`should resolve with a failure(${BroadcastingError.name}) with ${BroadcastingErrorReason.REJECTED}`, async () => {
-      const relayResult = mockRelayErrorFragment(RelayErrorReasons.Rejected);
+  describe(`when relaying an ISignedProtocolCall fails`, () => {
+    describe(`with a Rejected reason`, () => {
+      it(`should resolve with a failure(${BroadcastingError.name}) with ${BroadcastingErrorReason.REJECTED}`, async () => {
+        const relayResult = mockRelayErrorFragment(RelayErrorReasons.Rejected);
 
-      const transactionRelayer = setupProtocolCallRelayer({ relayResult, signedCall });
-      const result = await transactionRelayer.relayProtocolCall(signedCall);
+        const transactionRelayer = setupProtocolCallRelayer({ relayResult, signedCall });
+        const result = await transactionRelayer.relayProtocolCall(signedCall);
 
-      expect(() => result.unwrap()).toThrowError(
-        new BroadcastingError(BroadcastingErrorReason.REJECTED),
-      );
+        expect(() => result.unwrap()).toThrowError(
+          new BroadcastingError(BroadcastingErrorReason.REJECTED),
+        );
+      });
     });
-  });
 
-  describe(`when relaying a ${SignedProtocolCall.name} fails with any other reason than Rejected`, () => {
-    it(`should resolve with a failure(${BroadcastingError.name}) with ${BroadcastingErrorReason.UNSPECIFIED}`, async () => {
-      const relayResult = mockRelayErrorFragment(RelayErrorReasons.NotAllowed);
+    describe(`with any other reason than Rejected`, () => {
+      it(`should resolve with a failure(${BroadcastingError.name}) with ${BroadcastingErrorReason.UNSPECIFIED}`, async () => {
+        const relayResult = mockRelayErrorFragment(RelayErrorReasons.NotAllowed);
 
-      const transactionRelayer = setupProtocolCallRelayer({ relayResult, signedCall });
-      const result = await transactionRelayer.relayProtocolCall(signedCall);
+        const transactionRelayer = setupProtocolCallRelayer({ relayResult, signedCall });
+        const result = await transactionRelayer.relayProtocolCall(signedCall);
 
-      expect(() => result.unwrap()).toThrowError(
-        new BroadcastingError(BroadcastingErrorReason.UNSPECIFIED),
-      );
+        expect(() => result.unwrap()).toThrowError(
+          new BroadcastingError(BroadcastingErrorReason.UNSPECIFIED),
+        );
+      });
     });
   });
 });

--- a/packages/react/src/transactions/adapters/__tests__/UnfollowProfileCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/UnfollowProfileCallGateway.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@lens-protocol/api-bindings/mocks';
 import { mockUnfollowRequest } from '@lens-protocol/domain/mocks';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { UnfollowProfileCallGateway } from '../UnfollowProfileCallGateway';
 
 function mockCreateUnfollowTypedDataMutationMockedResponse({
@@ -36,7 +36,7 @@ describe(`Given an instance of the ${UnfollowProfileCallGateway.name}`, () => {
   const request = mockUnfollowRequest();
 
   describe(`when calling the "${UnfollowProfileCallGateway.prototype.createUnsignedProtocolCall.name}"`, () => {
-    it(`should create an "${UnsignedLensProtocolCall.name}" w/ the expected typed data`, async () => {
+    it(`should create an "${UnsignedProtocolCall.name}" w/ the expected typed data`, async () => {
       const data = mockCreateUnfollowTypedDataData();
       const apollo = createMockApolloClientWithMultipleResponses([
         mockCreateUnfollowTypedDataMutationMockedResponse({
@@ -52,7 +52,7 @@ describe(`Given an instance of the ${UnfollowProfileCallGateway.name}`, () => {
 
       const unsignedCall = await gateway.createUnsignedProtocolCall(request);
 
-      expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+      expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
       expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
     });
   });

--- a/packages/react/src/transactions/adapters/publication-call-gateways/CreateCommentCallGateway.ts
+++ b/packages/react/src/transactions/adapters/publication-call-gateways/CreateCommentCallGateway.ts
@@ -23,7 +23,7 @@ import {
 import { ChainType, failure, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { v4 } from 'uuid';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { IMetadataUploader } from '../IMetadataUploader';
 import { ITransactionFactory } from '../ITransactionFactory';
 import { RelayReceipt } from '../RelayReceipt';
@@ -58,7 +58,7 @@ export class CreateCommentCallGateway implements ICreateCommentCallGateway {
   async createUnsignedProtocolCall(
     request: CreateCommentRequest,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<CreateCommentRequest>> {
+  ): Promise<UnsignedProtocolCall<CreateCommentRequest>> {
     const { data } = await this.apolloClient.mutate<
       CreateCommentTypedDataData,
       CreateCommentTypedDataVariables
@@ -70,11 +70,13 @@ export class CreateCommentCallGateway implements ICreateCommentCallGateway {
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'commentWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 
   private async broadcast(

--- a/packages/react/src/transactions/adapters/publication-call-gateways/CreateMirrorCallGateway.ts
+++ b/packages/react/src/transactions/adapters/publication-call-gateways/CreateMirrorCallGateway.ts
@@ -23,7 +23,7 @@ import {
 import { ChainType, failure, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { v4 } from 'uuid';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { ITransactionFactory } from '../ITransactionFactory';
 import { RelayReceipt } from '../RelayReceipt';
 
@@ -56,7 +56,7 @@ export class CreateMirrorCallGateway implements ICreateMirrorCallGateway {
   async createUnsignedProtocolCall(
     request: CreateMirrorRequest,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<CreateMirrorRequest>> {
+  ): Promise<UnsignedProtocolCall<CreateMirrorRequest>> {
     const { data } = await this.apolloClient.mutate<
       CreateMirrorTypedDataData,
       CreateMirrorTypedDataVariables
@@ -68,11 +68,13 @@ export class CreateMirrorCallGateway implements ICreateMirrorCallGateway {
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'mirrorWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 
   private async broadcast(

--- a/packages/react/src/transactions/adapters/publication-call-gateways/CreatePostCallGateway.ts
+++ b/packages/react/src/transactions/adapters/publication-call-gateways/CreatePostCallGateway.ts
@@ -23,7 +23,7 @@ import {
 import { ChainType, failure, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { v4 } from 'uuid';
 
-import { UnsignedLensProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
 import { IMetadataUploader } from '../IMetadataUploader';
 import { ITransactionFactory } from '../ITransactionFactory';
 import { RelayReceipt } from '../RelayReceipt';
@@ -58,7 +58,7 @@ export class CreatePostCallGateway<R extends CreatePostRequest> implements ICrea
   async createUnsignedProtocolCall<T extends R>(
     request: T,
     nonce?: Nonce,
-  ): Promise<UnsignedLensProtocolCall<CreatePostRequest>> {
+  ): Promise<UnsignedProtocolCall<CreatePostRequest>> {
     const { data } = await this.apolloClient.mutate<
       CreatePostTypedDataData,
       CreatePostTypedDataVariables
@@ -70,11 +70,13 @@ export class CreatePostCallGateway<R extends CreatePostRequest> implements ICrea
       },
     });
 
-    return new UnsignedLensProtocolCall(
-      data.result.id,
+    return UnsignedProtocolCall.create({
+      contractAddress: data.result.typedData.domain.verifyingContract,
+      functionName: 'postWithSig',
+      id: data.result.id,
       request,
-      omitTypename(data.result.typedData),
-    );
+      typedData: omitTypename(data.result.typedData),
+    });
   }
 
   private async broadcast(

--- a/packages/react/src/transactions/adapters/publication-call-gateways/__tests__/CreateCommentCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/publication-call-gateways/__tests__/CreateCommentCallGateway.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '@lens-protocol/domain/use-cases/transactions';
 import { ChainType, Url } from '@lens-protocol/shared-kernel';
 
-import { UnsignedLensProtocolCall } from '../../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../../wallet/adapters/ConcreteWallet';
 import { mockIMetadataUploader, mockITransactionFactory } from '../../__helpers__/mocks';
 import { CreateCommentCallGateway } from '../CreateCommentCallGateway';
 import {
@@ -111,7 +111,7 @@ describe(`Given an instance of ${CreateCommentCallGateway.name}`, () => {
     describe(`when creating an IUnsignedProtocolCall<CreateCommentRequest>`, () => {
       it(`should:
           - use the IMetadataUploader<CreateCommentRequest'> to upload the publication metadata
-          - create an instance of the ${UnsignedLensProtocolCall.name} with the expected typed data`, async () => {
+          - create an instance of the ${UnsignedProtocolCall.name} with the expected typed data`, async () => {
         const data = mockCreateCommentTypedDataData();
         const apolloClient = createMockApolloClientWithMultipleResponses([
           createCreateCommentTypedDataMockedResponse({
@@ -131,7 +131,7 @@ describe(`Given an instance of ${CreateCommentCallGateway.name}`, () => {
         const unsignedCall = await gateway.createUnsignedProtocolCall(request);
 
         expect(uploader.upload).toHaveBeenCalledWith(request);
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
 

--- a/packages/react/src/transactions/adapters/publication-call-gateways/__tests__/CreatePostCallGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/publication-call-gateways/__tests__/CreatePostCallGateway.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '@lens-protocol/domain/use-cases/transactions';
 import { ChainType, Url } from '@lens-protocol/shared-kernel';
 
-import { UnsignedLensProtocolCall } from '../../../../wallet/adapters/ConcreteWallet';
+import { UnsignedProtocolCall } from '../../../../wallet/adapters/ConcreteWallet';
 import { mockITransactionFactory, mockIMetadataUploader } from '../../__helpers__/mocks';
 import { CreatePostCallGateway } from '../CreatePostCallGateway';
 import {
@@ -111,7 +111,7 @@ describe(`Given an instance of ${CreatePostCallGateway.name}`, () => {
     describe(`when creating an IUnsignedProtocolCall<CreatePostRequest>`, () => {
       it(`should:
           - use the IMetadataUploader<CreatePostRequest'> to upload the publication metadata
-          - create an instance of the ${UnsignedLensProtocolCall.name} with the expected typed data`, async () => {
+          - create an instance of the ${UnsignedProtocolCall.name} with the expected typed data`, async () => {
         const data = mockCreatePostTypedDataData();
         const apolloClient = createMockApolloClientWithMultipleResponses([
           createCreatePostTypedDataMockedResponse({
@@ -130,7 +130,7 @@ describe(`Given an instance of ${CreatePostCallGateway.name}`, () => {
         const unsignedCall = await gateway.createUnsignedProtocolCall(request);
 
         expect(uploader.upload).toHaveBeenCalledWith(request);
-        expect(unsignedCall).toBeInstanceOf(UnsignedLensProtocolCall);
+        expect(unsignedCall).toBeInstanceOf(UnsignedProtocolCall);
         expect(unsignedCall.typedData).toEqual(omitTypename(data.result.typedData));
       });
 

--- a/packages/react/src/wallet/adapters/__helpers__/mocks.ts
+++ b/packages/react/src/wallet/adapters/__helpers__/mocks.ts
@@ -18,7 +18,7 @@ import {
   ConcreteWallet,
   ISignerFactory,
   ITransactionRequest,
-  UnsignedLensProtocolCall,
+  UnsignedProtocolCall,
 } from '../ConcreteWallet';
 import { Credentials } from '../Credentials';
 import { IProviderFactory } from '../IProviderFactory';
@@ -70,14 +70,20 @@ export function mockIProviderFactory({
   return factory;
 }
 
-export function mockUnsignedLensProtocolCall<T extends TransactionRequestModel>({
+export function mockUnsignedProtocolCall<T extends TransactionRequestModel>({
   typedData,
   request,
 }: {
   typedData: TypedData;
   request: T;
 }) {
-  return new UnsignedLensProtocolCall(faker.datatype.uuid(), request, typedData);
+  return UnsignedProtocolCall.create({
+    id: faker.datatype.uuid(),
+    request,
+    typedData,
+    contractAddress: mockEthereumAddress(),
+    functionName: faker.datatype.string(),
+  });
 }
 
 class MockedUnsignedTransactionRequest<T extends TransactionRequestModel>

--- a/packages/react/src/wallet/adapters/__tests__/ConcreteWallet.spec.ts
+++ b/packages/react/src/wallet/adapters/__tests__/ConcreteWallet.spec.ts
@@ -5,7 +5,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import {
   NativeTransaction,
-  SignedProtocolCall,
   UnsignedTransaction,
   InsufficientGasError,
   WalletConnectionError,
@@ -25,11 +24,11 @@ import {
   mockITransactionFactory,
   mockTypedData,
 } from '../../../transactions/adapters/__helpers__/mocks';
-import { ConcreteWallet, ISignerFactory, UnsignedLensProtocolCall } from '../ConcreteWallet';
+import { ConcreteWallet, ISignerFactory, UnsignedProtocolCall } from '../ConcreteWallet';
 import {
   mockErrorWithCode,
   mockISignerFactory,
-  mockUnsignedLensProtocolCall,
+  mockUnsignedProtocolCall,
   mockUnsignedTransactionRequest,
 } from '../__helpers__/mocks';
 
@@ -48,13 +47,13 @@ function setupWalletInstance({ signerFactory }: { signerFactory: ISignerFactory 
 }
 
 describe(`Given an instance of ${ConcreteWallet.name}`, () => {
-  describe(`when signing an ${UnsignedLensProtocolCall.name}`, () => {
+  describe(`when signing an ${UnsignedProtocolCall.name}`, () => {
     const typedData = mockTypedData();
     const request = mockTransactionRequestModel();
-    const unsignedCall = mockUnsignedLensProtocolCall({ typedData, request });
+    const unsignedCall = mockUnsignedProtocolCall({ typedData, request });
     const signature = mockSignature();
 
-    it(`should resolve with a ${SignedProtocolCall.name} instance`, async () => {
+    it(`should resolve with a ISignedProtocolCall instance`, async () => {
       const signer = mock<providers.JsonRpcSigner>();
       when(signer._signTypedData)
         .calledWith(typedData.domain, typedData.types, typedData.value)
@@ -68,7 +67,6 @@ describe(`Given an instance of ${ConcreteWallet.name}`, () => {
       const wallet = setupWalletInstance({ signerFactory });
       const result = await wallet.signProtocolCall(unsignedCall);
 
-      expect(result.unwrap()).toBeInstanceOf(SignedProtocolCall);
       expect(result.unwrap()).toEqual({
         id: unsignedCall.id,
         nonce: unsignedCall.nonce,


### PR DESCRIPTION
In this PR:
- `PayTransaction` use case (not wired yet)
- Ensures `UnsigneProtocolCall` has contract address and contract function name that could be used to create a fallback call from the user's wallet