### PR TITLE
Present wallet and profile at the same time during login flow.

### DIFF
--- a/.changeset/chilled-games-push.md
+++ b/.changeset/chilled-games-push.md
@@ -1,0 +1,6 @@
+---
+"@lens-protocol/domain": patch
+"@lens-protocol/react": patch
+---
+
+Synchonise state change between `useAciveWallet` and `useActiveProfile` hooks

--- a/packages/domain/src/use-cases/profile/ActiveProfileLoader.ts
+++ b/packages/domain/src/use-cases/profile/ActiveProfileLoader.ts
@@ -1,48 +1,28 @@
-import { invariant } from '@lens-protocol/shared-kernel';
-
-import { Profile } from '../../entities';
 import { IActiveProfileGateway } from './IActiveProfileGateway';
-import { IActiveProfilePresenter } from './IActiveProfilePresenter';
 import { IProfileGateway } from './IProfileGateway';
 
 export class ActiveProfileLoader {
   constructor(
     private readonly profileGateway: IProfileGateway,
     private readonly activeProfileGateway: IActiveProfileGateway,
-    private readonly activeProfilePresenter: IActiveProfilePresenter,
   ) {}
 
   async loadActiveProfileByOwnerAddress(walletAddress: string, handle?: string) {
     const activeProfile = await this.activeProfileGateway.getActiveProfile();
 
     if (activeProfile) {
-      await this.activeProfilePresenter.presentActiveProfile(activeProfile);
-      return;
+      return activeProfile;
     }
+
     const profiles = await this.profileGateway.getAllProfilesByOwnerAddress(walletAddress);
     const profile = handle ? profiles.find((p) => p.handle === handle) : profiles[0];
 
     if (profile) {
-      await this.storeAndPresent(profile);
+      await this.activeProfileGateway.setActiveProfile(profile);
+
+      return profile;
     }
-  }
 
-  async loadActiveProfileByHandle(handle: string) {
-    const activeProfile = await this.activeProfileGateway.getActiveProfile();
-
-    if (activeProfile?.handle === handle) {
-      await this.activeProfilePresenter.presentActiveProfile(activeProfile);
-      return;
-    }
-    const profile = await this.profileGateway.getProfileByHandle(handle);
-
-    invariant(profile, 'Profile not found');
-
-    await this.storeAndPresent(profile);
-  }
-
-  private async storeAndPresent(profile: Profile) {
-    await this.activeProfileGateway.setActiveProfile(profile);
-    await this.activeProfilePresenter.presentActiveProfile(profile);
+    return null;
   }
 }

--- a/packages/domain/src/use-cases/profile/IActiveProfilePresenter.ts
+++ b/packages/domain/src/use-cases/profile/IActiveProfilePresenter.ts
@@ -6,5 +6,5 @@ export type ProfileIdentifier = {
 };
 
 export interface IActiveProfilePresenter {
-  presentActiveProfile(profileIdentifier: ProfileIdentifier | null): Promise<void>;
+  presentActiveProfile(profileIdentifier: ProfileIdentifier | null): void;
 }

--- a/packages/domain/src/use-cases/profile/SwitchActiveProfile.ts
+++ b/packages/domain/src/use-cases/profile/SwitchActiveProfile.ts
@@ -22,6 +22,6 @@ export class SwitchActiveProfile {
     invariant(profile, 'Profile not found');
 
     await this.activeProfileGateway.setActiveProfile(profile);
-    await this.activeProfilePresenter.presentActiveProfile(profile);
+    this.activeProfilePresenter.presentActiveProfile(profile);
   }
 }

--- a/packages/domain/src/use-cases/profile/__tests__/ActiveProfileLoader.spec.ts
+++ b/packages/domain/src/use-cases/profile/__tests__/ActiveProfileLoader.spec.ts
@@ -4,7 +4,6 @@ import { when } from 'jest-when';
 import { mockProfile, mockWallet } from '../../../entities/__helpers__/mocks';
 import { ActiveProfileLoader } from '../ActiveProfileLoader';
 import { IActiveProfileGateway } from '../IActiveProfileGateway';
-import { IActiveProfilePresenter } from '../IActiveProfilePresenter';
 import { IProfileGateway } from '../IProfileGateway';
 
 describe(`Given the ${ActiveProfileLoader.name} interactor`, () => {
@@ -12,118 +11,62 @@ describe(`Given the ${ActiveProfileLoader.name} interactor`, () => {
     it(`should:
         - retrieve the list of profiles owned by the provided address
         - store the first one as active profile
-        - present the active profile`, async () => {
+        - return the active profile`, async () => {
       const wallet = mockWallet();
       const firstProfile = mockProfile();
       const profileGateway = mock<IProfileGateway>();
       const activeProfileGateway = mock<IActiveProfileGateway>();
-      const activeProfilePresenter = mock<IActiveProfilePresenter>();
 
       when(profileGateway.getAllProfilesByOwnerAddress)
         .calledWith(wallet.address)
         .mockResolvedValue([firstProfile, mockProfile()]);
 
-      const activeProfile = new ActiveProfileLoader(
-        profileGateway,
-        activeProfileGateway,
-        activeProfilePresenter,
+      const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
+
+      const activeProfile = await activeProfileLoader.loadActiveProfileByOwnerAddress(
+        wallet.address,
       );
 
-      await activeProfile.loadActiveProfileByOwnerAddress(wallet.address);
-
       expect(activeProfileGateway.setActiveProfile).toHaveBeenCalledWith(firstProfile);
-      expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(firstProfile);
+      expect(activeProfile).toEqual(firstProfile);
     });
 
-    it('should just present the profile already loaded into the ActiveProfileGateway', async () => {
+    it('should just return the profile already loaded into the ActiveProfileGateway', async () => {
       const wallet = mockWallet();
       const profile = mockProfile();
       const profileGateway = mock<IProfileGateway>();
       const activeProfileGateway = mock<IActiveProfileGateway>();
-      const activeProfilePresenter = mock<IActiveProfilePresenter>();
 
       when(activeProfileGateway.getActiveProfile).mockResolvedValue(profile);
 
-      const activeProfile = new ActiveProfileLoader(
-        profileGateway,
-        activeProfileGateway,
-        activeProfilePresenter,
-      );
+      const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
 
-      await activeProfile.loadActiveProfileByOwnerAddress(wallet.address);
+      const activeProfile = await activeProfileLoader.loadActiveProfileByOwnerAddress(
+        wallet.address,
+      );
 
       expect(profileGateway.getAllProfilesByOwnerAddress).not.toHaveBeenCalled();
       expect(activeProfileGateway.setActiveProfile).not.toHaveBeenCalled();
-      expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(profile);
+      expect(activeProfile).toEqual(profile);
     });
 
     it('should bail out if not active profile is present and the wallet does not own any profile', async () => {
       const wallet = mockWallet();
       const profileGateway = mock<IProfileGateway>();
       const activeProfileGateway = mock<IActiveProfileGateway>();
-      const activeProfilePresenter = mock<IActiveProfilePresenter>();
 
       when(profileGateway.getAllProfilesByOwnerAddress)
         .calledWith(wallet.address)
         .mockResolvedValue([]);
 
-      const activeProfile = new ActiveProfileLoader(
-        profileGateway,
-        activeProfileGateway,
-        activeProfilePresenter,
-      );
+      const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
 
-      await activeProfile.loadActiveProfileByOwnerAddress(wallet.address);
+      const activeProfile = await activeProfileLoader.loadActiveProfileByOwnerAddress(
+        wallet.address,
+      );
 
       expect(activeProfileGateway.setActiveProfile).not.toHaveBeenCalled();
-      expect(activeProfilePresenter.presentActiveProfile).not.toHaveBeenCalled();
-    });
-  });
-
-  describe(`when "${ActiveProfileLoader.prototype.loadActiveProfileByHandle.name}" method is invoked`, () => {
-    it(`should:
-          - retrieve the profile details
-          - store it as active profile
-          - present the active profile`, async () => {
-      const profile = mockProfile();
-      const profileGateway = mock<IProfileGateway>();
-      const activeProfileGateway = mock<IActiveProfileGateway>();
-      const activeProfilePresenter = mock<IActiveProfilePresenter>();
-
-      when(activeProfileGateway.getActiveProfile).mockResolvedValue(null);
-      when(profileGateway.getProfileByHandle).calledWith(profile.handle).mockResolvedValue(profile);
-
-      const activeProfile = new ActiveProfileLoader(
-        profileGateway,
-        activeProfileGateway,
-        activeProfilePresenter,
-      );
-
-      await activeProfile.loadActiveProfileByHandle(profile.handle);
-
-      expect(activeProfileGateway.setActiveProfile).toHaveBeenCalledWith(profile);
-      expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(profile);
-    });
-
-    it('should just present the active profile if the profile handle matches with the one provided', async () => {
-      const profile = mockProfile();
-      const profileGateway = mock<IProfileGateway>();
-      const activeProfileGateway = mock<IActiveProfileGateway>();
-      const activeProfilePresenter = mock<IActiveProfilePresenter>();
-
-      when(activeProfileGateway.getActiveProfile).mockResolvedValue(profile);
-
-      const activeProfile = new ActiveProfileLoader(
-        profileGateway,
-        activeProfileGateway,
-        activeProfilePresenter,
-      );
-
-      await activeProfile.loadActiveProfileByHandle(profile.handle);
-
-      expect(profileGateway.getProfileByHandle).not.toHaveBeenCalled();
-      expect(activeProfileGateway.setActiveProfile).not.toHaveBeenCalled();
-      expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(profile);
+      expect(activeProfile).toBeNull();
     });
   });
 });

--- a/packages/domain/src/use-cases/wallets/WalletLogin.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogin.ts
@@ -3,13 +3,14 @@ import { EthereumAddress, failure, PromiseResult, success } from '@lens-protocol
 import {
   ICredentials,
   PendingSigningRequestError,
+  Profile,
   UserRejectedError,
   Wallet,
   WalletConnectionError,
 } from '../../entities';
-import { ActiveProfileLoader } from '../profile/ActiveProfileLoader';
+import { IActiveProfilePresenter, ActiveProfileLoader } from '../profile';
 import { IGenericResultPresenter } from '../transactions';
-import { IActiveWalletPresenter } from './IActiveWalletPresenter';
+import { IActiveWalletPresenter, WalletData } from './IActiveWalletPresenter';
 
 export interface IWalletFactory {
   create(request: WalletLoginRequest): Promise<Wallet>;
@@ -19,8 +20,13 @@ export interface IWritableWalletGateway {
   save(wallet: Wallet): Promise<void>;
 }
 
+export type WalletLoginResult = {
+  wallet: WalletData;
+  profile: Profile | null;
+};
+
 export type IWalletLoginPresenter = IGenericResultPresenter<
-  void,
+  WalletLoginResult,
   PendingSigningRequestError | UserRejectedError | WalletConnectionError
 >;
 
@@ -51,6 +57,7 @@ export class WalletLogin {
     private readonly activeWalletPresenter: IActiveWalletPresenter,
     private readonly walletLoginPresenter: IWalletLoginPresenter,
     private readonly activeProfileLoader: ActiveProfileLoader,
+    private readonly activeProfilePresenter: IActiveProfilePresenter,
   ) {}
 
   async login(request: WalletLoginRequest): Promise<void> {
@@ -65,10 +72,14 @@ export class WalletLogin {
     await this.walletGateway.save(wallet);
     await this.credentialsWriter.save(result.value);
 
+    const profile = await this.activeProfileLoader.loadActiveProfileByOwnerAddress(
+      wallet.address,
+      request.handle,
+    );
+
+    this.activeProfilePresenter.presentActiveProfile(profile);
     this.activeWalletPresenter.presentActiveWallet(wallet);
 
-    await this.activeProfileLoader.loadActiveProfileByOwnerAddress(wallet.address, request.handle);
-
-    this.walletLoginPresenter.present(success());
+    this.walletLoginPresenter.present(success({ wallet, profile }));
   }
 }

--- a/packages/domain/src/use-cases/wallets/WalletLogin.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogin.ts
@@ -10,7 +10,7 @@ import {
 } from '../../entities';
 import { IActiveProfilePresenter, ActiveProfileLoader } from '../profile';
 import { IGenericResultPresenter } from '../transactions';
-import { IActiveWalletPresenter, WalletData } from './IActiveWalletPresenter';
+import { IActiveWalletPresenter } from './IActiveWalletPresenter';
 
 export interface IWalletFactory {
   create(request: WalletLoginRequest): Promise<Wallet>;
@@ -20,10 +20,7 @@ export interface IWritableWalletGateway {
   save(wallet: Wallet): Promise<void>;
 }
 
-export type WalletLoginResult = {
-  wallet: WalletData;
-  profile: Profile | null;
-};
+export type WalletLoginResult = Profile | null;
 
 export type IWalletLoginPresenter = IGenericResultPresenter<
   WalletLoginResult,
@@ -80,6 +77,6 @@ export class WalletLogin {
     this.activeProfilePresenter.presentActiveProfile(profile);
     this.activeWalletPresenter.presentActiveWallet(wallet);
 
-    this.walletLoginPresenter.present(success({ wallet, profile }));
+    this.walletLoginPresenter.present(success(profile));
   }
 }

--- a/packages/domain/src/use-cases/wallets/WalletLogout.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogout.ts
@@ -35,7 +35,7 @@ export class WalletLogout {
     await this.activeProfileGateway.reset();
 
     this.activeWalletPresenter.presentActiveWallet(null);
-    await this.activeProfilePresenter.presentActiveProfile(null);
+    this.activeProfilePresenter.presentActiveProfile(null);
 
     await this.credentialsGateway.invalidate();
 

--- a/packages/domain/src/use-cases/wallets/__tests__/WalletLogin.spec.ts
+++ b/packages/domain/src/use-cases/wallets/__tests__/WalletLogin.spec.ts
@@ -109,7 +109,7 @@ describe(`Given the ${WalletLogin.name} interactor`, () => {
       expect(walletPresenter.presentActiveWallet).toHaveBeenCalledWith(wallet);
       expect(activeProfilePresenter.presentActiveProfile).toHaveBeenCalledWith(activeProfile);
 
-      expect(genericPresenter.present).toBeCalledWith(success({ wallet, profile: activeProfile }));
+      expect(genericPresenter.present).toBeCalledWith(success(activeProfile));
     });
 
     it('should handle scenarios where the user cancels the challenge signing operation', async () => {

--- a/packages/react/src/lifecycle/adapters/useBootstrapController.ts
+++ b/packages/react/src/lifecycle/adapters/useBootstrapController.ts
@@ -21,11 +21,7 @@ export function useBootstrapController({
     const activeWalletPresenter = new ActiveWalletPresenter();
     const logoutPresenter = new LogoutPresenter(onLogout);
     const applicationPresenter = new ApplicationPresenter();
-    const activeProfileLoader = new ActiveProfileLoader(
-      profileGateway,
-      activeProfileGateway,
-      activeProfilePresenter,
-    );
+    const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
     const bootstrap = new Bootstrap(
       activeWallet,
       credentialsGateway,
@@ -35,7 +31,7 @@ export function useBootstrapController({
       logoutPresenter,
       activeProfileLoader,
       transactionQueue,
-      activeProfileGateway,
+      activeProfilePresenter,
     );
 
     void bootstrap.start();

--- a/packages/react/src/profile/adapters/ActiveProfilePresenter.ts
+++ b/packages/react/src/profile/adapters/ActiveProfilePresenter.ts
@@ -5,7 +5,7 @@ import {
 } from '@lens-protocol/domain/use-cases/profile';
 
 export class ActiveProfilePresenter implements IActiveProfilePresenter {
-  async presentActiveProfile(profileIdentifier: ProfileIdentifier | null): Promise<void> {
+  presentActiveProfile(profileIdentifier: ProfileIdentifier | null): void {
     activeProfileIdentifierVar(profileIdentifier);
   }
 }

--- a/packages/react/src/wallet/adapters/useWalletLoginController.ts
+++ b/packages/react/src/wallet/adapters/useWalletLoginController.ts
@@ -4,7 +4,11 @@ import {
   WalletConnectionError,
 } from '@lens-protocol/domain/entities';
 import { ActiveProfileLoader } from '@lens-protocol/domain/use-cases/profile';
-import { WalletLogin, WalletLoginRequest } from '@lens-protocol/domain/use-cases/wallets';
+import {
+  WalletLogin,
+  WalletLoginRequest,
+  WalletLoginResult,
+} from '@lens-protocol/domain/use-cases/wallets';
 
 import { useSharedDependencies } from '../../shared';
 import { PromiseResultPresenter } from '../../transactions/adapters/PromiseResultPresenter';
@@ -24,14 +28,10 @@ export function useWalletLoginController() {
   return async (request: WalletLoginRequest) => {
     const activeWalletPresenter = new ActiveWalletPresenter();
     const loginPresenter = new PromiseResultPresenter<
-      void,
+      WalletLoginResult,
       PendingSigningRequestError | WalletConnectionError | UserRejectedError
     >();
-    const activeProfileLoader = new ActiveProfileLoader(
-      profileGateway,
-      activeProfileGateway,
-      activeProfilePresenter,
-    );
+    const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
     const walletLogin = new WalletLogin(
       walletFactory,
       walletGateway,
@@ -40,6 +40,7 @@ export function useWalletLoginController() {
       activeWalletPresenter,
       loginPresenter,
       activeProfileLoader,
+      activeProfilePresenter,
     );
 
     await walletLogin.login(request);

--- a/packages/react/src/wallet/index.ts
+++ b/packages/react/src/wallet/index.ts
@@ -3,7 +3,11 @@ export * from './useActiveWalletSigner';
 export * from './useWalletLogin';
 export * from './useWalletLogout';
 
-export type { LogoutData, LogoutReason } from '@lens-protocol/domain/use-cases/wallets';
+export type {
+  LogoutData,
+  LogoutReason,
+  WalletLoginResult,
+} from '@lens-protocol/domain/use-cases/wallets';
 export type { LogoutHandler } from './adapters/LogoutPresenter';
 export type { RequiredSigner } from './adapters/ConcreteWallet';
 export type { Wallet } from '@lens-protocol/api-bindings';

--- a/packages/react/src/wallet/useWalletLogin.ts
+++ b/packages/react/src/wallet/useWalletLogin.ts
@@ -3,13 +3,14 @@ import {
   UserRejectedError,
   WalletConnectionError,
 } from '@lens-protocol/domain/entities';
+import { WalletLoginResult } from '@lens-protocol/domain/use-cases/wallets';
 import { Signer } from 'ethers';
 
 import { Operation, useOperation } from '../helpers/operations';
 import { useWalletLoginController } from './adapters/useWalletLoginController';
 
 export type WalletLoginOperation = Operation<
-  void,
+  WalletLoginResult,
   PendingSigningRequestError | WalletConnectionError | UserRejectedError,
   [Signer, string?]
 >;


### PR DESCRIPTION
This PR shuffles the logic a little bit to present the wallet and profile at the same time otherwise ui state in inconsistent and implementation of the claiming flow is trickier/buggy.
Also `useWalletLogin` now returns `WalletLoginResult` with the wallet and profile to allow imperative redirect call when someone needs it.