### PR TITLE
Use @ethersproject/address in place of ethers/lib/utils

### DIFF
--- a/.changeset/quiet-garlics-live.md
+++ b/.changeset/quiet-garlics-live.md
@@ -1,0 +1,5 @@
+---
+"@lens-protocol/react": patch
+---
+
+Use @ethersproject/address instead of ethers/lib/utils

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,6 +53,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/logger": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/wallet": "^5.7.0",
     "@lens-protocol/api-bindings": "workspace:*",

--- a/packages/react/src/polls/adapters/SnapshotVoteFactory.ts
+++ b/packages/react/src/polls/adapters/SnapshotVoteFactory.ts
@@ -15,7 +15,7 @@ import {
   VoteChoice,
 } from '@lens-protocol/domain/use-cases/polls';
 import { invariant, InvariantError, never } from '@lens-protocol/shared-kernel';
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 
 import { vote2Types, voteArray2Types, voteString2Types } from './types';
 

--- a/packages/react/src/polls/adapters/__tests__/SnapshotVoteFactory.spec.ts
+++ b/packages/react/src/polls/adapters/__tests__/SnapshotVoteFactory.spec.ts
@@ -12,7 +12,7 @@ import { AppId, PollId } from '@lens-protocol/domain/entities';
 import { mockAppId, mockCreateUnsignedVoteRequest, mockWallet } from '@lens-protocol/domain/mocks';
 import { InvariantError, never } from '@lens-protocol/shared-kernel';
 import { mockEvmAddress } from '@lens-protocol/shared-kernel/mocks';
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 
 import { SnapshotVoteFactory, UnsignedVote } from '../SnapshotVoteFactory';
 import { vote2Types, voteArray2Types, voteString2Types } from '../types';

--- a/packages/react/src/wallet/adapters/ConcreteWallet.ts
+++ b/packages/react/src/wallet/adapters/ConcreteWallet.ts
@@ -27,8 +27,9 @@ import {
   PromiseResult,
   success,
 } from '@lens-protocol/shared-kernel';
-import { errors, Signer } from 'ethers';
+import { Signer } from '@ethersproject/abstract-signer';
 import { getAddress } from '@ethersproject/address';
+import { ErrorCode as errors } from '@ethersproject/logger';
 import { z } from 'zod';
 
 import { UnsignedVote } from '../../polls/adapters/SnapshotVoteFactory';

--- a/packages/react/src/wallet/adapters/ConcreteWallet.ts
+++ b/packages/react/src/wallet/adapters/ConcreteWallet.ts
@@ -28,7 +28,7 @@ import {
   success,
 } from '@lens-protocol/shared-kernel';
 import { errors, Signer } from 'ethers';
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 import { z } from 'zod';
 
 import { UnsignedVote } from '../../polls/adapters/SnapshotVoteFactory';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -867,6 +867,9 @@ importers:
       '@ethersproject/hash':
         specifier: ^5.7.0
         version: 5.7.0
+      '@ethersproject/logger':
+        specifier: ^5.7.0
+        version: 5.7.0
       '@ethersproject/providers':
         specifier: ^5.7.2
         version: 5.7.2


### PR DESCRIPTION
This is a small contribution. This issue is keeping me from using ethers v6 in conjunction with @lens-protocol/react-native. Because `getAddress` is getting routed through `ethers/lib/utils`, it is trying to resolve to the ethers v6 dependency instead of the v5 that the SDK needs.

I couldn't run the tests locally, I think I need some env configuration. Here is hoping that the change is small enough to not break anything.

EDIT. Some further investigation revealed that the direct use of the ethers library should also be removed, so I pushed additional changes