### PR TITLE
client: remove forApps from config to avoid confusion

### DIFF
--- a/.changeset/shy-pugs-taste.md
+++ b/.changeset/shy-pugs-taste.md
@@ -1,0 +1,5 @@
+---
+"@lens-protocol/client": patch
+---
+
+Removed `forApps` from config as it was used only when quering for profile stats

--- a/packages/client/src/LensClient.ts
+++ b/packages/client/src/LensClient.ts
@@ -43,12 +43,6 @@ export type LensClientConfig = {
    * @see {@link MediaTransformsConfig} for more information
    */
   mediaTransforms?: MediaTransformsConfig;
-
-  /**
-   * The app ids to use to read data from the Lens Protocol.
-   * If not provided, all apps will be used.
-   */
-  forApps?: string[];
 };
 
 /**
@@ -79,7 +73,6 @@ export class LensClient {
       environment: config.environment,
       storage: config.storage || new InMemoryStorageProvider(),
       mediaTransforms: config.mediaTransforms || {},
-      forApps: config.forApps || [],
     };
     this._authentication = new Authentication(this.context);
   }

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -34,6 +34,4 @@ export type LensContext = {
   storage: IStorageProvider;
 
   mediaTransforms: MediaTransformsConfig;
-
-  forApps: string[];
 };

--- a/packages/client/src/helpers/buildImageTransformsFromConfig.ts
+++ b/packages/client/src/helpers/buildImageTransformsFromConfig.ts
@@ -1,9 +1,0 @@
-import { MediaTransformsConfig } from '../context';
-
-export function buildImageTransformsFromConfig(config: MediaTransformsConfig = {}) {
-  return {
-    publicationImageTransform: config.publication,
-    profileCoverTransform: config.profileCover,
-    profilePictureTransform: config.profilePicture,
-  };
-}

--- a/packages/client/src/helpers/buildRequestFromConfig.ts
+++ b/packages/client/src/helpers/buildRequestFromConfig.ts
@@ -1,11 +1,10 @@
 import { LensContext } from '../context';
-import { ImageTransform, ProfileStatsArg } from '../graphql/types.generated';
+import { ImageTransform } from '../graphql';
 
 type RequestFromConfig = {
   publicationImageTransform?: ImageTransform;
   profileCoverTransform?: ImageTransform;
   profilePictureTransform?: ImageTransform;
-  profileStatsArg?: ProfileStatsArg;
 };
 
 export function buildRequestFromConfig(config: LensContext): RequestFromConfig {
@@ -13,8 +12,5 @@ export function buildRequestFromConfig(config: LensContext): RequestFromConfig {
     publicationImageTransform: config.mediaTransforms?.publication,
     profileCoverTransform: config.mediaTransforms?.profileCover,
     profilePictureTransform: config.mediaTransforms?.profilePicture,
-    profileStatsArg: {
-      forApps: config.forApps,
-    },
   };
 }

--- a/packages/client/src/helpers/requireAuthHeaders.spec.ts
+++ b/packages/client/src/helpers/requireAuthHeaders.spec.ts
@@ -9,7 +9,6 @@ import { requireAuthHeaders } from './requireAuthHeaders';
 const context: LensContext = {
   environment: buildTestEnvironment(),
   storage: new InMemoryStorageProvider(),
-  forApps: [],
   mediaTransforms: {},
 };
 

--- a/packages/client/src/helpers/sdkAuthHeaderWrapper.spec.ts
+++ b/packages/client/src/helpers/sdkAuthHeaderWrapper.spec.ts
@@ -9,7 +9,6 @@ const context: LensContext = {
   environment: buildTestEnvironment(),
   mediaTransforms: {},
   storage: new InMemoryStorageProvider(),
-  forApps: [],
 };
 
 describe(`Given the "${sdkAuthHeaderWrapper.name}" helper`, () => {

--- a/packages/client/src/submodules/profile/types.ts
+++ b/packages/client/src/submodules/profile/types.ts
@@ -1,5 +1,6 @@
-import { ProfileStatsCountOpenActionArgs } from '../../graphql/types.generated';
+import { ProfileStatsArg, ProfileStatsCountOpenActionArgs } from '../../graphql/types.generated';
 
 export type FetchProfileOptions = {
+  profileStatsArg?: ProfileStatsArg;
   profileStatsCountOpenActionArgs?: ProfileStatsCountOpenActionArgs;
 };


### PR DESCRIPTION
forApps was not doing what was described in the config, forApps has to be provided as part of a request object in each query