### PR TITLE
Drafts initial snapshot API integration setup

### DIFF
--- a/packages/api-bindings/.eslintrc.cjs
+++ b/packages/api-bindings/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
           {
             name: '@apollo/client',
             importNames: ['createHttpLink', 'HttpLink'],
-            message: 'Please use "createHttpLink" from src/apollo/links.ts.',
+            message: 'Please terminating links from src/apollo/links.ts.',
           },
         ],
       },

--- a/packages/api-bindings/codegen-api.yml
+++ b/packages/api-bindings/codegen-api.yml
@@ -23,6 +23,7 @@ generates:
         CollectModuleData: string
         CollectPolicy: CollectPolicy
         ContentEncryptionKey: ContentEncryptionKey
+        ContentInsight: ContentInsight
         ContractAddress: string
         Cursor: string
         DataAvailabilityId: string
@@ -82,6 +83,7 @@ generates:
               "import type { AppId, DecryptionCriteria, ProfileId, PublicationId } from '@lens-protocol/domain/entities';",
               "import type { Erc20Amount as ClientErc20Amount, EthereumAddress, Url } from '@lens-protocol/shared-kernel';",
               "import type { ContentEncryptionKey } from './ContentEncryptionKey';",
+              "import type { ContentInsight } from './ContentInsight';",
               "import type { ProfileAttributes } from './ProfileAttributes';",
               "import type { FollowPolicy } from './FollowPolicy';",
               "import type { FollowStatus } from './FollowStatus';",
@@ -101,3 +103,32 @@ generates:
           fragmentVariablePrefix: Fragment # because FragmentDoc suffix is removed by omitOperationSuffix we need to add a prefix to differentiate fragment types from fragment documents
       - 'typescript-apollo-client-helpers'
       - 'fragment-matcher'
+
+  src/snapshot/generated.ts:
+    config:
+      strictScalars: true
+      scalars:
+        Any: unknown
+    schema: https://hub.snapshot.org/graphql
+    documents:
+      - src/snapshot/*.graphql
+    plugins:
+      - 'typescript':
+          onlyOperationTypes: true # scalars and enums
+      - add:
+          content: [
+              '/** Code generated. DO NOT EDIT. */',
+              '/* eslint-disable import/no-default-export */', # generatedTypes default export
+              '/* eslint-disable no-restricted-imports */', # import * from @apollo/client
+            ]
+      - 'typescript-operations':
+          skipTypename: true
+          immutableTypes: false
+          inlineFragmentTypes: combine
+          omitOperationSuffix: true
+          operationResultSuffix: 'Data'
+      - 'typescript-react-apollo':
+          pureMagicComment: true # keep
+          omitOperationSuffix: true # MUST goes with typescript-operations.omitOperationSuffix
+          operationResultSuffix: 'Data' # goes with typescript-operations.operationResultSuffix
+          fragmentVariablePrefix: Fragment # because FragmentDoc suffix is removed by omitOperationSuffix we need to add a prefix to differentiate fragment types from fragment documents

--- a/packages/api-bindings/src/apollo/__helpers__/mocks.ts
+++ b/packages/api-bindings/src/apollo/__helpers__/mocks.ts
@@ -3,7 +3,7 @@ import { MockedResponse, mockSingleLink } from '@apollo/client/testing';
 import { DocumentNode, ExecutionResult, GraphQLError } from 'graphql';
 
 import { LensApolloClient } from '../LensApolloClient';
-import { createMockApolloCache, MockCacheConfiguration } from '../cache/__helpers__/mocks';
+import { mockLensCache, MockCacheConfiguration } from '../cache/__helpers__/mocks';
 import { ApolloServerErrorCode } from '../isGraphQLValidationError';
 
 export function createMockApolloClientWithMultipleResponses(
@@ -11,7 +11,7 @@ export function createMockApolloClientWithMultipleResponses(
   cacheConfiguration: MockCacheConfiguration = {},
 ): LensApolloClient<NormalizedCacheObject> {
   return new LensApolloClient({
-    cache: createMockApolloCache(cacheConfiguration),
+    cache: mockLensCache(cacheConfiguration),
 
     link: mockSingleLink(...mocks).setOnError((error) => {
       throw error;

--- a/packages/api-bindings/src/apollo/__tests__/links.spec.ts
+++ b/packages/api-bindings/src/apollo/__tests__/links.spec.ts
@@ -4,7 +4,7 @@ import { mock } from 'jest-mock-extended';
 
 import { semVer } from '../../SemVer';
 import { createHttpJsonResponse } from '../__helpers__/mocks';
-import { createHttpLink } from '../links';
+import { createLensLink } from '../links';
 
 const query = gql`
   query Ping {
@@ -13,7 +13,7 @@ const query = gql`
 `;
 
 describe(`Given an instance of the ${ApolloClient.name}`, () => {
-  describe('wired with our custom HttpLink', () => {
+  describe('wired with our custom LensLink', () => {
     const supportedVersion = semVer('2.0.0');
 
     describe(`when the response 'x-api-version' is ahead by a major version or more compared to the SDK supported range`, () => {
@@ -28,7 +28,7 @@ describe(`Given an instance of the ${ApolloClient.name}`, () => {
         );
         const client = new ApolloClient({
           cache: new InMemoryCache(),
-          link: createHttpLink({
+          link: createLensLink({
             fetch: jest.fn().mockResolvedValue(response),
             logger,
             uri: 'http://localhost:4000/graphql',
@@ -54,7 +54,7 @@ describe(`Given an instance of the ${ApolloClient.name}`, () => {
         );
         const client = new ApolloClient({
           cache: new InMemoryCache(),
-          link: createHttpLink({
+          link: createLensLink({
             fetch: jest.fn().mockResolvedValue(response),
             logger,
             uri: 'http://localhost:4000/graphql',
@@ -80,7 +80,7 @@ describe(`Given an instance of the ${ApolloClient.name}`, () => {
         );
         const client = new ApolloClient({
           cache: new InMemoryCache(),
-          link: createHttpLink({
+          link: createLensLink({
             fetch: jest.fn().mockResolvedValue(response),
             logger,
             uri: 'http://localhost:4000/graphql',

--- a/packages/api-bindings/src/apollo/cache/__helpers__/mocks.ts
+++ b/packages/api-bindings/src/apollo/cache/__helpers__/mocks.ts
@@ -4,17 +4,17 @@ import { mockCreatePostRequest } from '@lens-protocol/domain/mocks';
 import { AnyTransactionRequest } from '@lens-protocol/domain/use-cases/transactions';
 import { WalletData } from '@lens-protocol/domain/use-cases/wallets';
 
-import { createApolloCache } from '../createApolloCache';
+import { createLensCache } from '../createLensCache';
 import { TransactionState, TxStatus } from '../transactions';
 
 export type MockCacheConfiguration = {
   activeWalletVar?: ReactiveVar<WalletData | null>;
 };
 
-export function createMockApolloCache({
+export function mockLensCache({
   activeWalletVar = makeVar<WalletData | null>(null),
 }: MockCacheConfiguration = {}): ApolloCache<NormalizedCacheObject> {
-  return createApolloCache({ activeWalletVar });
+  return createLensCache({ activeWalletVar });
 }
 
 export function mockTransactionState<T extends AnyTransactionRequest>(

--- a/packages/api-bindings/src/apollo/cache/createLensCache.ts
+++ b/packages/api-bindings/src/apollo/cache/createLensCache.ts
@@ -21,6 +21,7 @@ import { createPublicationsFieldPolicy } from './createPublicationsFieldPolicy';
 import { createRevenueAggregateTypePolicy } from './createRevenueAggregateTypePolicy';
 import { createSearchFieldPolicy } from './createSearchFieldPolicy';
 import { createWhoReactedPublicationFieldPolicy } from './createWhoReactedPublicationFieldPolicy';
+import { ContentInsightMatcher } from './utils/ContentInsight';
 import { noCachedField } from './utils/noCachedField';
 import { notNormalizedType } from './utils/notNormalizedType';
 
@@ -29,13 +30,21 @@ type TypePoliciesArgs = {
    * @deprecated this should not be provided by the consumer but should be part of `@lens-protocol/api-bindings` exports
    */
   activeWalletVar: ReactiveVar<WalletData | null>;
+
+  /**
+   * A list of ContentInsightMatcher used to extract insights from publication metadata content
+   */
+  contentMatchers?: ContentInsightMatcher[];
 };
 
-function createTypePolicies({ activeWalletVar }: TypePoliciesArgs): StrictTypedTypePolicies {
+function createTypePolicies({
+  activeWalletVar,
+  contentMatchers = [],
+}: TypePoliciesArgs): StrictTypedTypePolicies {
   return {
     Profile: createProfileTypePolicy(activeWalletVar),
-    Post: createContentPublicationTypePolicy(),
-    Comment: createContentPublicationTypePolicy(),
+    Post: createContentPublicationTypePolicy({ contentMatchers }),
+    Comment: createContentPublicationTypePolicy({ contentMatchers }),
 
     FeedItem: notNormalizedType(),
 
@@ -82,11 +91,9 @@ function createTypePolicies({ activeWalletVar }: TypePoliciesArgs): StrictTypedT
   };
 }
 
-export function createApolloCache({
-  activeWalletVar,
-}: TypePoliciesArgs): ApolloCache<NormalizedCacheObject> {
+export function createLensCache(args: TypePoliciesArgs): ApolloCache<NormalizedCacheObject> {
   return new InMemoryCache({
     possibleTypes: generatedIntrospection.possibleTypes,
-    typePolicies: createTypePolicies({ activeWalletVar }),
+    typePolicies: createTypePolicies(args),
   });
 }

--- a/packages/api-bindings/src/apollo/cache/createSnapshotCache.ts
+++ b/packages/api-bindings/src/apollo/cache/createSnapshotCache.ts
@@ -1,0 +1,5 @@
+import { ApolloCache, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
+
+export function createSnapshotCache(): ApolloCache<NormalizedCacheObject> {
+  return new InMemoryCache();
+}

--- a/packages/api-bindings/src/apollo/cache/index.ts
+++ b/packages/api-bindings/src/apollo/cache/index.ts
@@ -1,1 +1,2 @@
-export * from './createApolloCache';
+export * from './createLensCache';
+export * from './createSnapshotCache';

--- a/packages/api-bindings/src/apollo/cache/utils/ContentInsight/__tests__/matchers.spec.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/ContentInsight/__tests__/matchers.spec.ts
@@ -1,0 +1,48 @@
+import { ContentInsightType } from '../../../../../lens';
+import {
+  mockSnapshotPollUrl,
+  mockSnapshotProposalId,
+  mockSnapshotSpaceId,
+} from '../../__helpers__/mocks';
+import { snapshotPoll, demoSnapshotPoll } from '../matchers';
+
+const spaceId = mockSnapshotSpaceId();
+const proposalId = mockSnapshotProposalId();
+
+describe(`Given the content insights matchers`, () => {
+  describe.each([
+    {
+      matcher: snapshotPoll,
+      snapshotUrl: 'https://snapshot.org',
+    },
+    {
+      matcher: demoSnapshotPoll,
+      snapshotUrl: 'https://demo.snapshot.org',
+    },
+  ])(`when testing the "$matcher.name" matcher`, ({ matcher, snapshotUrl }) => {
+    const url = mockSnapshotPollUrl({
+      baseUrl: snapshotUrl,
+      spaceId,
+      proposalId,
+    });
+
+    it('should recognize compatible snapshot URLs and return the extracted content insights', () => {
+      const result = matcher(url);
+
+      expect(result).toEqual({
+        type: ContentInsightType.SNAPSHOT_POLL,
+        spaceId,
+        proposalId,
+        url,
+      });
+    });
+
+    it('should return null in case of unmatched URLs', () => {
+      const url = 'https://www.example.com';
+
+      const result = matcher(url);
+
+      expect(result).toBe(null);
+    });
+  });
+});

--- a/packages/api-bindings/src/apollo/cache/utils/ContentInsight/index.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/ContentInsight/index.ts
@@ -1,0 +1,1 @@
+export * from './matchers';

--- a/packages/api-bindings/src/apollo/cache/utils/ContentInsight/matchers.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/ContentInsight/matchers.ts
@@ -1,0 +1,37 @@
+import { Url } from '@lens-protocol/shared-kernel';
+
+import {
+  ContentInsight,
+  ContentInsightType,
+  SnapshotProposalId,
+  SnapshotSpaceId,
+} from '../../../../lens';
+import { Matcher } from '../firstMatch';
+
+export type ContentInsightMatcher = Matcher<Url, ContentInsight>;
+
+const snapshotRegExp = /https:\/\/snapshot\.org\/#\/([^/]+)\/proposal\/(0x[a-fA-F0-9]+)/;
+
+const snapshotDemoRegExp = /https:\/\/demo\.snapshot\.org\/#\/([^/]+)\/proposal\/(0x[a-fA-F0-9]+)/;
+
+function snapshotUrlMatcher(pattern: RegExp, url: Url) {
+  const [, spaceId, proposalId] = pattern.exec(url) ?? [];
+
+  if (spaceId && proposalId) {
+    return {
+      type: ContentInsightType.SNAPSHOT_POLL,
+      spaceId: spaceId as SnapshotSpaceId,
+      proposalId: proposalId as SnapshotProposalId,
+      url,
+    };
+  }
+  return null;
+}
+
+export function snapshotPoll(url: Url) {
+  return snapshotUrlMatcher(snapshotRegExp, url);
+}
+
+export function demoSnapshotPoll(url: Url) {
+  return snapshotUrlMatcher(snapshotDemoRegExp, url);
+}

--- a/packages/api-bindings/src/apollo/cache/utils/__helpers__/mocks.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/__helpers__/mocks.ts
@@ -1,0 +1,24 @@
+import { faker } from '@faker-js/faker';
+import { Url } from '@lens-protocol/shared-kernel';
+
+import { SnapshotProposalId, SnapshotSpaceId } from '../../../../lens';
+
+export function mockSnapshotSpaceId(): SnapshotSpaceId {
+  return faker.internet.domainName() as SnapshotSpaceId;
+}
+
+export function mockSnapshotProposalId(): SnapshotProposalId {
+  return faker.datatype.hexadecimal() as SnapshotProposalId;
+}
+
+export function mockSnapshotPollUrl({
+  baseUrl = 'https://snapshot.org',
+  spaceId = mockSnapshotSpaceId(),
+  proposalId = mockSnapshotProposalId(),
+}: {
+  baseUrl?: Url;
+  spaceId?: SnapshotSpaceId;
+  proposalId?: SnapshotProposalId;
+} = {}) {
+  return `${baseUrl}/#/${spaceId}/proposal/${proposalId}`;
+}

--- a/packages/api-bindings/src/apollo/cache/utils/__tests__/extractUrls.spec.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/__tests__/extractUrls.spec.ts
@@ -1,0 +1,43 @@
+import { extractUrls } from '../extractUrls';
+
+describe(`Given the ${extractUrls.name} helper`, () => {
+  describe('when called with an empty string', () => {
+    it('should return an empty array', () => {
+      const inputString = '';
+      const urls = extractUrls(inputString);
+      expect(urls).toEqual([]);
+    });
+  });
+
+  describe('when called with a string containing a single URL', () => {
+    it('should extract the URL from the string', () => {
+      const inputString = 'Check out this website: https://example.com';
+      const urls = extractUrls(inputString);
+      expect(urls).toEqual(['https://example.com']);
+    });
+  });
+
+  describe('when called with a string containing multiple URLs', () => {
+    it('should extract all URLs from the string', () => {
+      const inputString = 'Visit these websites: https://example.com and https://www.openai.com';
+      const urls = extractUrls(inputString);
+      expect(urls).toEqual(['https://example.com', 'https://www.openai.com']);
+    });
+  });
+
+  describe('when called with a string containing a URL with query parameters and fragments', () => {
+    it('should extract the URL with query parameters and fragments', () => {
+      const inputString = 'Check out this URL: https://example.com/path?param=value#fragment';
+      const urls = extractUrls(inputString);
+      expect(urls).toEqual(['https://example.com/path?param=value#fragment']);
+    });
+  });
+
+  describe('when called with a string containing URLs with different protocols', () => {
+    it('should extract all URLs with different protocols', () => {
+      const inputString = 'Visit these websites: http://example.com and ftp://ftp.example.com';
+      const urls = extractUrls(inputString);
+      expect(urls).toEqual(['http://example.com', 'ftp://ftp.example.com']);
+    });
+  });
+});

--- a/packages/api-bindings/src/apollo/cache/utils/__tests__/firstMatch.spec.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/__tests__/firstMatch.spec.ts
@@ -1,0 +1,55 @@
+import { firstMatch, Matcher } from '../firstMatch';
+
+describe(`Given the ${firstMatch.name} helper`, () => {
+  describe('when called with an empty array', () => {
+    it('should return null', () => {
+      const candidates: unknown[] = [];
+      const matchers: Matcher<unknown, boolean>[] = [(_: unknown) => true];
+
+      const result = firstMatch(candidates, matchers);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('when called with an array of candidates and matchers', () => {
+    it('should return the result of the first matching matcher', () => {
+      const candidates = [1, 2, 3];
+      const matchers: Matcher<number, string | null>[] = [
+        (value) => (value === 2 ? 'two' : null),
+        (value) => (value === 3 ? 'three' : null),
+        (value) => (value === 4 ? 'four' : null),
+      ];
+
+      const result = firstMatch(candidates, matchers);
+
+      expect(result).toEqual('two');
+    });
+
+    it('should return null if no matcher matches any candidate', () => {
+      const candidates = [1, 2, 3];
+      const matchers: Matcher<number, string | null>[] = [
+        (value) => (value === 4 ? 'four' : null),
+        (value) => (value === 5 ? 'five' : null),
+      ];
+
+      const result = firstMatch(candidates, matchers);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return the result of the first matching matcher even if subsequent matchers match other candidates', () => {
+      const candidates = [1, 2, 3];
+      const matchers: Matcher<number, string | null>[] = [
+        (value) => (value === 1 ? 'one' : null),
+        (value) => (value === 2 ? 'two' : null),
+        (value) => (value === 3 ? 'three' : null),
+        (value) => (value === 2 ? 'another two' : null),
+      ];
+
+      const result = firstMatch(candidates, matchers);
+
+      expect(result).toEqual('one');
+    });
+  });
+});

--- a/packages/api-bindings/src/apollo/cache/utils/extractUrls.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/extractUrls.ts
@@ -1,0 +1,7 @@
+import { Url } from '@lens-protocol/shared-kernel';
+
+export function extractUrls(input: string): Url[] {
+  const urlRegex = /(\w+:\/\/[^\s]+)/gi;
+  const urls = input.match(urlRegex) || [];
+  return urls;
+}

--- a/packages/api-bindings/src/apollo/cache/utils/firstMatch.ts
+++ b/packages/api-bindings/src/apollo/cache/utils/firstMatch.ts
@@ -1,0 +1,18 @@
+export type Matcher<T, R> = (value: T) => R | null;
+
+export function firstMatch<T, R>(candidates: T[], matchers: Matcher<T, R>[]): R | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  for (const candidate of candidates) {
+    for (const matcher of matchers) {
+      const result = matcher(candidate);
+      if (result !== null) {
+        return result;
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/api-bindings/src/apollo/links.ts
+++ b/packages/api-bindings/src/apollo/links.ts
@@ -84,19 +84,19 @@ function wrapFetch(
   };
 }
 
-export type HttpLinkArgs = {
+export type LensLinkArgs = {
   fetch?: WindowOrWorkerGlobalScope['fetch'];
   logger: ILogger;
   supportedVersion: SemVer;
   uri: string;
 };
 
-export function createHttpLink({
+export function createLensLink({
   fetch: preferredFetch,
   logger,
   supportedVersion,
   uri,
-}: HttpLinkArgs) {
+}: LensLinkArgs) {
   // see https://github.com/apollographql/apollo-client/blob/4bf773f64b78f15419f07676f434fa33e058404e/src/link/http/createHttpLink.ts#L160-L165
   const currentFetch = preferredFetch ?? maybe(() => fetch) ?? backupFetch ?? never();
 
@@ -104,4 +104,12 @@ export function createHttpLink({
     uri,
     fetch: wrapFetch(logger, supportedVersion, currentFetch),
   });
+}
+
+export type SnapshotLinkArgs = {
+  uri: string;
+};
+
+export function createSnapshotLink({ uri }: SnapshotLinkArgs) {
+  return new HttpLink({ uri });
 }

--- a/packages/api-bindings/src/index.ts
+++ b/packages/api-bindings/src/index.ts
@@ -1,3 +1,5 @@
 export * from './apollo';
 export * from './lens';
 export * from './metadata';
+export { useGetSnapshotProposal } from './snapshot';
+export type { SnapshotProposal } from './snapshot';

--- a/packages/api-bindings/src/lens/ContentInsight.ts
+++ b/packages/api-bindings/src/lens/ContentInsight.ts
@@ -1,0 +1,22 @@
+import { Brand, Url } from '@lens-protocol/shared-kernel';
+
+export enum ContentInsightType {
+  SNAPSHOT_POLL = 'SNAPSHOT_POLL',
+  UNDETERMINED = 'UNDETERMINED',
+}
+
+export type SnapshotProposalId = Brand<string, 'SnapshotProposalId'>;
+export type SnapshotSpaceId = Brand<string, 'SnapshotSpaceId'>;
+
+export type SnapshotPoll = {
+  type: ContentInsightType.SNAPSHOT_POLL;
+  proposalId: SnapshotProposalId;
+  spaceId: SnapshotSpaceId;
+  url: Url;
+};
+
+export type Undetermined = {
+  type: ContentInsightType.UNDETERMINED;
+};
+
+export type ContentInsight = SnapshotPoll | Undetermined;

--- a/packages/api-bindings/src/lens/client.graphql
+++ b/packages/api-bindings/src/lens/client.graphql
@@ -6,6 +6,7 @@ scalar ReferencePolicy
 scalar FollowStatus
 scalar DecryptionCriteria
 scalar PendingPublicationId
+scalar ContentInsight
 
 extend type Profile {
   ownedByMe: Boolean!
@@ -26,6 +27,8 @@ extend type Post {
   isMirroredByMe: Boolean!
   collectPolicy: CollectPolicy!
   referencePolicy: ReferencePolicy!
+
+  contentInsight: ContentInsight!
 }
 
 extend type Comment {
@@ -40,6 +43,8 @@ extend type Comment {
   isMirroredByMe: Boolean!
   collectPolicy: CollectPolicy!
   referencePolicy: ReferencePolicy!
+
+  contentInsight: ContentInsight!
 }
 
 type PendingPost {

--- a/packages/api-bindings/src/lens/common.graphql
+++ b/packages/api-bindings/src/lens/common.graphql
@@ -389,6 +389,7 @@ fragment CommentBase on Comment {
   collectPolicy @client
   referencePolicy @client
   decryptionCriteria @client
+  contentInsight @client
 }
 
 fragment CommonPaginatedResultInfo on PaginatedResultInfo {
@@ -527,6 +528,7 @@ fragment Post on Post {
   collectPolicy @client
   referencePolicy @client
   decryptionCriteria @client
+  contentInsight @client
 }
 
 fragment PendingPost on PendingPost {

--- a/packages/api-bindings/src/snapshot/generated.ts
+++ b/packages/api-bindings/src/snapshot/generated.ts
@@ -1,0 +1,268 @@
+/** Code generated. DO NOT EDIT. */
+/* eslint-disable import/no-default-export */
+/* eslint-disable no-restricted-imports */
+import * as Apollo from '@apollo/client';
+import gql from 'graphql-tag';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+const defaultOptions = {} as const;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  Any: unknown;
+};
+
+export type AliasWhere = {
+  address?: InputMaybe<Scalars['String']>;
+  address_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  alias?: InputMaybe<Scalars['String']>;
+  alias_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  created?: InputMaybe<Scalars['Int']>;
+  created_gt?: InputMaybe<Scalars['Int']>;
+  created_gte?: InputMaybe<Scalars['Int']>;
+  created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  created_lt?: InputMaybe<Scalars['Int']>;
+  created_lte?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ipfs?: InputMaybe<Scalars['String']>;
+  ipfs_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type FollowWhere = {
+  created?: InputMaybe<Scalars['Int']>;
+  created_gt?: InputMaybe<Scalars['Int']>;
+  created_gte?: InputMaybe<Scalars['Int']>;
+  created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  created_lt?: InputMaybe<Scalars['Int']>;
+  created_lte?: InputMaybe<Scalars['Int']>;
+  follower?: InputMaybe<Scalars['String']>;
+  follower_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ipfs?: InputMaybe<Scalars['String']>;
+  ipfs_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  space?: InputMaybe<Scalars['String']>;
+  space_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type MessageWhere = {
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  mci?: InputMaybe<Scalars['Int']>;
+  mci_gt?: InputMaybe<Scalars['Int']>;
+  mci_gte?: InputMaybe<Scalars['Int']>;
+  mci_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  mci_lt?: InputMaybe<Scalars['Int']>;
+  mci_lte?: InputMaybe<Scalars['Int']>;
+  space?: InputMaybe<Scalars['String']>;
+  space_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  timestamp?: InputMaybe<Scalars['Int']>;
+  timestamp_gt?: InputMaybe<Scalars['Int']>;
+  timestamp_gte?: InputMaybe<Scalars['Int']>;
+  timestamp_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  timestamp_lt?: InputMaybe<Scalars['Int']>;
+  timestamp_lte?: InputMaybe<Scalars['Int']>;
+  type?: InputMaybe<Scalars['String']>;
+  type_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export enum OrderDirection {
+  Asc = 'asc',
+  Desc = 'desc',
+}
+
+export type ProposalWhere = {
+  app?: InputMaybe<Scalars['String']>;
+  app_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  app_not?: InputMaybe<Scalars['String']>;
+  app_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  author?: InputMaybe<Scalars['String']>;
+  author_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  created?: InputMaybe<Scalars['Int']>;
+  created_gt?: InputMaybe<Scalars['Int']>;
+  created_gte?: InputMaybe<Scalars['Int']>;
+  created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  created_lt?: InputMaybe<Scalars['Int']>;
+  created_lte?: InputMaybe<Scalars['Int']>;
+  end?: InputMaybe<Scalars['Int']>;
+  end_gt?: InputMaybe<Scalars['Int']>;
+  end_gte?: InputMaybe<Scalars['Int']>;
+  end_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  end_lt?: InputMaybe<Scalars['Int']>;
+  end_lte?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ipfs?: InputMaybe<Scalars['String']>;
+  ipfs_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  network?: InputMaybe<Scalars['String']>;
+  network_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  plugins_contains?: InputMaybe<Scalars['String']>;
+  scores_state?: InputMaybe<Scalars['String']>;
+  scores_state_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  space?: InputMaybe<Scalars['String']>;
+  space_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  space_verified?: InputMaybe<Scalars['Boolean']>;
+  start?: InputMaybe<Scalars['Int']>;
+  start_gt?: InputMaybe<Scalars['Int']>;
+  start_gte?: InputMaybe<Scalars['Int']>;
+  start_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  start_lt?: InputMaybe<Scalars['Int']>;
+  start_lte?: InputMaybe<Scalars['Int']>;
+  state?: InputMaybe<Scalars['String']>;
+  strategies_contains?: InputMaybe<Scalars['String']>;
+  title_contains?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']>;
+  type_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  validation?: InputMaybe<Scalars['String']>;
+};
+
+export type RankingWhere = {
+  category?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  network?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']>;
+};
+
+export type SpaceWhere = {
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type SubscriptionWhere = {
+  address?: InputMaybe<Scalars['String']>;
+  address_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  created?: InputMaybe<Scalars['Int']>;
+  created_gt?: InputMaybe<Scalars['Int']>;
+  created_gte?: InputMaybe<Scalars['Int']>;
+  created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  created_lt?: InputMaybe<Scalars['Int']>;
+  created_lte?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ipfs?: InputMaybe<Scalars['String']>;
+  ipfs_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  space?: InputMaybe<Scalars['String']>;
+  space_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type UsersWhere = {
+  created?: InputMaybe<Scalars['Int']>;
+  created_gt?: InputMaybe<Scalars['Int']>;
+  created_gte?: InputMaybe<Scalars['Int']>;
+  created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  created_lt?: InputMaybe<Scalars['Int']>;
+  created_lte?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ipfs?: InputMaybe<Scalars['String']>;
+  ipfs_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type VoteWhere = {
+  app?: InputMaybe<Scalars['String']>;
+  app_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  app_not?: InputMaybe<Scalars['String']>;
+  app_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  created?: InputMaybe<Scalars['Int']>;
+  created_gt?: InputMaybe<Scalars['Int']>;
+  created_gte?: InputMaybe<Scalars['Int']>;
+  created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  created_lt?: InputMaybe<Scalars['Int']>;
+  created_lte?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['String']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ipfs?: InputMaybe<Scalars['String']>;
+  ipfs_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  proposal?: InputMaybe<Scalars['String']>;
+  proposal_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  reason?: InputMaybe<Scalars['String']>;
+  reason_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  reason_not?: InputMaybe<Scalars['String']>;
+  reason_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  space?: InputMaybe<Scalars['String']>;
+  space_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  voter?: InputMaybe<Scalars['String']>;
+  voter_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  vp?: InputMaybe<Scalars['Float']>;
+  vp_gt?: InputMaybe<Scalars['Float']>;
+  vp_gte?: InputMaybe<Scalars['Float']>;
+  vp_in?: InputMaybe<Array<InputMaybe<Scalars['Float']>>>;
+  vp_lt?: InputMaybe<Scalars['Float']>;
+  vp_lte?: InputMaybe<Scalars['Float']>;
+  vp_state?: InputMaybe<Scalars['String']>;
+  vp_state_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type SnapshotProposal = { id: string };
+
+export type GetSnapshotProposalVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+export type GetSnapshotProposalData = { proposal: SnapshotProposal | null };
+
+export const FragmentSnapshotProposal = /*#__PURE__*/ gql`
+  fragment SnapshotProposal on Proposal {
+    id
+  }
+`;
+export const GetSnapshotProposalDocument = /*#__PURE__*/ gql`
+  query GetSnapshotProposal($id: String!) {
+    proposal(id: $id) {
+      ...SnapshotProposal
+    }
+  }
+  ${FragmentSnapshotProposal}
+`;
+
+/**
+ * __useGetSnapshotProposal__
+ *
+ * To run a query within a React component, call `useGetSnapshotProposal` and pass it any options that fit your needs.
+ * When your component renders, `useGetSnapshotProposal` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSnapshotProposal({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetSnapshotProposal(
+  baseOptions: Apollo.QueryHookOptions<GetSnapshotProposalData, GetSnapshotProposalVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetSnapshotProposalData, GetSnapshotProposalVariables>(
+    GetSnapshotProposalDocument,
+    options,
+  );
+}
+export function useGetSnapshotProposalLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetSnapshotProposalData, GetSnapshotProposalVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetSnapshotProposalData, GetSnapshotProposalVariables>(
+    GetSnapshotProposalDocument,
+    options,
+  );
+}
+export type GetSnapshotProposalHookResult = ReturnType<typeof useGetSnapshotProposal>;
+export type GetSnapshotProposalLazyQueryHookResult = ReturnType<
+  typeof useGetSnapshotProposalLazyQuery
+>;
+export type GetSnapshotProposalQueryResult = Apollo.QueryResult<
+  GetSnapshotProposalData,
+  GetSnapshotProposalVariables
+>;

--- a/packages/api-bindings/src/snapshot/index.ts
+++ b/packages/api-bindings/src/snapshot/index.ts
@@ -1,0 +1,1 @@
+export * from './generated';

--- a/packages/api-bindings/src/snapshot/proposals.graphql
+++ b/packages/api-bindings/src/snapshot/proposals.graphql
@@ -1,0 +1,9 @@
+fragment SnapshotProposal on Proposal {
+  id
+}
+
+query GetSnapshotProposal($id: String!) {
+  proposal(id: $id) {
+    ...SnapshotProposal
+  }
+}

--- a/packages/react/src/environments.ts
+++ b/packages/react/src/environments.ts
@@ -1,9 +1,20 @@
+import { ContentInsightMatcher, demoSnapshotPoll, snapshotPoll } from '@lens-protocol/api-bindings';
 import { ChainType, Url } from '@lens-protocol/shared-kernel';
 
 import { ChainConfigRegistry, goerli, mainnet, mumbai, polygon } from './chains';
 import { TransactionObserverTimings } from './transactions/infrastructure/TransactionObserver';
 
 export type { TransactionObserverTimings };
+
+/**
+ * The Snapshot.org integration configuration
+ *
+ * @internal
+ */
+export type SnapshotConfig = {
+  hub: Url;
+  matcher: ContentInsightMatcher;
+};
 
 /**
  * A function that resolves a profile handle to a fully qualified profile handle
@@ -23,6 +34,7 @@ export type EnvironmentConfig = {
   chains: ChainConfigRegistry;
   timings: TransactionObserverTimings;
   handleResolver: ProfileHandleResolver;
+  snapshot: SnapshotConfig;
 };
 
 /**
@@ -48,8 +60,11 @@ export const production: EnvironmentConfig = {
     maxMiningWaitTime: 60000,
   },
   handleResolver: (handle) => `${handle}.lens`,
+  snapshot: {
+    hub: 'https://hub.snapshot.org',
+    matcher: snapshotPoll,
+  },
 };
-
 /**
  * The development environment configuration
  *
@@ -73,6 +88,10 @@ export const development: EnvironmentConfig = {
     maxMiningWaitTime: 120000,
   },
   handleResolver: (handle) => `${handle}.test`,
+  snapshot: {
+    hub: 'https://testnet.snapshot.org',
+    matcher: demoSnapshotPoll,
+  },
 };
 
 /**

--- a/packages/react/src/helpers/arguments.ts
+++ b/packages/react/src/helpers/arguments.ts
@@ -1,19 +1,37 @@
 import { OperationVariables } from '@apollo/client';
-import { LensApolloClient, Sources } from '@lens-protocol/api-bindings';
+import { createSnapshotApolloClient, LensApolloClient, Sources } from '@lens-protocol/api-bindings';
 import { ProfileId } from '@lens-protocol/domain/entities';
 import { Overwrite, Prettify } from '@lens-protocol/shared-kernel';
+import { useState } from 'react';
 
 import { useActiveProfileIdentifier } from '../profile/useActiveProfileIdentifier';
 import { useSharedDependencies } from '../shared';
 
-export type UseLensApolloClientResult<TOptions> = TOptions & {
+export type UseApolloClientResult<TOptions> = TOptions & {
   client: LensApolloClient;
 };
 
 export function useLensApolloClient<TOptions>(
   args: TOptions = {} as TOptions,
-): UseLensApolloClientResult<TOptions> {
+): UseApolloClientResult<TOptions> {
   const { apolloClient: client } = useSharedDependencies();
+
+  return {
+    ...args,
+    client,
+  };
+}
+
+export function useSnapshotApolloClient<TOptions>(
+  args: TOptions = {} as TOptions,
+): UseApolloClientResult<TOptions> {
+  const { environment } = useSharedDependencies();
+
+  const [client] = useState(() =>
+    createSnapshotApolloClient({
+      backendURL: environment.snapshot.hub,
+    }),
+  );
 
   return {
     ...args,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,6 +10,7 @@ export * from './experimental';
 export * from './feed';
 export * from './modules';
 export * from './notifications';
+export * from './polls';
 export * from './profile';
 export * from './publication';
 export * from './revenue';

--- a/packages/react/src/polls/index.ts
+++ b/packages/react/src/polls/index.ts
@@ -1,0 +1,4 @@
+export * from './usePollDetails';
+
+export { isPollPublication } from '@lens-protocol/api-bindings';
+export type { PollPublication } from '@lens-protocol/api-bindings';

--- a/packages/react/src/polls/usePollDetails.ts
+++ b/packages/react/src/polls/usePollDetails.ts
@@ -1,0 +1,9 @@
+import { PollPublication, useGetSnapshotProposal } from '@lens-protocol/api-bindings';
+
+import { useSnapshotApolloClient } from '../helpers/arguments';
+
+export function usePollDetails({ contentInsight }: PollPublication) {
+  return useGetSnapshotProposal(
+    useSnapshotApolloClient({ variables: { id: contentInsight.proposalId } }),
+  );
+}

--- a/packages/react/src/publication/adapters/__tests__/HidePublicationPresenter.spec.ts
+++ b/packages/react/src/publication/adapters/__tests__/HidePublicationPresenter.spec.ts
@@ -1,6 +1,6 @@
 import { Post, FragmentPost } from '@lens-protocol/api-bindings';
 import {
-  createMockApolloCache,
+  mockLensCache,
   mockPostFragment,
   mockPublicationStatsFragment,
 } from '@lens-protocol/api-bindings/mocks';
@@ -9,7 +9,7 @@ import { PublicationCacheManager } from '../../../transactions/adapters/Publicat
 import { HidePublicationPresenter } from '../HidePublicationPresenter';
 
 function setupTestScenario({ post }: { post: Post }) {
-  const apolloCache = createMockApolloCache();
+  const apolloCache = mockLensCache();
 
   apolloCache.writeFragment({
     id: apolloCache.identify({

--- a/packages/react/src/publication/adapters/__tests__/ReactionPresenter.spec.ts
+++ b/packages/react/src/publication/adapters/__tests__/ReactionPresenter.spec.ts
@@ -1,6 +1,6 @@
 import { Post, FragmentPost, ReactionTypes } from '@lens-protocol/api-bindings';
 import {
-  createMockApolloCache,
+  mockLensCache,
   mockPostFragment,
   mockPublicationStatsFragment,
 } from '@lens-protocol/api-bindings/mocks';
@@ -12,7 +12,7 @@ import { PublicationCacheManager } from '../../../transactions/adapters/Publicat
 import { ReactionPresenter } from '../ReactionPresenter';
 
 function setupTestScenario({ post, request }: { post: Post; request: ReactionRequest }) {
-  const apolloCache = createMockApolloCache();
+  const apolloCache = mockLensCache();
 
   apolloCache.writeFragment({
     id: apolloCache.identify({

--- a/packages/react/src/shared.tsx
+++ b/packages/react/src/shared.tsx
@@ -1,6 +1,6 @@
 import {
-  createAnonymousApolloClient,
-  createApolloClient,
+  createAnonymousLensApolloClient,
+  createLensApolloClient,
   LensApolloClient,
   Sources,
 } from '@lens-protocol/api-bindings';
@@ -117,19 +117,20 @@ export function createSharedDependencies(
   const transactionStorage = createTransactionStorage(config.storage, config.environment.name);
 
   // apollo client
-  const anonymousApolloClient = createAnonymousApolloClient({
+  const anonymousApolloClient = createAnonymousLensApolloClient({
     backendURL: config.environment.backend,
     activeWalletVar: activeWalletVar,
     logger,
   });
   const authApi = new AuthApi(anonymousApolloClient);
   const accessTokenStorage = new AccessTokenStorage(authApi, credentialsStorage);
-  const apolloClient = createApolloClient({
+  const apolloClient = createLensApolloClient({
     backendURL: config.environment.backend,
     accessTokenStorage,
     activeWalletVar: activeWalletVar,
     pollingInterval: config.environment.timings.pollingInterval,
     logger,
+    contentMatchers: [config.environment.snapshot.matcher],
   });
   const publicationCacheManager = new PublicationCacheManager(apolloClient.cache);
   const profileCacheManager = new ProfileCacheManager(apolloClient, sources);

--- a/packages/react/src/transactions/adapters/__tests__/PublicationCacheManager.spec.ts
+++ b/packages/react/src/transactions/adapters/__tests__/PublicationCacheManager.spec.ts
@@ -1,6 +1,6 @@
 import { AnyPublication } from '@lens-protocol/api-bindings';
 import {
-  createMockApolloCache,
+  mockLensCache,
   mockPostFragment,
   mockCommentFragment,
   mockMirrorFragment,
@@ -13,7 +13,7 @@ import {
 } from '../PublicationCacheManager';
 
 function setupTestScenario({ publication }: { publication: AnyPublication }) {
-  const apolloCache = createMockApolloCache();
+  const apolloCache = mockLensCache();
 
   apolloCache.writeFragment({
     id: apolloCache.identify({

--- a/packages/react/src/transactions/adapters/responders/__tests__/FollowProfilesResponder.spec.ts
+++ b/packages/react/src/transactions/adapters/responders/__tests__/FollowProfilesResponder.spec.ts
@@ -1,6 +1,6 @@
 import { Profile, FragmentProfile } from '@lens-protocol/api-bindings';
 import {
-  createMockApolloCache,
+  mockLensCache,
   mockProfileFragment,
   mockProfileStatsFragment,
 } from '@lens-protocol/api-bindings/mocks';
@@ -9,7 +9,7 @@ import { mockTransactionData, mockUnconstrainedFollowRequest } from '@lens-proto
 import { FollowProfilesResponder } from '../FollowProfilesResponder';
 
 function setupTestScenario({ existingProfile }: { existingProfile: Profile }) {
-  const apolloCache = createMockApolloCache();
+  const apolloCache = mockLensCache();
 
   apolloCache.writeFragment({
     id: apolloCache.identify({


### PR DESCRIPTION
This PR mostly exist to isolate all the small changes needed to integrate another GQL API.

It builds on top of the refactoring done in the previous PR: https://github.com/lens-protocol/lens-sdk/pull/350

It will be merged into the main branch and released together with the first workable Snapshot related hook (`usePollDetails`).