### PR TITLE
Require an active profile to have active wallet

### DIFF
--- a/.changeset/mighty-balloons-shop.md
+++ b/.changeset/mighty-balloons-shop.md
@@ -1,0 +1,6 @@
+---
+"@lens-protocol/domain": patch
+"@lens-protocol/react": patch
+---
+
+**Fixed** active profile to be always `null` when there is not active wallet

--- a/packages/domain/src/use-cases/wallets/WalletLogin.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogin.ts
@@ -74,8 +74,8 @@ export class WalletLogin {
       request.handle,
     );
 
-    this.activeProfilePresenter.presentActiveProfile(profile);
     this.activeWalletPresenter.presentActiveWallet(wallet);
+    this.activeProfilePresenter.presentActiveProfile(profile);
 
     this.walletLoginPresenter.present(success(profile));
   }

--- a/packages/react/src/profile/useActiveProfile.ts
+++ b/packages/react/src/profile/useActiveProfile.ts
@@ -8,6 +8,7 @@ import { invariant } from '@lens-protocol/shared-kernel';
 
 import { useSourcesFromConfig, useLensApolloClient } from '../helpers/arguments';
 import { ReadResult } from '../helpers/reads';
+import { useActiveWalletVar } from '../wallet/adapters/ActiveWalletPresenter';
 import { useActiveProfileIdentifier } from './useActiveProfileIdentifier';
 
 /**
@@ -42,6 +43,8 @@ import { useActiveProfileIdentifier } from './useActiveProfileIdentifier';
  */
 export function useActiveProfile(): ReadResult<ProfileOwnedByMe | null, UnspecifiedError> {
   const { data: identifier, loading: bootstrapping } = useActiveProfileIdentifier();
+  // TODO: This is a patch fix to move forward.
+  const activeWallet = useActiveWalletVar();
 
   const { data, error, loading } = useGetProfile(
     useLensApolloClient({
@@ -60,6 +63,14 @@ export function useActiveProfile(): ReadResult<ProfileOwnedByMe | null, Unspecif
       data: undefined,
       error: undefined,
       loading: true,
+    };
+  }
+
+  if (activeWallet === null) {
+    return {
+      data: null,
+      error: undefined,
+      loading: false,
     };
   }
 


### PR DESCRIPTION
This is just a patch fix for now, created the ticket to track the proper change on the use case levels https://avara.height.app/T-12199.