### PR TITLE
chore: re-export ClientError as GraphQLClientError

### DIFF
--- a/.changeset/olive-spiders-pull.md
+++ b/.changeset/olive-spiders-pull.md
@@ -1,0 +1,5 @@
+---
+"@lens-protocol/client": patch
+---
+
+**feat:** re-exported GraphQLClientError from graphql-request

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,3 +1,5 @@
+export { ClientError as GraphQLClientError } from 'graphql-request';
+
 export class NotAuthenticatedError extends Error {
   name = 'NotAuthenticatedError' as const;
   message = 'Not Authenticated';


### PR DESCRIPTION
## Use case

```ts
import { GraphQLClientError } from '@lens-protocol/client'
try {
  await client.follow(...)
  await doSomeThingElse()
} catch (error) {
  if (error instanceof Error) {
     if (error instanceof GraphQLClientError) {
        // handle client error.
     }
     // handle other error.
  }
}
```