### PR TITLE
fix: correct grammar in JSDoc comments

### DIFF
--- a/packages/client/src/actions/account.ts
+++ b/packages/client/src/actions/account.ts
@@ -85,7 +85,7 @@ export function fetchAccount(
 }
 
 /**
- * Fetch an Accounts.
+ * Fetch Accounts.
  *
  * Using a {@link SessionClient} will yield {@link Account#operations} specific to the authenticated Account.
  *
@@ -105,7 +105,7 @@ export function fetchAccounts(
 }
 
 /**
- * Fetch an Accounts Bulk.
+ * Fetch Accounts in Bulk.
  *
  * ```ts
  * const result = await fetchAccountsBulk(anyClient, {
@@ -125,7 +125,7 @@ export function fetchAccountsBulk(
 }
 
 /**
- * Fetch an Account Stats.
+ * Fetch Account Stats.
  *
  * ```ts
  * const result = await fetchAccountStats(anyClient, {
@@ -145,7 +145,7 @@ export function fetchAccountStats(
 }
 
 /**
- * Fetch an Account Feed Stats.
+ * Fetch Account Feed Stats.
  *
  * ```ts
  * const result = await fetchAccountFeedStats(anyClient, {
@@ -165,7 +165,7 @@ export function fetchAccountFeedStats(
 }
 
 /**
- * Fetch an Account Graph Stats.
+ * Fetch Account Graph Stats.
  *
  * ```ts
  * const result = await fetchAccountGraphStats(anyClient, {

--- a/packages/client/src/actions/misc.ts
+++ b/packages/client/src/actions/misc.ts
@@ -29,7 +29,7 @@ export function health(
 }
 
 /**
- * Fetch an Access Control details.
+ * Fetch Access Control details.
  *
  * ```ts
  * const result = await fetchAccessControl(anyClient, {

--- a/packages/react/src/account/useAccountFeedsStats.ts
+++ b/packages/react/src/account/useAccountFeedsStats.ts
@@ -15,7 +15,7 @@ import { useSuspendableQuery } from '../helpers';
 export type UseAccountFeedsStatsArgs = AccountFeedsStatsRequest;
 
 /**
- * Fetch an Account Feed Stats.
+ * Fetch Account Feed Stats.
  *
  * This signature supports React Suspense:
  *
@@ -31,7 +31,7 @@ export function useAccountFeedsStats(
 ): SuspenseResult<AccountFeedsStats>;
 
 /**
- * Fetch an Account Feed Stats.
+ * Fetch Account Feed Stats.
  *
  * ```tsx
  * const { data, loading } = useAccountFeedsStats({

--- a/packages/react/src/account/useAccountStats.ts
+++ b/packages/react/src/account/useAccountStats.ts
@@ -15,7 +15,7 @@ import { useSuspendableQuery } from '../helpers';
 export type UseAccountStatsArgs = AccountStatsRequest;
 
 /**
- * Fetch an Account Stats.
+ * Fetch Account Stats.
  *
  * This signature supports React Suspense:
  *
@@ -31,7 +31,7 @@ export function useAccountStats(
 ): SuspenseResult<AccountStats>;
 
 /**
- * Fetch an Account Stats.
+ * Fetch Account Stats.
  *
  * ```tsx
  * const { data, loading } = useAccountStats({


### PR DESCRIPTION
## Summary
Fix incorrect use of "an" before plural nouns and compound nouns in JSDoc comments across the client and react packages:

- "Fetch an Accounts" -> "Fetch Accounts"
- "Fetch an Accounts Bulk" -> "Fetch Accounts in Bulk"
- "Fetch an Account Stats" -> "Fetch Account Stats"
- "Fetch an Account Feed Stats" -> "Fetch Account Feed Stats"
- "Fetch an Account Graph Stats" -> "Fetch Account Graph Stats"
- "Fetch an Access Control details" -> "Fetch Access Control details"

## Files changed
- packages/client/src/actions/account.ts
- packages/client/src/actions/misc.ts
- packages/react/src/account/useAccountFeedsStats.ts
- packages/react/src/account/useAccountStats.ts

## Test plan
- Visual inspection of JSDoc comments
- These are documentation-only changes that do not affect functionality