### PR TITLE
fix: makes XMTP SDK optional by not importing it from SDK main entrypoint

### DIFF
--- a/.changeset/slow-glasses-study.md
+++ b/.changeset/slow-glasses-study.md
@@ -1,0 +1,7 @@
+---
+"@lens-protocol/react-web": patch
+"@lens-protocol/react": patch
+"example-wagmi": patch
+---
+
+**Fixed** XMTP dep is optional until chat features are requested via `@lens-protocol/react-web/inbox` entrypoint

--- a/examples/web-wagmi/src/inbox/UseConversation.tsx
+++ b/examples/web-wagmi/src/inbox/UseConversation.tsx
@@ -1,4 +1,5 @@
-import { ProfileOwnedByMe, useEnhanceConversation } from '@lens-protocol/react-web';
+import { ProfileOwnedByMe } from '@lens-protocol/react-web';
+import { useEnhanceConversation } from '@lens-protocol/react-web/inbox';
 import { Conversation, useClient, useConversations } from '@xmtp/react-sdk';
 import { useParams } from 'react-router-dom';
 

--- a/examples/web-wagmi/src/inbox/UseConversations.tsx
+++ b/examples/web-wagmi/src/inbox/UseConversations.tsx
@@ -1,4 +1,5 @@
-import { ProfileOwnedByMe, useEnhanceConversations } from '@lens-protocol/react-web';
+import { ProfileOwnedByMe } from '@lens-protocol/react-web';
+import { useEnhanceConversations } from '@lens-protocol/react-web/inbox';
 import { useClient, useConversations } from '@xmtp/react-sdk';
 import { Link } from 'react-router-dom';
 

--- a/examples/web-wagmi/src/inbox/components/ConversationCard.tsx
+++ b/examples/web-wagmi/src/inbox/components/ConversationCard.tsx
@@ -1,4 +1,5 @@
-import { EnhancedConversation, Profile } from '@lens-protocol/react-web';
+import { Profile } from '@lens-protocol/react-web';
+import { EnhancedConversation } from '@lens-protocol/react-web/inbox';
 import { ReactNode } from 'react';
 
 import { ProfilePicture } from '../../profiles/components/ProfilePicture';

--- a/examples/web-wagmi/src/inbox/components/ConversationComposer.tsx
+++ b/examples/web-wagmi/src/inbox/components/ConversationComposer.tsx
@@ -1,4 +1,5 @@
-import { Profile, ProfileOwnedByMe, useStartLensConversation } from '@lens-protocol/react-web';
+import { Profile, ProfileOwnedByMe } from '@lens-protocol/react-web';
+import { useStartLensConversation } from '@lens-protocol/react-web/inbox';
 
 import { never } from '../../utils';
 

--- a/examples/web-wagmi/src/inbox/components/EnableConversationsButton.tsx
+++ b/examples/web-wagmi/src/inbox/components/EnableConversationsButton.tsx
@@ -1,4 +1,4 @@
-import { useXmtpClient } from '@lens-protocol/react-web';
+import { useXmtpClient } from '@lens-protocol/react-web/inbox';
 
 import { ErrorMessage } from '../../components/error/ErrorMessage';
 import { Loading } from '../../components/loading/Loading';

--- a/packages/react-web/inbox/package.json
+++ b/packages/react-web/inbox/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/lens-protocol-react-web-inbox.cjs.js",
+  "module": "dist/lens-protocol-react-web-inbox.esm.js"
+}

--- a/packages/react-web/package.json
+++ b/packages/react-web/package.json
@@ -9,6 +9,10 @@
       "module": "./dist/lens-protocol-react-web.esm.js",
       "default": "./dist/lens-protocol-react-web.cjs.js"
     },
+    "./inbox": {
+      "module": "./inbox/dist/lens-protocol-react-web-inbox.esm.js",
+      "default": "./inbox/dist/lens-protocol-react-web-inbox.cjs.js"
+    },
     "./package.json": "./package.json"
   },
   "repository": {
@@ -18,7 +22,8 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "inbox"
   ],
   "scripts": {
     "build": "preconstruct build",
@@ -93,7 +98,8 @@
   },
   "preconstruct": {
     "entrypoints": [
-      "index.ts"
+      "index.ts",
+      "inbox/index.ts"
     ],
     "exports": true
   },

--- a/packages/react-web/src/index.ts
+++ b/packages/react-web/src/index.ts
@@ -23,6 +23,3 @@ export type {
 export type EncryptionConfig = never;
 export type IStorageProvider = never;
 export type IObservableStorageProvider = never;
-
-// xmtp integration
-export * from './inbox';


### PR DESCRIPTION
Given that XMTP is an optional dependencies there should not be codepaths from the main Lens SDK entry point that requires the XMTP SDK.

This PR exposes XMTP integration API from a dedicated entry point. Documentation will be updated once 1.3 becomes stable.