### PR TITLE
fix: remove duplicate word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nvm use
 
 to switch to the correct Node.js version.
 
-Enable [corepack](https://www.totaltypescript.com/how-to-use-corepack) to use the the correct version of `pnpm`.
+Enable [corepack](https://www.totaltypescript.com/how-to-use-corepack) to use the correct version of `pnpm`.
 
 Run the following command in the project root folder:
 


### PR DESCRIPTION
## Summary
- Fix typo "the the" -> "the" in the corepack section of README.md

## Test plan
- Visual inspection of the README.md file