### PR TITLE
react: enable useLinkHandle and useUnlinkHandle hooks

### DIFF
--- a/.changeset/smooth-ties-roll.md
+++ b/.changeset/smooth-ties-roll.md
@@ -1,0 +1,8 @@
+---
+"@lens-protocol/api-bindings": minor
+"@lens-protocol/domain": minor
+"@lens-protocol/react": minor
+"@lens-protocol/react-web": minor
+---
+
+Added useLinkHandle and useUnlinkHandle hooks

--- a/examples/web/src/misc/UseNotifications.tsx
+++ b/examples/web/src/misc/UseNotifications.tsx
@@ -1,6 +1,6 @@
 import { useNotifications } from '@lens-protocol/react-web';
 
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
@@ -34,9 +34,7 @@ export function UseNotifications() {
       <WhenLoggedIn>
         <UseNotificationsInner />
       </WhenLoggedIn>
-      <WhenLoggedOut>
-        <p>You must be logged in to use this example.</p>
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </div>
   );
 }

--- a/examples/web/src/profiles/ProfilesPage.tsx
+++ b/examples/web/src/profiles/ProfilesPage.tsx
@@ -72,10 +72,8 @@ const profileHooks = [
     path: '/profiles/useUpdateFollowPolicy',
   },
   {
-    label: 'useOwHandles',
-    // label: 'useOwnedHandles & useLinkHandle & useUnlinkHandle',
-    // description: `Link and unlink handle from a profile.`,
-    description: `Fetch all handles owned by a wallet.`,
+    label: 'useOwnedHandles & useLinkHandle & useUnlinkHandle',
+    description: `Link and unlink handle from a profile.`,
     path: '/profiles/useOwnedHandles',
   },
   {

--- a/examples/web/src/profiles/UseFollowAndUnfollow.tsx
+++ b/examples/web/src/profiles/UseFollowAndUnfollow.tsx
@@ -6,7 +6,7 @@ import {
   useUnfollow,
 } from '@lens-protocol/react-web';
 
-import { UnauthenticatedFallback, WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
 import { ProfileCard } from './components/ProfileCard';
@@ -74,9 +74,7 @@ export function UseFollowAndUnfollow() {
       <WhenLoggedIn>
         <UseFollowInner />
       </WhenLoggedIn>
-      <WhenLoggedOut>
-        <UnauthenticatedFallback />
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </>
   );
 }

--- a/examples/web/src/profiles/UseProfileActionHistory.tsx
+++ b/examples/web/src/profiles/UseProfileActionHistory.tsx
@@ -1,6 +1,6 @@
 import { useProfileActionHistory } from '@lens-protocol/react-web';
 
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
@@ -41,9 +41,7 @@ export function UseProfileActionHistory() {
       <WhenLoggedIn>
         <UseProfileActionHistoryInner />
       </WhenLoggedIn>
-      <WhenLoggedOut>
-        <p>You must be logged in to use this example.</p>
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </div>
   );
 }

--- a/examples/web/src/profiles/UseSetProfileMetadata.tsx
+++ b/examples/web/src/profiles/UseSetProfileMetadata.tsx
@@ -2,7 +2,7 @@ import { MetadataAttributeType, profile } from '@lens-protocol/metadata';
 import { Profile, useSetProfileMetadata } from '@lens-protocol/react-web';
 import { toast } from 'react-hot-toast';
 
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { Loading } from '../components/loading/Loading';
 import { uploadJson } from '../upload';
 import { ProfileCard } from './components/ProfileCard';
@@ -139,10 +139,7 @@ export function UseSetProfileMetadata() {
       <WhenLoggedIn loadingElement={<Loading />}>
         {({ profile: activeProfile }) => <UpdateProfileForm activeProfile={activeProfile} />}
       </WhenLoggedIn>
-
-      <WhenLoggedOut>
-        <p>You need to be logged in to use this example.</p>
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </div>
   );
 }

--- a/examples/web/src/profiles/UseUpdateFollowPolicy.tsx
+++ b/examples/web/src/profiles/UseUpdateFollowPolicy.tsx
@@ -9,7 +9,7 @@ import {
 } from '@lens-protocol/react-web';
 import { useState } from 'react';
 
-import { UnauthenticatedFallback, WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
 import { invariant, never } from '../utils';
@@ -221,9 +221,7 @@ export function UseUpdateFollowPolicy() {
         <code>useUpdateFollowPolicy</code>
       </h1>
       <WhenLoggedIn>{({ profile }) => <UpdateFollowPolicy profile={profile} />}</WhenLoggedIn>
-      <WhenLoggedOut>
-        <UnauthenticatedFallback />
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </>
   );
 }

--- a/examples/web/src/profiles/UseUpdateProfileManagers.tsx
+++ b/examples/web/src/profiles/UseUpdateProfileManagers.tsx
@@ -1,6 +1,6 @@
 import { Profile, useUpdateProfileManagers, useProfileManagers } from '@lens-protocol/react-web';
 
-import { UnauthenticatedFallback, WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 
 function UpdateProfileManagersForm({ profile }: { profile: Profile }) {
@@ -71,10 +71,7 @@ export function UseUpdateProfileManagers() {
       <WhenLoggedIn>
         {({ profile }) => <UpdateProfileManagersForm profile={profile} />}
       </WhenLoggedIn>
-
-      <WhenLoggedOut>
-        <UnauthenticatedFallback />
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </div>
   );
 }

--- a/examples/web/src/publications/UseBookmarkToggle.tsx
+++ b/examples/web/src/publications/UseBookmarkToggle.tsx
@@ -64,7 +64,7 @@ export function UseBookmarkToggle() {
       <WhenLoggedIn>
         <UseBookmarkToggleInner />
       </WhenLoggedIn>
-      <UnauthenticatedFallback message="Log in to run this demo." />
+      <UnauthenticatedFallback />
     </>
   );
 }

--- a/examples/web/src/publications/UseHidePublication.tsx
+++ b/examples/web/src/publications/UseHidePublication.tsx
@@ -7,7 +7,7 @@ import {
   usePublications,
 } from '@lens-protocol/react-web';
 
-import { LoginButton, WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
@@ -90,12 +90,7 @@ export function UseHidePublication() {
       <WhenLoggedIn>
         {({ profile, address }) => <Feed profile={profile} address={address} />}
       </WhenLoggedIn>
-      <WhenLoggedOut>
-        <div>
-          <p>You must be logged in to use this example.</p>
-          <LoginButton />
-        </div>
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </>
   );
 }

--- a/examples/web/src/publications/UseMyBookmarks.tsx
+++ b/examples/web/src/publications/UseMyBookmarks.tsx
@@ -39,7 +39,7 @@ export function UseMyBookmarks() {
       </h1>
 
       <WhenLoggedIn>{() => <MyBookmarks />}</WhenLoggedIn>
-      <UnauthenticatedFallback message="Log in to run this demo." />
+      <UnauthenticatedFallback />
     </div>
   );
 }

--- a/examples/web/src/publications/UseNotInterestedToggle.tsx
+++ b/examples/web/src/publications/UseNotInterestedToggle.tsx
@@ -63,7 +63,7 @@ export function UseNotInterestedToggle() {
       <WhenLoggedIn>
         <UseNotInterestedToggleInner />
       </WhenLoggedIn>
-      <UnauthenticatedFallback message="Log in mark publications as not interesting." />
+      <UnauthenticatedFallback />
     </>
   );
 }

--- a/examples/web/src/publications/UseReactionToggle.tsx
+++ b/examples/web/src/publications/UseReactionToggle.tsx
@@ -8,7 +8,7 @@ import {
   useReactionToggle,
 } from '@lens-protocol/react-web';
 
-import { WhenLoggedIn, WhenLoggedOut } from '../components/auth';
+import { UnauthenticatedFallback, WhenLoggedIn } from '../components/auth';
 import { ErrorMessage } from '../components/error/ErrorMessage';
 import { Loading } from '../components/loading/Loading';
 import { invariant } from '../utils';
@@ -78,9 +78,7 @@ export function UseReactionToggle() {
       <WhenLoggedIn>
         <UseReactionToggleInner />
       </WhenLoggedIn>
-      <WhenLoggedOut>
-        <p>You must be logged in to use this example.</p>
-      </WhenLoggedOut>
+      <UnauthenticatedFallback />
     </div>
   );
 }

--- a/packages/api-bindings/src/apollo/cache/transactions.ts
+++ b/packages/api-bindings/src/apollo/cache/transactions.ts
@@ -7,9 +7,11 @@ import {
   TransactionKind,
 } from '@lens-protocol/domain/entities';
 import {
-  UnblockProfilesRequest,
   FollowRequest,
+  LinkHandleRequest,
+  UnblockProfilesRequest,
   UnfollowRequest,
+  UnlinkHandleRequest,
 } from '@lens-protocol/domain/use-cases/profile';
 import { OpenActionRequest, AllOpenActionType } from '@lens-protocol/domain/use-cases/publications';
 import { AnyTransactionRequest } from '@lens-protocol/domain/use-cases/transactions';
@@ -209,4 +211,38 @@ export function countPendingUnfollowFor(profileId: ProfileId) {
         : 0),
     0,
   );
+}
+
+function isPendingLinkHandleTransaction(
+  transaction: TransactionState<AnyTransactionRequest>,
+): transaction is TransactionState<LinkHandleRequest> {
+  return (
+    transaction.request.kind === TransactionKind.LINK_HANDLE &&
+    transaction.status === TxStatus.PENDING
+  );
+}
+
+export function getPendingLinkHandleTxFor(profileId: ProfileId) {
+  return recentTransactionsVar().find((transaction) => {
+    return (
+      isPendingLinkHandleTransaction(transaction) && transaction.request.profileId === profileId
+    );
+  }) as TransactionState<LinkHandleRequest> | undefined;
+}
+
+function isPendingUnlinkHandleTransaction(
+  transaction: TransactionState<AnyTransactionRequest>,
+): transaction is TransactionState<UnlinkHandleRequest> {
+  return (
+    transaction.request.kind === TransactionKind.UNLINK_HANDLE &&
+    transaction.status === TxStatus.PENDING
+  );
+}
+
+export function getPendingUnlinkHandleTxFor(profileId: ProfileId) {
+  return recentTransactionsVar().find((transaction) => {
+    return (
+      isPendingUnlinkHandleTransaction(transaction) && transaction.request.profileId === profileId
+    );
+  }) as TransactionState<UnlinkHandleRequest> | undefined;
 }

--- a/packages/api-bindings/src/apollo/cache/type-policies/createProfileTypePolicy.ts
+++ b/packages/api-bindings/src/apollo/cache/type-policies/createProfileTypePolicy.ts
@@ -1,7 +1,63 @@
-import { StrictTypedTypePolicies } from '../../../lens';
+import { FieldFunctionOptions } from '@apollo/client';
+import { ProfileId } from '@lens-protocol/domain/entities';
+
+import { HandleInfo, StrictTypedTypePolicies } from '../../../lens';
+import { getPendingLinkHandleTxFor, getPendingUnlinkHandleTxFor } from '../transactions';
+
+function buildHandleInfo({
+  fullHandle,
+  profileId,
+}: {
+  fullHandle: string;
+  profileId: ProfileId;
+}): HandleInfo {
+  const namespace = fullHandle.split('/')[0] || '';
+  const localName = fullHandle.split('/')[1] || '';
+
+  return {
+    __typename: 'HandleInfo',
+    id: '',
+    fullHandle: fullHandle,
+    namespace,
+    localName,
+    ownedBy: '',
+    suggestedFormatted: { full: `${namespace}/@${localName}`, localName: `@${localName}` },
+    linkedTo: {
+      nftTokenId: profileId,
+      contract: {
+        __typename: 'NetworkAddress',
+        address: '',
+        chainId: 1,
+      },
+    },
+  };
+}
 
 export function createProfileTypePolicy(): StrictTypedTypePolicies['Profile'] {
   return {
-    fields: {},
+    fields: {
+      handle: {
+        read(
+          existing: HandleInfo | undefined,
+          { readField }: FieldFunctionOptions,
+        ): HandleInfo | undefined {
+          const profileId = readField('id') as ProfileId;
+          const pendingLinkHandleTx = getPendingLinkHandleTxFor(profileId);
+          const pendingUnlinkHandleTx = getPendingUnlinkHandleTxFor(profileId);
+
+          if (pendingLinkHandleTx) {
+            return buildHandleInfo({
+              profileId,
+              fullHandle: pendingLinkHandleTx.request.fullHandle,
+            });
+          }
+          if (pendingUnlinkHandleTx) {
+            return undefined;
+          }
+
+          return existing;
+        },
+      },
+    },
   };
 }

--- a/packages/api-bindings/src/lens/__helpers__/fragments.ts
+++ b/packages/api-bindings/src/lens/__helpers__/fragments.ts
@@ -95,7 +95,7 @@ export function mockHandleInfo(): gql.HandleInfo {
   const namespace = faker.internet.domainWord();
   return {
     id: `${namespace}/${localName}}`,
-    fullHandle: `@${localName}/${namespace}`,
+    fullHandle: `${localName}/${namespace}`,
     namespace,
     localName,
     ownedBy: mockEvmAddress(),

--- a/packages/domain/src/use-cases/profile/LinkHandle.ts
+++ b/packages/domain/src/use-cases/profile/LinkHandle.ts
@@ -1,8 +1,9 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import { DelegableSigning } from '../transactions/DelegableSigning';
 
 export type LinkHandleRequest = {
-  handle: string;
+  fullHandle: string;
+  profileId: ProfileId;
   kind: TransactionKind.LINK_HANDLE;
   delegate: boolean;
 };

--- a/packages/domain/src/use-cases/profile/UnlinkHandle.ts
+++ b/packages/domain/src/use-cases/profile/UnlinkHandle.ts
@@ -1,8 +1,9 @@
-import { TransactionKind } from '../../entities';
+import { ProfileId, TransactionKind } from '../../entities';
 import { DelegableSigning } from '../transactions/DelegableSigning';
 
 export type UnlinkHandleRequest = {
-  handle: string;
+  fullHandle: string;
+  profileId: ProfileId;
   kind: TransactionKind.UNLINK_HANDLE;
   delegate: boolean;
 };

--- a/packages/domain/src/use-cases/profile/__helpers__/mocks.ts
+++ b/packages/domain/src/use-cases/profile/__helpers__/mocks.ts
@@ -170,9 +170,17 @@ export function mockINftOwnershipChallengeGateway({
   return gateway;
 }
 
+function mockFullHandle(): string {
+  const localName = faker.internet.userName();
+  const namespace = faker.internet.domainWord();
+
+  return `${localName}/${namespace}`;
+}
+
 export function mockLinkHandleRequest(overrides?: Partial<LinkHandleRequest>): LinkHandleRequest {
   return {
-    handle: faker.internet.userName(),
+    fullHandle: mockFullHandle(),
+    profileId: mockProfileId(),
     delegate: true,
     ...overrides,
     kind: TransactionKind.LINK_HANDLE,
@@ -183,7 +191,8 @@ export function mockUnlinkHandleRequest(
   overrides?: Partial<UnlinkHandleRequest>,
 ): UnlinkHandleRequest {
   return {
-    handle: faker.internet.userName(),
+    fullHandle: mockFullHandle(),
+    profileId: mockProfileId(),
     delegate: true,
     ...overrides,
     kind: TransactionKind.UNLINK_HANDLE,

--- a/packages/react/src/shared.tsx
+++ b/packages/react/src/shared.tsx
@@ -39,6 +39,7 @@ import { PendingTransactionGateway } from './transactions/adapters/PendingTransa
 import { TransactionQueuePresenter } from './transactions/adapters/TransactionQueuePresenter';
 import { BlockProfilesResponder } from './transactions/adapters/responders/BlockProfilesResponder';
 import { FollowProfileResponder } from './transactions/adapters/responders/FollowProfileResponder';
+import { LinkHandleResponder } from './transactions/adapters/responders/LinkHandleResponder';
 import { NoopResponder } from './transactions/adapters/responders/NoopResponder';
 import { RefreshCurrentProfileResponder } from './transactions/adapters/responders/RefreshCurrentProfileResponder';
 import { RefreshPublicationResponder } from './transactions/adapters/responders/RefreshPublicationResponder';
@@ -121,11 +122,11 @@ export function createSharedDependencies(config: LensConfig): SharedDependencies
     [TransactionKind.CREATE_PROFILE]: new NoopResponder(),
     [TransactionKind.CREATE_QUOTE]: new NoopResponder(), // TODO update profile for new stats
     [TransactionKind.FOLLOW_PROFILE]: new FollowProfileResponder(profileCacheManager),
-    [TransactionKind.LINK_HANDLE]: new RefreshCurrentProfileResponder(profileCacheManager),
+    [TransactionKind.LINK_HANDLE]: new LinkHandleResponder(apolloClient, profileCacheManager),
     [TransactionKind.MIRROR_PUBLICATION]: new NoopResponder(), // TODO update profile for new stats
     [TransactionKind.UNBLOCK_PROFILE]: new UnblockProfilesResponder(profileCacheManager),
     [TransactionKind.UNFOLLOW_PROFILE]: new UnfollowProfileResponder(profileCacheManager),
-    [TransactionKind.UNLINK_HANDLE]: new RefreshCurrentProfileResponder(profileCacheManager),
+    [TransactionKind.UNLINK_HANDLE]: new LinkHandleResponder(apolloClient, profileCacheManager),
     [TransactionKind.UPDATE_FOLLOW_POLICY]: new RefreshCurrentProfileResponder(profileCacheManager),
     [TransactionKind.UPDATE_PROFILE_DETAILS]: new RefreshCurrentProfileResponder(
       profileCacheManager,

--- a/packages/react/src/transactions/adapters/profiles/LinkHandleGateway.ts
+++ b/packages/react/src/transactions/adapters/profiles/LinkHandleGateway.ts
@@ -78,7 +78,7 @@ export class LinkHandleGateway
       mutation: LinkHandleToProfileDocument,
       variables: {
         request: {
-          handle: request.handle,
+          handle: request.fullHandle,
         },
       },
     });
@@ -101,7 +101,7 @@ export class LinkHandleGateway
       mutation: CreateLinkHandleToProfileTypedDataDocument,
       variables: {
         request: {
-          handle: request.handle,
+          handle: request.fullHandle,
         },
         options: nonce ? { overrideSigNonce: nonce } : undefined,
       },

--- a/packages/react/src/transactions/adapters/profiles/UnlinkHandleGateway.ts
+++ b/packages/react/src/transactions/adapters/profiles/UnlinkHandleGateway.ts
@@ -78,7 +78,7 @@ export class UnlinkHandleGateway
       mutation: UnlinkHandleFromProfileDocument,
       variables: {
         request: {
-          handle: request.handle,
+          handle: request.fullHandle,
         },
       },
     });
@@ -101,7 +101,7 @@ export class UnlinkHandleGateway
       mutation: CreateUnlinkHandleFromProfileTypedDataDocument,
       variables: {
         request: {
-          handle: request.handle,
+          handle: request.fullHandle,
         },
         options: nonce ? { overrideSigNonce: nonce } : undefined,
       },

--- a/packages/react/src/transactions/adapters/profiles/__tests__/LinkHandleGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/profiles/__tests__/LinkHandleGateway.spec.ts
@@ -33,7 +33,7 @@ describe(`Given an instance of ${LinkHandleGateway.name}`, () => {
         mockCreateLinkHandleToProfileTypedDataResponse({
           variables: {
             request: {
-              handle: request.handle,
+              handle: request.fullHandle,
             },
           },
           data,
@@ -54,7 +54,7 @@ describe(`Given an instance of ${LinkHandleGateway.name}`, () => {
         mockLinkHandleToProfileResponse({
           variables: {
             request: {
-              handle: request.handle,
+              handle: request.fullHandle,
             },
           },
           data: {

--- a/packages/react/src/transactions/adapters/profiles/__tests__/UnlinkHandleGateway.spec.ts
+++ b/packages/react/src/transactions/adapters/profiles/__tests__/UnlinkHandleGateway.spec.ts
@@ -33,7 +33,7 @@ describe(`Given an instance of ${UnlinkHandleGateway.name}`, () => {
         mockCreateUnlinkHandleFromProfileTypedDataResponse({
           variables: {
             request: {
-              handle: request.handle,
+              handle: request.fullHandle,
             },
           },
           data,
@@ -54,7 +54,7 @@ describe(`Given an instance of ${UnlinkHandleGateway.name}`, () => {
         mockUnlinkHandleFromProfileResponse({
           variables: {
             request: {
-              handle: request.handle,
+              handle: request.fullHandle,
             },
           },
           data: {

--- a/packages/react/src/transactions/adapters/responders/LinkHandleResponder.ts
+++ b/packages/react/src/transactions/adapters/responders/LinkHandleResponder.ts
@@ -1,0 +1,21 @@
+import { OwnedHandlesDocument, SafeApolloClient } from '@lens-protocol/api-bindings';
+import { AnyTransactionRequestModel } from '@lens-protocol/domain/entities';
+import { ITransactionResponder } from '@lens-protocol/domain/use-cases/transactions';
+
+import { IProfileCacheManager } from '../../../profile/adapters/IProfileCacheManager';
+
+export class LinkHandleResponder implements ITransactionResponder<AnyTransactionRequestModel> {
+  constructor(
+    private readonly apolloClient: SafeApolloClient,
+    private readonly profileCacheManager: IProfileCacheManager,
+  ) {}
+
+  async commit() {
+    await Promise.all([
+      this.profileCacheManager.refreshCurrentProfile(),
+      this.apolloClient.refetchQueries({
+        include: [OwnedHandlesDocument],
+      }),
+    ]);
+  }
+}

--- a/packages/react/src/transactions/adapters/schemas/profiles.ts
+++ b/packages/react/src/transactions/adapters/schemas/profiles.ts
@@ -97,13 +97,15 @@ export const SetProfileMetadataRequestSchema = z.object({
 });
 
 export const LinkHandleRequestSchema = z.object({
-  handle: z.string(),
+  fullHandle: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.LINK_HANDLE),
   delegate: z.boolean(),
 });
 
 export const UnlinkHandleRequestSchema = z.object({
-  handle: z.string(),
+  fullHandle: z.string(),
+  profileId: ProfileIdSchema,
   kind: z.literal(TransactionKind.UNLINK_HANDLE),
   delegate: z.boolean(),
 });

--- a/packages/react/src/transactions/useLinkHandle.ts
+++ b/packages/react/src/transactions/useLinkHandle.ts
@@ -1,3 +1,4 @@
+import { HandleInfo } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
   TransactionKind,
@@ -16,7 +17,7 @@ export type LinkHandleArgs = {
   /**
    * The owned handle to link to the currently authenticated Profile.
    */
-  handle: string;
+  handle: HandleInfo;
 };
 
 /**
@@ -35,7 +36,6 @@ export type LinkHandleArgs = {
  *
  * @category Profiles
  * @group Hooks
- * @experimental This hook is experimental and may change in future releases.
  */
 export function useLinkHandle(): UseDeferredTask<
   AsyncTransactionResult<void>,
@@ -54,10 +54,15 @@ export function useLinkHandle(): UseDeferredTask<
       session.type === SessionType.WithProfile,
       'You must have a profile to use this operation.',
     );
+    invariant(
+      !args.handle.linkedTo,
+      `The handle is already linked to profile ${args.handle.linkedTo?.nftTokenId}.`,
+    );
 
     return linkHandle({
       kind: TransactionKind.LINK_HANDLE,
-      handle: args.handle,
+      fullHandle: args.handle.fullHandle,
+      profileId: session.profile.id,
       delegate: session.profile.signless,
     });
   });

--- a/packages/react/src/transactions/useUnlinkHandle.ts
+++ b/packages/react/src/transactions/useUnlinkHandle.ts
@@ -1,3 +1,4 @@
+import { HandleInfo } from '@lens-protocol/api-bindings';
 import {
   PendingSigningRequestError,
   TransactionKind,
@@ -16,7 +17,7 @@ export type UnlinkHandleArgs = {
   /**
    * The handle to unlink from the currently authenticated Profile.
    */
-  handle: string;
+  handle: HandleInfo;
 };
 
 /**
@@ -35,7 +36,6 @@ export type UnlinkHandleArgs = {
  *
  * @category Profiles
  * @group Hooks
- * @experimental This hook is experimental and may change in future releases.
  */
 export function useUnlinkHandle(): UseDeferredTask<
   AsyncTransactionResult<void>,
@@ -54,10 +54,15 @@ export function useUnlinkHandle(): UseDeferredTask<
       session.type === SessionType.WithProfile,
       'You must have a profile to use this operation.',
     );
+    invariant(
+      args.handle.linkedTo?.nftTokenId === session.profile.id,
+      `You can't unlink handle that is not linked to current profile.`,
+    );
 
     return unlinkHandle({
       kind: TransactionKind.UNLINK_HANDLE,
-      handle: args.handle,
+      fullHandle: args.handle.fullHandle,
+      profileId: session.profile.id,
       delegate: session.profile.signless,
     });
   });


### PR DESCRIPTION
- API error when unlinking not-linked handle is not propagated to the `error` returned from hook
  - solved with preventing submitting a mutation that could cause API error
- API should include more data in the response from `ownedHandles` to build meaningful UI https://avara.height.app/T-17101 
  - done
- add an optimistic update
  - done
- figure out why updateProfileCache doesn't include new handle
  - done