### PR TITLE
feat: use CredentialsExpiryController and subscribe to expired event

### DIFF
--- a/packages/react/src/lifecycle/adapters/useBootstrapController.ts
+++ b/packages/react/src/lifecycle/adapters/useBootstrapController.ts
@@ -1,6 +1,5 @@
 import { Bootstrap } from '@lens-protocol/domain/use-cases/lifecycle';
 import { ActiveProfileLoader } from '@lens-protocol/domain/use-cases/profile';
-import { WalletLogout } from '@lens-protocol/domain/use-cases/wallets';
 
 import { SharedDependencies } from '../../shared';
 
@@ -12,17 +11,11 @@ export function useBootstrapController({
   profileGateway,
   sessionPresenter,
   transactionQueue,
-  walletGateway,
+  walletLogout,
 }: SharedDependencies) {
   return function () {
     const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
-    const walletLogout = new WalletLogout(
-      walletGateway,
-      credentialsGateway,
-      activeWallet,
-      activeProfileGateway,
-      sessionPresenter,
-    );
+
     const bootstrap = new Bootstrap(
       activeWallet,
       credentialsGateway,

--- a/packages/react/src/wallet/adapters/WalletGateway.ts
+++ b/packages/react/src/wallet/adapters/WalletGateway.ts
@@ -41,7 +41,7 @@ export class WalletGateway
   }
 
   async reset(): Promise<void> {
-    await this.storage.set([]);
+    await this.storage.reset();
   }
 
   async save(wallet: ConcreteWallet): Promise<void> {

--- a/packages/react/src/wallet/adapters/useWalletLoginController.ts
+++ b/packages/react/src/wallet/adapters/useWalletLoginController.ts
@@ -1,33 +1,13 @@
-import { ActiveProfileLoader } from '@lens-protocol/domain/use-cases/profile';
-import { WalletLogin, WalletLoginRequest } from '@lens-protocol/domain/use-cases/wallets';
+import { WalletLoginRequest } from '@lens-protocol/domain/use-cases/wallets';
 
 import { useSharedDependencies } from '../../shared';
 import { WalletLoginPresenter } from './WalletLoginPresenter';
 
 export function useWalletLoginController() {
-  const {
-    activeProfileGateway,
-    credentialsFactory,
-    credentialsGateway,
-    profileCacheManager,
-    profileGateway,
-    sessionPresenter,
-    walletFactory,
-    walletGateway,
-  } = useSharedDependencies();
+  const { profileCacheManager, walletLogin } = useSharedDependencies();
 
   return async (request: WalletLoginRequest) => {
     const loginPresenter = new WalletLoginPresenter(profileCacheManager);
-    const activeProfileLoader = new ActiveProfileLoader(profileGateway, activeProfileGateway);
-    const walletLogin = new WalletLogin(
-      walletFactory,
-      walletGateway,
-      credentialsFactory,
-      credentialsGateway,
-      loginPresenter,
-      activeProfileLoader,
-      sessionPresenter,
-    );
 
     await walletLogin.login(request);
 

--- a/packages/react/src/wallet/adapters/useWalletLogoutController.ts
+++ b/packages/react/src/wallet/adapters/useWalletLogoutController.ts
@@ -1,26 +1,12 @@
-import { LogoutReason, WalletLogout } from '@lens-protocol/domain/use-cases/wallets';
+import { LogoutReason } from '@lens-protocol/domain/use-cases/wallets';
 import { PromiseResult, success } from '@lens-protocol/shared-kernel';
 
 import { useSharedDependencies } from '../../shared';
 
 export function useWalletLogoutController() {
-  const {
-    activeWallet,
-    activeProfileGateway,
-    credentialsGateway,
-    sessionPresenter,
-    walletGateway,
-  } = useSharedDependencies();
+  const { walletLogout } = useSharedDependencies();
 
   return async (reason: LogoutReason): PromiseResult<void, never> => {
-    const walletLogout = new WalletLogout(
-      walletGateway,
-      credentialsGateway,
-      activeWallet,
-      activeProfileGateway,
-      sessionPresenter,
-    );
-
     await walletLogout.logout(reason);
 
     return success();


### PR DESCRIPTION
I was able to trigger the token expiry event by modifying refreshToken stored in local storage and changing its `exp` value. Also setting `AccessTokenStorage.getAccessToken` to always return `''`, to trigger the token refresh.
The logout and storage cleanup proceeded as expected.
Seems everything works fine now!

![Screenshot 2023-07-21 at 15 51 27](https://github.com/lens-protocol/lens-sdk/assets/605420/8c3b3233-936f-4dc0-a4bd-f708ff8cc69e)
