### PR TITLE
react: enable profile field policy

### DIFF
--- a/.changeset/forty-horses-speak.md
+++ b/.changeset/forty-horses-speak.md
@@ -1,0 +1,5 @@
+---
+"@lens-protocol/api-bindings": patch
+---
+
+**feat:** enabled profile field policy

--- a/packages/api-bindings/src/apollo/cache/createTypePolicies.ts
+++ b/packages/api-bindings/src/apollo/cache/createTypePolicies.ts
@@ -11,6 +11,7 @@ import {
   createFollowingFieldPolicy,
   createMutualFollowersFieldPolicy,
   createProfileActionHistoryFieldPolicy,
+  createProfileFieldPolicy,
   createProfileRecommendationsFieldPolicy,
   createProfilesFieldPolicy,
   createPublicationFieldPolicy,
@@ -68,8 +69,7 @@ export function createTypePolicies(): StrictTypedTypePolicies & InheritedTypePol
         mutualFollowers: createMutualFollowersFieldPolicy(),
         profileActionHistory: createProfileActionHistoryFieldPolicy(),
         profileRecommendations: createProfileRecommendationsFieldPolicy(),
-        // TODO: investigate correct usage of cache redirect
-        // profile: createProfileFieldPolicy() as FieldPolicy<unknown>,
+        profile: createProfileFieldPolicy() as FieldPolicy<unknown>,
         profiles: createProfilesFieldPolicy(),
         publication: createPublicationFieldPolicy() as FieldPolicy<unknown>,
         publications: createPublicationsFieldPolicy(),

--- a/packages/api-bindings/src/apollo/cache/field-policies/createProfileFieldPolicy.ts
+++ b/packages/api-bindings/src/apollo/cache/field-policies/createProfileFieldPolicy.ts
@@ -1,17 +1,19 @@
 import { FieldFunctionOptions, FieldPolicy, Reference } from '@apollo/client';
 
-import { Profile, ProfileRequest } from '../../../lens';
+import { ProfileRequest } from '../../../lens';
 
-// this function is not in use
-// TODO: investigate correct usage of cache redirect
 export function createProfileFieldPolicy(): FieldPolicy<
-  Profile,
-  Profile,
+  Reference,
+  Reference,
   Reference,
   FieldFunctionOptions<{ request: ProfileRequest }>
 > {
   return {
-    read(_, { args, toReference, canRead }) {
+    read(existing, { args, toReference, canRead }) {
+      if (existing) {
+        return existing;
+      }
+
       if (!args) {
         return undefined;
       }


### PR DESCRIPTION
when I try to read a profile by a handle in the field policy, I'm getting an apollo error, this could be because of react strict mode

```ts
if (args.request?.forHandle) {
  
  const profile = cache.readQuery({
    query: ProfileDocument,
    variables: variables,
  });

  console.log('profile', profile);
}
```


<img width="555" alt="Screenshot 2024-04-04 at 14 46 28" src="https://github.com/lens-protocol/lens-sdk/assets/605420/29ef5145-328b-42a6-8b72-373b0cce5828">
