### PR TITLE
refactor: generalizes `resolveCollectModule` helper tests ahead of `CreateCommentRequest` changes

### DIFF
--- a/packages/domain/src/use-cases/publications/__helpers__/mocks.ts
+++ b/packages/domain/src/use-cases/publications/__helpers__/mocks.ts
@@ -18,6 +18,7 @@ import { ReferencePolicyType } from '../ReferencePolicyConfig';
 import { ReportPublicationRequest } from '../ReportPublication';
 import { ImageType } from '../config';
 import {
+  ChargeCollectPolicyConfig,
   CollectPolicyType,
   ContentFocus,
   FreeCollectPolicyConfig,
@@ -110,7 +111,7 @@ export function mockFreeCollectPolicyConfig(
 }
 
 export function mockChargeCollectPolicyConfig(
-  overrides?: Partial<SimpleChargeCollectPolicyConfig>,
+  overrides?: Partial<ChargeCollectPolicyConfig>,
 ): SimpleChargeCollectPolicyConfig {
   return {
     type: CollectPolicyType.CHARGE,


### PR DESCRIPTION
While developing my changes I noticed that this test was not fully testing resolving of collect module for `CreateCommentRequest` but also was giving me issue with TS typedef as I made changes to the request models.

This PR just isolates a refactoring of the existing tests, some rewording, and also extends it to `CreateCommentRequest`.

This just isolates these changes from the following PR.