### PR TITLE
DO NOT MERGE: script to reproduce bug T-11895

### DIFF
--- a/examples/node/.env
+++ b/examples/node/.env
@@ -1,0 +1,1 @@
+WALLET_PRIVATE_KEY=272b8d63faac40bfc342bacc4cb9af6f146bdf8c45e2accadeb43846d9fce965

--- a/examples/node/scripts/paginationBug.ts
+++ b/examples/node/scripts/paginationBug.ts
@@ -1,0 +1,114 @@
+import {
+  LensClient,
+  isCreateDataAvailabilityPublicationResult,
+  isPostPublication,
+} from "@lens-protocol/client";
+import { setupWallet } from "./shared/setupWallet";
+import { getAuthenticatedClient } from "./shared/getAuthenticatedClient";
+import { getActiveProfile } from "./shared/getActiveProfile";
+import { buildPublicationMetadata } from "./shared/buildPublicationMetadata";
+import { uploadWithBundlr } from "./shared/uploadWithBundlr";
+import { Wallet } from "ethers";
+
+async function addMoreRecentPost(lensClient: LensClient, wallet: Wallet, profileId: string) {
+  // prepare metadata
+  const metadata = buildPublicationMetadata({
+    content: "Data Availability Post created with LensClient SDK",
+    name: "Data Availability Post created with LensClient SDK",
+  });
+
+  // validate metadata
+  const validateResult = await lensClient.publication.validateMetadata(metadata);
+
+  if (!validateResult.valid) {
+    throw new Error(`Metadata is not valid.`);
+  }
+
+  // upload metadata to
+  const contentURI = await uploadWithBundlr(metadata);
+
+  // fetch a create DA post typed data
+  const createPostTypedDataResult =
+    await lensClient.publication.createDataAvailabilityPostTypedData({
+      from: profileId,
+      contentURI,
+    });
+
+  const createPostTypedDataValue = createPostTypedDataResult.unwrap();
+
+  // sign with the wallet
+  const signedTypedData = await wallet._signTypedData(
+    createPostTypedDataValue.typedData.domain,
+    createPostTypedDataValue.typedData.types,
+    createPostTypedDataValue.typedData.value
+  );
+
+  const broadcastResult = await lensClient.transaction.broadcastDataAvailability({
+    id: createPostTypedDataValue.id,
+    signature: signedTypedData,
+  });
+
+  // broadcastResult is a Result object
+  const broadcastValue = broadcastResult.unwrap();
+
+  if (!isCreateDataAvailabilityPublicationResult(broadcastValue)) {
+    return false;
+  }
+
+  console.log("New post created with id:", broadcastValue.id);
+  return true;
+}
+
+async function main() {
+  const wallet = setupWallet();
+  const address = await wallet.getAddress();
+  const lensClient = await getAuthenticatedClient(wallet);
+  const profile = await getActiveProfile(lensClient, address);
+  const profileId = profile.id;
+
+  const publications = await lensClient.publication.fetchAll({
+    profileId,
+    limit: 1,
+  });
+
+  console.log(
+    `Posts fetched:`,
+    JSON.stringify(
+      publications.items.map((i) => ({
+        id: i.id,
+      })),
+      null,
+      2
+    )
+  );
+
+  await addMoreRecentPost(lensClient, wallet, profileId);
+
+  const previous = await publications.prev();
+
+  console.log(
+    `First call to more recent posts with prev=${previous.pageInfo.prev}:\n`,
+    JSON.stringify(
+      previous.items.map((i) => ({
+        id: i.id,
+      })),
+      null,
+      2
+    )
+  );
+
+  const secondTry = await publications.prev();
+
+  console.log(
+    `Second call to more recent posts with prev=${previous.pageInfo.prev}:\n`,
+    JSON.stringify(
+      secondTry.items.map((i) => ({
+        id: i.id,
+      })),
+      null,
+      2
+    )
+  );
+}
+
+main();


### PR DESCRIPTION
API: https://api-mumbai.lens.dev/
Wallet Address: `0x02dB2668ec7D9F09408eF7E848b05ec595B13363`
Profile ID: `0x8a46`
Profile Handle: `1689673406665.test`

The query is limited to 1 items per page to make things easier to scan.

**The PK embedded in this PR is a burner address.**

To setup:

```bash
git checkout T-13199/pagination-bug-script

pnpm install

cd examples/node
```

To run:
```bash
pnpm ts-node  scripts/paginationBug.ts
```

Example output:
```bash
> example-node@0.0.1 ts-node /Users/***/workspace/lens-sdk/examples/node
> ts-node "scripts/paginationBug.ts"

Posts fetched: [
  {
    "id": "0x8a46-0x01-DA-059bb0a5"
  }
]
Bundlr balance for wallet 0x02db2668ec7d9f09408ef7e848b05ec595b13363 is 0.099263288173200796 MUMBAI MATIC
New post created with id: 0x8a46-0x01-DA-7a8f8f3c
First call to more recent posts with prev={"entityIdentifier":"0x8a46-0x01-DA-7a8f8f3c","timestamp":1689674178,"cursorDirection":"BEFORE"}:
 [
  {
    "id": "0x8a46-0x01-DA-7a8f8f3c"
  }
]
Second call to more recent posts with prev={"entityIdentifier":"0x8a46-0x01-DA-7a8f8f3c","timestamp":1689674178,"cursorDirection":"BEFORE"}:
 []
```



