### PR TITLE
fix: fix typo in storage mocks comment

### DIFF
--- a/packages/storage/src/__helpers__/mocks.ts
+++ b/packages/storage/src/__helpers__/mocks.ts
@@ -38,7 +38,7 @@ export function mockStorageProvider(
 
 // Simulates actual serialization/deserialization.
 // Otherwise it might keep references to the actual original objects and it might trick
-// consumer tests to think they are deserializing correctly (i.e. it might let them thing they
+// consumer tests to think they are deserializing correctly (i.e. it might let them think they
 // are recreating the correct object with appropriate prototype chains while they don't).
 function mockStorageRoundTrip(data: unknown): unknown {
   return JSON.parse(JSON.stringify(data));


### PR DESCRIPTION
## Summary
- Fix typo "thing they" -> "think they" in packages/storage/src/__helpers__/mocks.ts

## Test plan
- Visual inspection of the comment