### PR TITLE
chore: bump node engine upper limit to support new LTS

### DIFF
--- a/.changeset/thirty-apes-hear.md
+++ b/.changeset/thirty-apes-hear.md
@@ -1,0 +1,6 @@
+---
+"@lens-protocol/client": patch
+"@lens-protocol/cli": patch
+---
+
+up the node engine restriction to allow new node lts ver 22

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "typescript": "5.2.2"
   },
   "engines": {
-    "node": ">=18 <21"
+    "node": ">=18 <=22"
   },
   "prettier": "@lens-protocol/prettier-config"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -97,7 +97,7 @@
     "typescript": "5.2.2"
   },
   "engines": {
-    "node": ">=18 <21"
+    "node": ">=18 <=22"
   },
   "prettier": "@lens-protocol/prettier-config",
   "babel": {


### PR DESCRIPTION
issue: https://github.com/lens-protocol/lens-sdk/issues/966