### PR TITLE
fix: correctly destructure customData in client's ethers' signWith function

### DIFF
--- a/.changeset/thirty-experts-tell.md
+++ b/.changeset/thirty-experts-tell.md
@@ -1,0 +1,5 @@
+---
+"@lens-protocol/client": patch
+---
+
+Fix incorrect destructuring of sponsored transactions `customData` in ethers client

--- a/packages/client/src/ethers/signer.ts
+++ b/packages/client/src/ethers/signer.ts
@@ -37,7 +37,7 @@ function signWith(
     const { __typename, from, customData, ...transactionLike } = request.raw;
     const tx: types.TransactionLike = types.Transaction.from({
       ...transactionLike,
-      ...nullableToOptional(customData),
+      customData: customData ? { ...nullableToOptional(customData) } : null,
     });
 
     return ResultAsync.fromPromise(


### PR DESCRIPTION
Found an issue that is preventing me from sending sponsored transactions because the `customData` contents are being destructured into the root of the TransactionLike object, instead of inside of `TransactionLike::customData`.