### PR TITLE
cjs to esm

### DIFF
--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git://github.com/lens-protocol/lens-sdk.git"
   },
-  "main": "dist/lens-protocol-wagmi.cjs.js",
+  "main": "dist/lens-protocol-wagmi.esm.js",
   "module": "dist/lens-protocol-wagmi.esm.js",
   "exports": {
     ".": {


### PR DESCRIPTION
#334 

- The main property is a property that specifies the entry point for the package.
- The entry point is the file that is loaded when the package is imported.
- In this case, the main property is set to dist/lens-protocol-wagmi.cjs.js. This means that the dist/lens-protocol-wagmi.cjs.js file is loaded when the package is imported.
- However, this file is a CommonJS module, which is not supported by all browsers.
- To fix this, you need to change the main property to point to the esm file instead of the cjs file.
- The esm file is an ES module, which is supported by all browsers.
