### PR TITLE
chore: update examples to use profilesManaged for login

### DIFF
--- a/examples/node/scripts/authentication/authenticate.ts
+++ b/examples/node/scripts/authentication/authenticate.ts
@@ -15,15 +15,15 @@ async function main() {
   const wallet = setupWallet();
   const address = await wallet.getAddress();
 
-  const ownedProfiles = await client.profile.fetchAll({ where: { ownedBy: [address] } });
+  const managedProfiles = await client.wallet.profilesManaged({ for: wallet.address });
 
-  if (ownedProfiles.items.length === 0) {
-    throw new Error(`You don't have any profiles, create one first`);
+  if (managedProfiles.items.length === 0) {
+    throw new Error(`You don't manage any profiles, create one first`);
   }
 
   const { id, text } = await client.authentication.generateChallenge({
     signedBy: address,
-    for: ownedProfiles.items[0].id,
+    for: managedProfiles.items[0].id,
   });
 
   console.log(`Challenge: `, text);

--- a/examples/web/src/LogInPage.tsx
+++ b/examples/web/src/LogInPage.tsx
@@ -1,4 +1,4 @@
-import { profileId, useLogin, useProfiles } from '@lens-protocol/react-web';
+import { profileId, useLogin, useProfilesManaged } from '@lens-protocol/react-web';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { useAccount, useConnect } from 'wagmi';
@@ -11,7 +11,7 @@ import { never } from './utils';
 function ProfilesList({ owner }: { owner: string }) {
   const navigate = useNavigate();
   const { execute: login, loading: isLoginPending } = useLogin();
-  const { data: profiles, error, loading } = useProfiles({ where: { ownedBy: [owner] } });
+  const { data: profiles, error, loading } = useProfilesManaged({ for: owner });
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/packages/react/src/authentication/useLogin.ts
+++ b/packages/react/src/authentication/useLogin.ts
@@ -19,7 +19,7 @@ export type { LoginError, LoginRequest };
  * Optionally you can login just with an EVM address. In this case the authenticated session
  * returned by {@link useSession} will be of type {@link SessionType.JustWallet} type and will not
  * contain any Profile information. The credentials associated with this session are limited to:
- * - claim a Profile with new Handle via the {@link useClaimProfile} hook
+ * - claim a Profile with new Handle via the {@link useClaimHandle} hook
  * - collect a publication via the {@link useOpenAction} hook
  *
  * See the respective hooks documentation for more information.


### PR DESCRIPTION
that's all that I found that mentions usage of profiles (ownedBy) query to get profiles before logging in.