### PR TITLE
fix: Incorrect use of the `await` operator

### DIFF
--- a/examples/user-onboarding/index.ts
+++ b/examples/user-onboarding/index.ts
@@ -66,5 +66,5 @@ const created = await createAccountWithUsername(sessionClient, {
 
 export default [
   `<h2>${created?.username?.value}</h2>`,
-  `<p>Address: ${await created?.address}</p>`,
+  `<p>Address: ${created?.address}</p>`,
 ];


### PR DESCRIPTION
`In the expression `${await created?.address}`, the `await` operator is used on the value `created?.address`, which is not a Promise. The `await` operator is intended to wait for the resolution of a Promise, and using it with a non-Promise value will result in a runtime error.