### PR TITLE
Proposal: forward `Result<T, E>` without need to rewrap

### DIFF
--- a/examples/web-wagmi/src/publications/components/PostComposer.tsx
+++ b/examples/web-wagmi/src/publications/components/PostComposer.tsx
@@ -40,6 +40,8 @@ export function PostComposer({ publisher }: PostComposerProps) {
     });
 
     if (subsidizedAttempt.isSuccess()) {
+      await subsidizedAttempt.value.waitForCompletion();
+
       form.reset();
       return;
     }

--- a/packages/client/src/helpers/requireAuthHeaders.ts
+++ b/packages/client/src/helpers/requireAuthHeaders.ts
@@ -16,7 +16,7 @@ export async function requireAuthHeaders<Val>(
   const headerResult = await authentication.getRequestHeader();
 
   if (headerResult.isFailure()) {
-    return failure(headerResult.error);
+    return headerResult.forward();
   }
 
   const result = await handler(headerResult.value);

--- a/packages/domain/src/use-cases/profile/CreateProfile.ts
+++ b/packages/domain/src/use-cases/profile/CreateProfile.ts
@@ -43,7 +43,7 @@ export class CreateProfile {
     const transactionResult = await this.transactionFactory.createProfileTransaction(request);
 
     if (transactionResult.isFailure()) {
-      this.presenter.present(failure(transactionResult.error));
+      this.presenter.present(transactionResult);
       return;
     }
 

--- a/packages/domain/src/use-cases/transactions/SignlessSubsidizeOnChain.ts
+++ b/packages/domain/src/use-cases/transactions/SignlessSubsidizeOnChain.ts
@@ -28,7 +28,7 @@ export class SignlessSubsidizeOnChain<T extends ProtocolTransactionRequestModel>
     const result = await this.relayer.createProxyTransaction(request);
 
     if (result.isFailure()) {
-      this.presenter.present(failure(result.error));
+      this.presenter.present(result);
       return;
     }
 

--- a/packages/domain/src/use-cases/transactions/TransactionQueue.ts
+++ b/packages/domain/src/use-cases/transactions/TransactionQueue.ts
@@ -113,7 +113,7 @@ export class TransactionQueue<TAll extends AnyTransactionRequestModel> {
     if (result.isFailure()) {
       const txData = transactionData(transaction);
       await this.rollback(result.error, txData);
-      presenter?.present(failure(result.error));
+      presenter?.present(result);
       return;
     }
 
@@ -147,7 +147,7 @@ export class TransactionQueue<TAll extends AnyTransactionRequestModel> {
       const result = await transaction.waitNextEvent();
 
       if (result.isFailure()) {
-        return failure(result.error);
+        return result;
       }
 
       if (result.value === TransactionEvent.SETTLED) {

--- a/packages/domain/src/use-cases/transactions/__tests__/DelegableSigning.spec.ts
+++ b/packages/domain/src/use-cases/transactions/__tests__/DelegableSigning.spec.ts
@@ -57,8 +57,7 @@ describe(`Given an instance of the ${DelegableSigning.name}<T> interactor`, () =
 
       it(`should:
           - create a ${NativeTransaction.name}<T>
-          - queue it into the ${TransactionQueue.name}
-          - present successful result`, async () => {
+          - queue it into the ${TransactionQueue.name}`, async () => {
         const transaction = MockedNativeTransaction.fromRequest(request);
         const transactionGateway = mockIDelegatedTransactionGateway({
           request,
@@ -78,8 +77,7 @@ describe(`Given an instance of the ${DelegableSigning.name}<T> interactor`, () =
         await call.execute(request);
 
         expect(transactionGateway.createDelegatedTransaction).toHaveBeenCalledWith(request);
-        expect(transactionQueue.push).toHaveBeenCalledWith(transaction);
-        expect(presenter.present).toHaveBeenCalledWith(success());
+        expect(transactionQueue.push).toHaveBeenCalledWith(transaction, presenter);
       });
 
       it(`should present any ${BroadcastingError.name} from the IDelegableProtocolCallGateway<T>`, async () => {

--- a/packages/domain/src/use-cases/transactions/__tests__/SignlessSubsidizeOnChain.spec.ts
+++ b/packages/domain/src/use-cases/transactions/__tests__/SignlessSubsidizeOnChain.spec.ts
@@ -1,4 +1,3 @@
-import { success } from '@lens-protocol/shared-kernel';
 import { mock } from 'jest-mock-extended';
 
 import { ProtocolTransactionRequestModel, ProxyTransaction } from '../../../entities';
@@ -17,11 +16,11 @@ import { mockISignlessSubsidizedCallRelayer, mockTransactionQueue } from '../__h
 function setupTestScenario<T extends ProtocolTransactionRequestModel>({
   relayer,
   transactionQueue = mockTransactionQueue(),
-  presenter = mock<ISignlessSubsidizeOnChainPresenter>(),
+  presenter = mock<ISignlessSubsidizeOnChainPresenter<T>>(),
 }: {
   relayer: ISignlessSubsidizedCallRelayer<T>;
   transactionQueue?: TransactionQueue<T>;
-  presenter?: ISignlessSubsidizeOnChainPresenter;
+  presenter?: ISignlessSubsidizeOnChainPresenter<T>;
 }) {
   const useCase = new SignlessSubsidizeOnChain(relayer, transactionQueue, presenter);
 
@@ -32,8 +31,7 @@ describe(`Given an instance of ${SignlessSubsidizeOnChain.name}<T> interactor`, 
   describe(`when calling "${SignlessSubsidizeOnChain.prototype.execute.name}" method`, () => {
     it(`should:
         - use the ISignlessSubsidizedCallRelayer to generate a ${ProxyTransaction.name}
-        - push the ${ProxyTransaction.name} into the ${TransactionQueue.name}
-        - call the presenter with success()`, async () => {
+        - push the ${ProxyTransaction.name} into the ${TransactionQueue.name}`, async () => {
       const request = mockProtocolTransactionRequestModel();
       const transaction = MockedProxyTransaction.fromRequest(request);
       const relayer = mockISignlessSubsidizedCallRelayer({
@@ -48,8 +46,7 @@ describe(`Given an instance of ${SignlessSubsidizeOnChain.name}<T> interactor`, 
       await useCase.execute(request);
 
       expect(relayer.createProxyTransaction).toHaveBeenCalledWith(request);
-      expect(transactionQueue.push).toHaveBeenCalledWith(transaction);
-      expect(presenter.present).toHaveBeenCalledWith(success());
+      expect(transactionQueue.push).toHaveBeenCalledWith(transaction, presenter);
     });
   });
 });

--- a/packages/domain/src/use-cases/transactions/__tests__/SubsidizeOffChain.spec.ts
+++ b/packages/domain/src/use-cases/transactions/__tests__/SubsidizeOffChain.spec.ts
@@ -27,7 +27,7 @@ import {
 } from '../SubsidizeOffChain';
 import { TransactionQueue } from '../TransactionQueue';
 
-function setupStoreOffChain<T extends ProtocolTransactionRequestModel>({
+function setup<T extends ProtocolTransactionRequestModel>({
   gateway,
   relayer = mock<IOffChainRelayer<T>>(),
   queue = mockTransactionQueue(),
@@ -37,7 +37,7 @@ function setupStoreOffChain<T extends ProtocolTransactionRequestModel>({
   gateway: IOffChainProtocolCallGateway<T>;
   relayer?: IOffChainRelayer<T>;
   queue?: TransactionQueue<AnyTransactionRequestModel>;
-  presenter: ISubsidizeOffChainPresenter;
+  presenter: ISubsidizeOffChainPresenter<T>;
   wallet: Wallet;
 }) {
   const activeWallet = mockActiveWallet({ wallet });
@@ -71,9 +71,9 @@ describe(`Given an instance of the ${SubsidizeOffChain.name}<T> interactor`, () 
 
       const queue = mockTransactionQueue();
 
-      const presenter = mock<ISubsidizeOffChainPresenter>();
+      const presenter = mock<ISubsidizeOffChainPresenter<typeof request>>();
 
-      const useCase = setupStoreOffChain({
+      const useCase = setup({
         gateway,
         relayer,
         queue,
@@ -83,8 +83,7 @@ describe(`Given an instance of the ${SubsidizeOffChain.name}<T> interactor`, () 
 
       await useCase.execute(request);
 
-      expect(queue.push).toHaveBeenCalledWith(transaction);
-      expect(presenter.present).toHaveBeenCalledWith(success());
+      expect(queue.push).toHaveBeenCalledWith(transaction, presenter);
     });
   });
 });

--- a/packages/domain/src/use-cases/transactions/__tests__/SubsidizeOnChain.spec.ts
+++ b/packages/domain/src/use-cases/transactions/__tests__/SubsidizeOnChain.spec.ts
@@ -49,7 +49,7 @@ function setupSubsidizedCall<T extends ProtocolTransactionRequestModel>({
   onChainProtocolCallGateway: IOnChainProtocolCallGateway<T>;
   relayer?: IOnChainRelayer<T>;
   transactionQueue?: TransactionQueue<AnyTransactionRequestModel>;
-  presenter: ISubsidizeOnChainPresenter;
+  presenter: ISubsidizeOnChainPresenter<T>;
   wallet: Wallet;
 }) {
   const activeWallet = mockActiveWallet({ wallet });
@@ -95,7 +95,7 @@ describe(`Given an instance of the ${SubsidizeOnChain.name}<T> interactor`, () =
 
       const transactionQueue = mockTransactionQueue();
 
-      const presenter = mock<ISubsidizeOnChainPresenter>();
+      const presenter = mock<ISubsidizeOnChainPresenter<typeof request>>();
 
       const useCase = setupSubsidizedCall({
         metaTransactionNonceGateway,
@@ -108,8 +108,7 @@ describe(`Given an instance of the ${SubsidizeOnChain.name}<T> interactor`, () =
 
       await useCase.execute(request);
 
-      expect(transactionQueue.push).toHaveBeenCalledWith(transaction);
-      expect(presenter.present).toHaveBeenCalledWith(success());
+      expect(transactionQueue.push).toHaveBeenCalledWith(transaction, presenter);
     });
 
     it.each([
@@ -134,7 +133,7 @@ describe(`Given an instance of the ${SubsidizeOnChain.name}<T> interactor`, () =
       const wallet = mockWallet();
       when(wallet.signProtocolCall).calledWith(unsignedCall).mockResolvedValue(failure(error));
 
-      const presenter = mock<ISubsidizeOnChainPresenter>();
+      const presenter = mock<ISubsidizeOnChainPresenter<typeof request>>();
 
       const useCase = setupSubsidizedCall({
         metaTransactionNonceGateway,
@@ -164,12 +163,13 @@ describe(`Given an instance of the ${SubsidizeOnChain.name}<T> interactor`, () =
       when(wallet.signProtocolCall).calledWith(unsignedCall).mockResolvedValue(success(signedCall));
 
       const error = new BroadcastingError('some reason');
+
       const relayer = mockIOnChainRelayer({
         signedCall,
         result: failure(error),
       });
 
-      const presenter = mock<ISubsidizeOnChainPresenter>();
+      const presenter = mock<ISubsidizeOnChainPresenter<typeof request>>();
 
       const useCase = setupSubsidizedCall({
         metaTransactionNonceGateway,

--- a/packages/domain/src/use-cases/wallets/WalletLogin.ts
+++ b/packages/domain/src/use-cases/wallets/WalletLogin.ts
@@ -1,4 +1,4 @@
-import { EthereumAddress, failure, PromiseResult, success } from '@lens-protocol/shared-kernel';
+import { EthereumAddress, PromiseResult, success } from '@lens-protocol/shared-kernel';
 
 import {
   ICredentials,
@@ -52,7 +52,7 @@ export class WalletLogin {
     const result = await this.credentialsIssuer.issueCredentials(wallet);
 
     if (result.isFailure()) {
-      this.loginPresenter.present(failure(result.error));
+      this.loginPresenter.present(result.forward());
       return;
     }
 

--- a/packages/react/src/profile/adapters/AsyncTransactionResult.ts
+++ b/packages/react/src/profile/adapters/AsyncTransactionResult.ts
@@ -1,0 +1,6 @@
+import { TransactionError } from '@lens-protocol/domain/entities';
+import { PromiseResult } from '@lens-protocol/shared-kernel';
+
+export type AsyncTransactionResult<TValue> = {
+  waitForCompletion(): PromiseResult<TValue, TransactionError>;
+};

--- a/packages/react/src/publication/useEncryptedPublication.ts
+++ b/packages/react/src/publication/useEncryptedPublication.ts
@@ -4,7 +4,7 @@ import {
   MetadataOutput,
   UnspecifiedError,
 } from '@lens-protocol/api-bindings';
-import { failure, invariant, success } from '@lens-protocol/shared-kernel';
+import { failure, invariant, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { EncryptionConfig } from '../config';
@@ -61,7 +61,7 @@ export function useEncryptedPublication<T extends ContentPublication>({
   const { data: signer } = useActiveWalletSigner();
 
   const { error, execute, isPending }: Operation<void, UseEncryptedPublicationError> = useOperation(
-    useCallback(async () => {
+    useCallback(async (): PromiseResult<void, DecryptionError | UnspecifiedError> => {
       invariant(isGatedPublication(publication), 'Publication is not gated');
       invariant(signer, `Cannot find the Active Wallet Signer`);
 

--- a/packages/react/src/transactions/adapters/CollectPublicationGateway.ts
+++ b/packages/react/src/transactions/adapters/CollectPublicationGateway.ts
@@ -50,7 +50,7 @@ export class CollectPublicationGateway
     const proxyReceipt = await this.proxy(request);
 
     if (proxyReceipt.isFailure()) {
-      return failure(proxyReceipt.error);
+      return proxyReceipt;
     }
 
     return success(

--- a/packages/react/src/transactions/adapters/CreatePostController.ts
+++ b/packages/react/src/transactions/adapters/CreatePostController.ts
@@ -20,7 +20,7 @@ import { ActiveWallet } from '@lens-protocol/domain/use-cases/wallets';
 
 import { IMetadataUploader } from './IMetadataUploader';
 import { ITransactionFactory } from './ITransactionFactory';
-import { PromiseResultPresenter } from './PromiseResultPresenter';
+import { TransactionResultPresenter } from './TransactionResultPresenter';
 import { CreateOffChainPostGateway } from './publication-call-gateways/CreateOffChainPostGateway';
 import { CreateOnChainPostGateway } from './publication-call-gateways/CreateOnChainPostGateway';
 
@@ -36,8 +36,8 @@ export type CreatePostControllerArgs<T extends CreatePostRequest> = {
 };
 
 export class CreatePostController<T extends CreatePostRequest> {
-  private readonly presenter = new PromiseResultPresenter<
-    void,
+  private readonly presenter = new TransactionResultPresenter<
+    CreatePostRequest,
     BroadcastingError | PendingSigningRequestError | UserRejectedError | WalletConnectionError
   >();
 

--- a/packages/react/src/transactions/adapters/TransactionResultPresenter.ts
+++ b/packages/react/src/transactions/adapters/TransactionResultPresenter.ts
@@ -1,0 +1,48 @@
+import { AnyTransactionRequestModel, TransactionError } from '@lens-protocol/domain/entities';
+import { ITransactionResultPresenter } from '@lens-protocol/domain/src/use-cases/transactions/ITransactionResultPresenter';
+import { TransactionData } from '@lens-protocol/domain/use-cases/transactions';
+import {
+  Deferred,
+  failure,
+  Failure,
+  IEquatableError,
+  Result,
+  success,
+} from '@lens-protocol/shared-kernel';
+
+import { AsyncTransactionResult } from '../../profile/adapters/AsyncTransactionResult';
+
+export class TransactionResultPresenter<
+  TRequest extends AnyTransactionRequestModel,
+  TError extends IEquatableError,
+> implements ITransactionResultPresenter<TRequest, TError>
+{
+  private earlyFailure: Failure<never, TError> | null = null;
+
+  private deferredResult = new Deferred<Result<void, TransactionError>>();
+
+  present(result: Result<TransactionData<TRequest>, TError | TransactionError>): void {
+    if (result.isFailure()) {
+      if (result.error instanceof TransactionError) {
+        this.deferredResult.resolve(failure(result.error));
+        return;
+      }
+      this.earlyFailure = failure(result.error);
+      return;
+    }
+
+    this.deferredResult.resolve(success());
+  }
+
+  asResult(): Result<AsyncTransactionResult<void>, TError> {
+    if (this.earlyFailure) {
+      return this.earlyFailure;
+    }
+
+    return success({
+      waitForCompletion: async () => {
+        return this.deferredResult.promise;
+      },
+    });
+  }
+}

--- a/packages/react/src/transactions/adapters/publication-call-gateways/CreateOnChainCommentGateway.ts
+++ b/packages/react/src/transactions/adapters/publication-call-gateways/CreateOnChainCommentGateway.ts
@@ -18,7 +18,7 @@ import {
   IDelegatedTransactionGateway,
   IOnChainProtocolCallGateway,
 } from '@lens-protocol/domain/use-cases/transactions';
-import { ChainType, failure, PromiseResult, success } from '@lens-protocol/shared-kernel';
+import { ChainType, PromiseResult, success } from '@lens-protocol/shared-kernel';
 import { v4 } from 'uuid';
 
 import { UnsignedProtocolCall } from '../../../wallet/adapters/ConcreteWallet';
@@ -48,7 +48,7 @@ export class CreateOnChainCommentGateway
   ): PromiseResult<NativeTransaction<CreateCommentRequest>, BroadcastingError> {
     const result = await this.broadcast(request);
 
-    if (result.isFailure()) return failure(result.error);
+    if (result.isFailure()) return result;
 
     const receipt = result.value;
     const transaction = this.transactionFactory.createNativeTransaction({

--- a/packages/react/src/transactions/infrastructure/TransactionFactory.ts
+++ b/packages/react/src/transactions/infrastructure/TransactionFactory.ts
@@ -124,7 +124,7 @@ class SerializableMetaTransaction<T extends ProtocolTransactionRequest>
       this.state = result.value.state;
       return success(result.value.event);
     }
-    return failure(result.error);
+    return result;
   }
 }
 

--- a/packages/react/src/transactions/useCreatePost.ts
+++ b/packages/react/src/transactions/useCreatePost.ts
@@ -23,6 +23,7 @@ import { BroadcastingError } from '@lens-protocol/domain/use-cases/transactions'
 import { failure, PromiseResult, Url } from '@lens-protocol/shared-kernel';
 
 import { Operation, useOperation } from '../helpers/operations';
+import { AsyncTransactionResult } from '../profile/adapters/AsyncTransactionResult';
 import { useSharedDependencies } from '../shared';
 import { FailedUploadError } from './adapters/IMetadataUploader';
 import { MetadataUploadHandler } from './adapters/MetadataUploadHandler';
@@ -158,7 +159,7 @@ export type CreateEmbedPostArgs = CreatePostBaseArgs & {
 export type CreatePostArgs = CreateTextualPostArgs | CreateMediaPostArgs | CreateEmbedPostArgs;
 
 export type CreatePostOperation = Operation<
-  void,
+  AsyncTransactionResult<void>,
   | BroadcastingError
   | PendingSigningRequestError
   | UserRejectedError
@@ -236,7 +237,7 @@ export function useCreatePost({ publisher, upload }: UseCreatePostArgs): CreateP
       reference = { type: ReferencePolicyType.ANYONE },
       ...args
     }: CreatePostArgs): PromiseResult<
-      void,
+      AsyncTransactionResult<void>,
       | BroadcastingError
       | PendingSigningRequestError
       | UserRejectedError

--- a/packages/shared-kernel/src/Result.ts
+++ b/packages/shared-kernel/src/Result.ts
@@ -64,7 +64,7 @@ export interface IEquatableError<T extends string = string, P = Narrow<T>> {
 }
 
 /**
- * A `Result` type represents either `Success` or failure `Failure`.
+ * A `Result` type represents either `Success` or `Failure`.
  *
  * **TL;DR**
  *
@@ -156,23 +156,23 @@ export type Result<T, E extends IEquatableError> = Success<T, E> | Failure<T, E>
  */
 export type PromiseResult<T, E extends IEquatableError> = Promise<Result<T, E>>;
 
-export function success<T extends void, E>(): Success<T, E>;
-export function success<T, E>(value: T): Success<T, E>;
+export function success<T extends void>(): Success<T, never>;
+export function success<T>(value: T): Success<T, never>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function success<T, E>(value: any = undefined): Success<T, E> {
+export function success<T>(value: any = undefined): Success<T, never> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return new Success(value);
 }
 
-export const failure = <T, E extends IEquatableError>(error: E): Failure<T, E> =>
+export const failure = <E extends IEquatableError>(error: E): Failure<never, E> =>
   new Failure(error);
 
 /**
  * Returns `true` if the result is a success.
  */
-export function assertSuccess<T, E extends IEquatableError>(
-  result: Result<T, E>,
-): asserts result is Success<T, E> {
+export function assertSuccess<T>(
+  result: Result<T, IEquatableError>,
+): asserts result is Success<T, never> {
   invariant(result.isSuccess(), 'Expected a success result');
 }
 
@@ -181,6 +181,6 @@ export function assertSuccess<T, E extends IEquatableError>(
  */
 export function assertFailure<T, E extends IEquatableError>(
   result: Result<T, E>,
-): asserts result is Failure<T, E> {
+): asserts result is Failure<never, E> {
   invariant(result.isFailure(), 'Expected a failure result');
 }

--- a/packages/shared-kernel/src/Result.ts
+++ b/packages/shared-kernel/src/Result.ts
@@ -10,7 +10,7 @@ import { Narrow } from './ts-helpers/types';
  * @sealed
  * @privateRemarks DO NOT EXPORT, see type export later on
  */
-class Success<T, E> {
+class Success<T, E extends IEquatableError> {
   /** @internal */
   public constructor(public readonly value: T) {}
 
@@ -20,6 +20,10 @@ class Success<T, E> {
 
   public isFailure(): this is Failure<T, E> {
     return false;
+  }
+
+  public forward() {
+    return success(this.value);
   }
 
   unwrap(): T {
@@ -36,7 +40,7 @@ class Success<T, E> {
  * @sealed
  * @privateRemarks DO NOT EXPORT, see type export later on
  */
-class Failure<T, E> {
+class Failure<T, E extends IEquatableError> {
   /** @internal */
   public constructor(public readonly error: E) {}
 
@@ -46,6 +50,10 @@ class Failure<T, E> {
 
   public isFailure(): this is Failure<T, E> {
     return true;
+  }
+
+  public forward() {
+    return failure(this.error);
   }
 
   unwrap(): never {
@@ -164,8 +172,9 @@ export function success<T>(value: any = undefined): Success<T, never> {
   return new Success(value);
 }
 
-export const failure = <E extends IEquatableError>(error: E): Failure<never, E> =>
-  new Failure(error);
+export function failure<E extends IEquatableError>(error: E): Failure<never, E> {
+  return new Failure(error);
+}
 
 /**
  * Returns `true` if the result is a success.


### PR DESCRIPTION
This was something discussed a long time ago and partially available in some 3rd party implementations of the Result monad.

In this PR you can see the change I am suggesting to the `Result` definition, which are backwards compatible as well as some places to showcase the impact.

If the proposal gets approved I will amends the rest of the codebase to avoid rewrapping in `success(...)`, `failure(...)`.