### PR TITLE
feat: skippable read hooks

### DIFF
--- a/examples/web-wagmi/src/profiles/UseProfile.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfile.tsx
@@ -11,11 +11,13 @@ type ProfileByProps = {
 };
 
 function ProfileBy({ profileId }: ProfileByProps) {
-  const { data: profile, error, loading } = useProfile({ profileId });
+  const { data: profile, error, loading } = useProfile({ profileId, skip: true });
 
   if (loading) return <Loading />;
 
   if (error) return <ErrorMessage error={error} />;
+
+  if (!profile) return <div>Skipped</div>;
 
   return <ProfileCard profile={profile} />;
 }

--- a/examples/web-wagmi/src/profiles/UseProfiles.tsx
+++ b/examples/web-wagmi/src/profiles/UseProfiles.tsx
@@ -7,12 +7,14 @@ import { ProfileCard } from './components/ProfileCard';
 
 export function UseProfiles() {
   const { data, error, loading, hasMore, observeRef } = useInfiniteScroll(
-    useProfiles({ handles: ['yoginth.test', 'foobar.test'] }),
+    useProfiles({ handles: ['yoginth.test', 'foobar.test'], skip: false }),
   );
 
   if (loading) return <Loading />;
 
   if (error) return <ErrorMessage error={error} />;
+
+  if (!data) return <div>Skipped</div>;
 
   return (
     <div>

--- a/packages/react/src/helpers/arguments.ts
+++ b/packages/react/src/helpers/arguments.ts
@@ -46,18 +46,18 @@ export function useSnapshotApolloClient<TOptions>(
   };
 }
 
+export type Skipped = {
+  /**
+   * @experimental
+   */
+  skip: true;
+};
+
 /**
  * When `skip` prop is true then all other props are optional.
  * Used to allow to skip apollo API calls
  */
-export type Skippable<T extends UnknownObject> =
-  | (Partial<T> & {
-      /**
-       * @experimental
-       */
-      skip: true;
-    })
-  | (T & { skip?: false });
+export type Skippable<T extends UnknownObject> = (Partial<T> & Skipped) | (T & { skip?: false });
 
 export type WithObserverIdOverride<TVariables = unknown> = Prettify<
   TVariables & {

--- a/packages/react/src/profile/useProfile.ts
+++ b/packages/react/src/profile/useProfile.ts
@@ -11,7 +11,7 @@ import {
   useSourcesFromConfig,
   WithObserverIdOverride,
 } from '../helpers/arguments';
-import { ReadResult, useReadResult } from '../helpers/reads';
+import { SkippableReadResult, useReadResult } from '../helpers/reads';
 
 export type UseProfileByIdArgs = {
   profileId: ProfileId;
@@ -36,11 +36,11 @@ export type UseProfileArgs = Prettify<
  *
  * @param args - {@link UseProfileArgs}
  */
-export function useProfile({
+export function useProfile<A extends UseProfileArgs>({
   observerId,
   skip,
   ...request
-}: UseProfileArgs): ReadResult<Profile, NotFoundError | UnspecifiedError> {
+}: A): SkippableReadResult<A, Profile, NotFoundError | UnspecifiedError> {
   invariant(
     request.profileId === undefined || request.handle === undefined,
     "Only one of 'id' or 'handle' should be provided to 'useProfile' hook",
@@ -62,12 +62,20 @@ export function useProfile({
     ),
   );
 
+  if (skip) {
+    return {
+      data: undefined,
+      error: undefined,
+      loading: false,
+    } as SkippableReadResult<A, Profile, NotFoundError | UnspecifiedError>;
+  }
+
   if (loading) {
     return {
       data: undefined,
       error: undefined,
       loading: true,
-    };
+    } as SkippableReadResult<A, Profile, NotFoundError | UnspecifiedError>;
   }
 
   if (error) {
@@ -75,7 +83,7 @@ export function useProfile({
       data: undefined,
       error,
       loading: false,
-    };
+    } as SkippableReadResult<A, Profile, NotFoundError | UnspecifiedError>;
   }
 
   if (data === null) {
@@ -83,12 +91,12 @@ export function useProfile({
       data: undefined,
       error: new NotFoundError(`Profile for ${JSON.stringify(request)}`),
       loading: false,
-    };
+    } as SkippableReadResult<A, Profile, NotFoundError | UnspecifiedError>;
   }
 
   return {
     data,
     error: undefined,
     loading: false,
-  };
+  } as SkippableReadResult<A, Profile, NotFoundError | UnspecifiedError>;
 }


### PR DESCRIPTION
type-safe skippable hooks (one for read results and one for paginated read results).
I'm not happy with the solution but also don't know any better one.